### PR TITLE
Add speedy test mode with JS prebundling

### DIFF
--- a/bin/stencil-bundle
+++ b/bin/stencil-bundle
@@ -219,7 +219,7 @@ function getJspmBundleTask(jspmConfig) {
     return function (callback) {
         var oldConsoleError = console.error;
 
-        console.log('JavasScript Bundling Started...');
+        console.log('JavaScript Bundling Started...');
 
         // Need to suppress annoying errors from Babel.
         // They will be gone in the next minor version of JSPM (0.16.0).
@@ -232,7 +232,7 @@ function getJspmBundleTask(jspmConfig) {
 
         Jspm.setPackagePath(themePath);
         Jspm.bundle(jspmConfig.bootstrap, jspmConfig.tmpBundleFile, {minify: true}).then(function() {
-            console.log('ok'.green + ' -- JavasScript Bundling Finished');
+            console.log('ok'.green + ' -- JavaScript Bundling Finished');
             console.error = oldConsoleError;
             callback(null, true);
         });

--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -5,6 +5,7 @@ require('colors');
 var Fs = require('fs'),
     Inquirer = require('inquirer'),
     Jspm = require('jspm'),
+    JspmAssembler = require('../lib/jspmAssembler'),
     Path = require('path'),
     Program = require('commander'),
     ThemeConfig = require('../lib/themeConfig'),
@@ -63,7 +64,8 @@ Inquirer.prompt(questions, function(answers) {
     }
 
     Fs.writeFile(dotStencilFilePath, JSON.stringify(answers, null, 2), function(err) {
-        var ready = 'You are now ready to go! To start developing, run $ stencil start';
+        var ready = 'You are now ready to go! To start developing, run $ stencil start',
+            bundleTask;
 
         if (err) {
             throw err;
@@ -83,49 +85,19 @@ Inquirer.prompt(questions, function(answers) {
                 );
             }
 
-            getJspmBundleTask(themeConfig.jspm, function() {
+            bundleTask = JspmAssembler.assemble(
+                {
+                    bootstrap: themeConfig.jspm.dev.bootstrap
+                },
+                themePath
+            );
+
+            bundleTask(function() {
                 console.log(ready);
             });
+
         } else {
             console.log(ready);
         }
     });
 });
-
-function getJspmBundleTask(jspmConfig, callback) {
-    var oldConsoleError = console.error,
-        jspmDepLocation,
-        depLocation;
-
-    // Look for development configuration
-    if (jspmConfig.dev && jspmConfig.dev.dep_location) {
-        jspmDepLocation = jspmConfig.dev.dep_location;
-    } else {
-        jspmDepLocation = 'assets/js/dependency-bundle.js';
-    }
-
-    depLocation = Path.join(themePath, jspmDepLocation);
-
-    console.log('JavasScript Bundling Started...');
-
-    // Need to suppress annoying errors from Babel.
-    // They will be gone in the next minor version of JSPM (0.16.0).
-    // Until then, this will stay in place
-    console.error = function(error) {
-        if (! /Deprecated option metadataUsedHelpers/.test(error)) {
-            oldConsoleError(error);
-        }
-    };
-
-    // Delete old dependency file if it exists
-    if (Fs.existsSync(depLocation)) {
-        Fs.unlinkSync(depLocation);
-    }
-
-    Jspm.setPackagePath(themePath);
-    Jspm.bundle(jspmConfig.dev.bootstrap, depLocation, {minify: true, sourceMaps: true}).then(function() {
-        console.log('ok'.green + ' -- JavasScript Bundling Finished');
-        console.error = oldConsoleError;
-        callback(null, true);
-    });
-}

--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -5,6 +5,8 @@ require('colors');
 var _ = require('lodash'),
     Bs = require('browser-sync').create(),
     Fs = require('fs'),
+    Jspm = require('jspm'),
+    JspmAssembler = require('../lib/jspmAssembler'),
     Path = require('path'),
     Pkg = require('../package.json'),
     Program = require('commander'),
@@ -30,6 +32,7 @@ Program
     .version(Pkg.version)
     .option('-o, --open', 'Automatically open default browser')
     .option('-v, --variation [name]', 'Set which theme variation to use while developing')
+    .option('-t, --test', 'Enable QA mode which will bundle all javascript for speed to test locally')
     .parse(process.argv);
 
 if (! dotStencilFileExists) {
@@ -79,7 +82,8 @@ Wreck.get(
         }
     },
     function(err, res, payload) {
-        var retError = err !== null;
+        var retError = err !== null,
+            bundleTask;
 
         try {
             payload = JSON.parse(payload);
@@ -101,7 +105,20 @@ Wreck.get(
             dotStencilFile.storeUrl = payload.sslUrl;
             dotStencilFile.normalStoreUrl = payload.baseUrl;
 
-            startServer();
+            if (themeConfig.config.jspm && Program.test) {
+                bundleTask = JspmAssembler.assemble(
+                    {
+                        bootstrap: themeConfig.config.jspm.bootstrap
+                    },
+                    themePath
+                );
+
+                bundleTask(function(result) {
+                    startServer();
+                });
+            } else {
+                startServer();
+            }
         }
     }
 );

--- a/lib/jspmAssembler.js
+++ b/lib/jspmAssembler.js
@@ -1,0 +1,53 @@
+var Async = require('async'),
+    Jspm = require('jspm'),
+    Fs = require('fs'),
+    Path = require('path'),
+    _ = require('lodash');
+
+module.exports.assemble = assemble;
+
+/**
+ * Initiates the JSPM compilation piece
+ * @param jspmOptions
+ * @param themePath
+ * @returns {Function}
+ */
+function assemble(jspmOptions, themePath) {
+    return function(callback) {
+        var oldConsoleError = console.error,
+            jspmDepLocation,
+            depLocation;
+
+        // Look for development configuration
+        if (jspmOptions.dep_location) {
+            jspmDepLocation = jspmOptions.dep_location;
+        } else {
+            jspmDepLocation = 'assets/js/dependency-bundle.js';
+        }
+
+        depLocation = Path.join(themePath, jspmDepLocation);
+
+        console.log('JavaScript Bundling Started...');
+
+        // Need to suppress annoying errors from Babel.
+        // They will be gone in the next minor version of JSPM (0.16.0).
+        // Until then, this will stay in place
+        console.error = function (error) {
+            if (!/Deprecated option metadataUsedHelpers/.test(error)) {
+                oldConsoleError(error);
+            }
+        };
+
+        // Delete old dependency file if it exists
+        if (Fs.existsSync(depLocation)) {
+            Fs.unlinkSync(depLocation);
+        }
+
+        Jspm.setPackagePath(themePath);
+        Jspm.bundle(jspmOptions.bootstrap, jspmDepLocation, {minify: true, sourceMaps: true}).then(function () {
+            console.log('ok'.green + ' -- JavaScript Bundling Finished');
+            console.error = oldConsoleError;
+            callback(null, true);
+        });
+    };
+}


### PR DESCRIPTION
Add speedy test mode with JS prebundling

Adds an optional stencil local "Testing Mode" which bundles both dependencies and theme application code so seconds are saved each page load before clientside interaction can begin. It's quite fast and will help QA themes much quicker when no code has to be written.

This remains the same in that `stencil init` will bundle only dependencies, and `stencil start -t` or `stencil start --test` will bundle JS in the same manner as production.

@meenie @haubc @mickr @mcampa 
