### PR TITLE
BIG-20179: Add in environment vars and blank out cdn_url.

### DIFF
--- a/server/plugins/Renderer/responses/pencilResponse.js
+++ b/server/plugins/Renderer/responses/pencilResponse.js
@@ -11,6 +11,13 @@ module.exports = function (data) {
             html,
             preferredTranslation;
 
+        // Remove the CDN prefixes in development
+        data.context.cdn_url = '';
+        data.context.cdn_url_with_settings_hash = '';
+        // Set the environment to dev
+        data.context.in_development = true;
+        data.context.in_production = false;
+
         if (request.query.debug === 'context') {
             return reply(data.context);
         }


### PR DESCRIPTION
Adding in some new environment variables to check if in production or development.  In stapler, there is a similar change, but they are inversed.

I've also blanked out the CDN url passed back from BCApp/Stapler because you don't want it in development.
