### PR TITLE
BIG-19026 - Images not loading predictably

### DIFF
--- a/server/plugins/Renderer/index.js
+++ b/server/plugins/Renderer/index.js
@@ -106,7 +106,7 @@ internals.getResponse = function (request, callback) {
                 return callback(err);
             }
 
-            if (!bcAppData.content_type) {
+            if (!_.has(bcAppData, 'content_type')) {
                 // this is a raw response not emitted by TemplateEngine
                 return callback(null, new Responses.RawResponse(
                     bcAppData,


### PR DESCRIPTION
BIG-19026 checking content-type on null

Data being returned with a 304 statusCode is null and does so an error is cause be directly accessing the content_type property. Having lodash check if there is a property eliminates accessing the property and elminates the error and cause the 304 to work properly in Safari.
