### PR TITLE
BIG-17855: Fix missing variationName parameter

### DIFF
--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -109,7 +109,7 @@ Wreck.get(
  * Starts up the local Stencil Server as well as starts up BrowserSync and sets some watch options.
  */
 function startServer() {
-    Server({dotStencilFile: dotStencilFile, themeVariationName: themeConfig.variationName}, function(err) {
+    Server({dotStencilFile: dotStencilFile, themeVariationName: themeConfig.config.variationName}, function(err) {
         if (err) {
             throw err;
         }

--- a/lib/themeConfig.js
+++ b/lib/themeConfig.js
@@ -16,7 +16,7 @@ function ThemeConfig (configPath, variationName) {
  * @returns {object}
  */
 ThemeConfig.prototype.getConfig = function () {
-    return getConfig(this.configPath);
+    return getConfig(this.configPath, this.variationName);
 };
 
 /**
@@ -26,10 +26,10 @@ ThemeConfig.prototype.getConfig = function () {
  * @param configPath
  * @return {object}
  */
-function getConfig (configPath) {
+function getConfig (configPath, variationName) {
     var rawConfig = Fs.readFileSync(configPath, {encoding: 'utf-8'}),
         config = JSON.parse(rawConfig),
-        variation = getVariation(config, this.variationName);
+        variation = getVariation(config, variationName);
 
     // Set some defaults
     config.css_compiler = config.css_compiler || 'scss';


### PR DESCRIPTION
Fix `variationName` argument not getting passed through when running `stencil-start -v Light`

@meenie @christopher-hegre @haubc 
