### PR TITLE
BIG-21458: Trigger script hooks

### DIFF
--- a/bin/stencil-bundle
+++ b/bin/stencil-bundle
@@ -14,12 +14,14 @@ var _ = require('lodash'),
     LangAssembler = require('../lib/langAssembler'),
     TemplateAssembler = require('../lib/templateAssembler'),
     ThemeConfig = require('../lib/themeConfig'),
+    Shell = require('../lib/utils/shell'),
     Tmp = require('tmp'),
     pkg = require('../package.json'),
     themePath = process.cwd(),
     tasks = {},
     templatesBasePath = Path.join(themePath, 'templates'),
     themeConfig,
+    themeConfigHooks,
     themeConfigPath = Path.join(themePath, 'config.json'),
     themeConfigExists = Fs.existsSync(themeConfigPath);
 
@@ -43,6 +45,12 @@ if (! themeConfigExists) {
 }
 
 themeConfig = new ThemeConfig(themeConfigPath).getConfig();
+themeConfigHooks = themeConfig.hooks || {};
+
+// Execute hook before bundling
+if (themeConfigHooks.bundle && Shell.execSync(themeConfigHooks.bundle).status > 0) {
+    return;
+}
 
 tasks.css = getCssAssembleTask(themeConfig.css_compiler);
 tasks.templates = assembleTemplatesTask;

--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -14,11 +14,13 @@ var _ = require('lodash'),
     ThemeConfig = require('../lib/themeConfig'),
     Url = require('url'),
     Wreck = require('wreck'),
+    Shell = require('../lib/utils/shell'),
     themePath = process.cwd(),
     allowedCssCompilers = ['scss', 'less'],
     browserSyncPort,
     cssCompilerDir,
     cssWatchBaseDir = Path.join(themePath, 'assets/'),
+    jsCompilerDir = Path.join(themePath, 'assets/js'),
     dotStencilFilePath = Path.join(themePath, '.stencil'),
     dotStencilFileExists = Fs.existsSync(dotStencilFilePath),
     dotStencilFile,
@@ -26,7 +28,8 @@ var _ = require('lodash'),
     stencilServerPort,
     themeConfig,
     themeConfigPath = Path.join(themePath, 'config.json'),
-    themeConfigExists = Fs.existsSync(themeConfigPath);
+    themeConfigExists = Fs.existsSync(themeConfigPath),
+    themeConfigHooks;
 
 Program
     .version(Pkg.version)
@@ -53,6 +56,7 @@ dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
 dotStencilFile = JSON.parse(dotStencilFile);
 
 themeConfig = parseThemeConfig();
+themeConfigHooks = themeConfig.config.hooks || {};
 
 if (allowedCssCompilers.indexOf(themeConfig.config.css_compiler) === -1) {
     return console.error('Error: Only %s are allowed as CSS Compilers'.red, allowedCssCompilers.join(', '));
@@ -128,6 +132,10 @@ Wreck.get(
  * Starts up the local Stencil Server as well as starts up BrowserSync and sets some watch options.
  */
 function startServer() {
+    if (themeConfigHooks.start && Shell.execSync(themeConfigHooks.start).status > 0) {
+        return;
+    }
+
     Server({dotStencilFile: dotStencilFile, themeVariationName: themeConfig.config.variationName}, function(err) {
         if (err) {
             throw err;
@@ -162,6 +170,22 @@ function startServer() {
                 }
             }
         });
+
+        if (themeConfigHooks.change_js) {
+            Bs.watch(jsCompilerDir, { ignoreInitial: true }, function(event) {
+                if (event === 'add' || event === 'change') {
+                    Shell.exec(themeConfigHooks.change_js);
+                }
+            });
+        }
+
+        if (themeConfigHooks.change_css) {
+            Bs.watch(cssCompilerDir, { ignoreInitial: true }, function(event) {
+                if (event === 'add' || event === 'change') {
+                    Shell.exec(themeConfigHooks.change_css);
+                }
+            });
+        }
 
         Bs.watch('config.json', function(event) {
             if (event === 'change') {

--- a/lib/utils/shell.js
+++ b/lib/utils/shell.js
@@ -1,0 +1,40 @@
+var ChildProcess = require('child_process');
+
+function getShell() {
+    if (process.platform === 'win32') {
+        return { command: 'cmd', arg: '/C' };
+    } else {
+        return { command: 'sh', arg: '-c' };
+    }
+}
+
+/**
+ * Execute shell command
+ * @param {string} command Shell command to execute
+ * @return {ChildProcess}
+ */
+function exec(command) {
+    var shell = getShell(),
+        args = [shell.arg, command],
+        options = { stdio: 'inherit' };
+
+    return ChildProcess.spawn(shell.command, args, options);
+}
+
+/**
+ * Execute shell command synchronously
+ * @param {string} command Shell command to execute
+ * @return {Object}
+ */
+function execSync(command) {
+    var shell = getShell(),
+        args = [shell.arg, command],
+        options = { stdio: 'inherit' };
+
+    return ChildProcess.spawnSync(shell.command, args, options);
+}
+
+module.exports = {
+    exec: exec,
+    execSync: execSync
+};

--- a/test/lib/utils/shell.js
+++ b/test/lib/utils/shell.js
@@ -1,0 +1,82 @@
+var ChildProcess = require('child_process'),
+    Code = require('code'),
+    Lab = require('lab'),
+    Sinon = require('sinon'),
+    Shell = require('../../../lib/utils/shell');
+
+var lab = exports.lab = Lab.script(),
+    afterEach = lab.afterEach,
+    beforeEach = lab.beforeEach,
+    describe = lab.describe,
+    expect = Code.expect,
+    it = lab.it;
+
+describe('shell', function() {
+    describe('exec', function() {
+        var childProcess;
+
+        beforeEach(function(done) {
+            childProcess = {};
+
+            Sinon.stub(ChildProcess, 'spawn').returns(childProcess);
+
+            done();
+        });
+
+        afterEach(function(done) {
+            ChildProcess.spawn.restore();
+
+            done();
+        });
+
+        it('should spawn a child process and inherit parent\'s stdio', function(done) {
+            Shell.exec('node -h');
+
+            expect(ChildProcess.spawn.calledWith('sh', ['-c', 'node -h'], { stdio: 'inherit' })).to.be.true();
+
+            done();
+        });
+
+        it('should return a child process', function(done) {
+            var output = Shell.exec('node -h');
+
+            expect(output).to.equal(childProcess);
+
+            done();
+        });
+    });
+
+    describe('execSync', function() {
+        var results;
+
+        beforeEach(function(done) {
+            results = {};
+
+            Sinon.stub(ChildProcess, 'spawnSync').returns(results);
+
+            done();
+        });
+
+        afterEach(function(done) {
+            ChildProcess.spawnSync.restore();
+
+            done();
+        });
+
+        it('should spawn a child process synchronously and inherit parent\'s stdio', function(done) {
+            Shell.execSync('node -h');
+
+            expect(ChildProcess.spawnSync.calledWith('sh', ['-c', 'node -h'], { stdio: 'inherit' })).to.be.true();
+
+            done();
+        });
+
+        it('should return the results of the process', function(done) {
+            var output = Shell.execSync('node -h');
+
+            expect(output).to.equal(results);
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Added the ability to hook into `stencil start` and `stencil bundle`

Example:

``` js
// config.json
{
  "hooks": {
    "start": "grunt check",
    "bundle": "grunt check",
    "change_js": "grunt check:js",
    "change_css": "grunt check:css"
  }
}
```

Imagine `grunt check` is a simple grunt task that lints your JS/SCSS and runs tests, When running `stencil bundle`, `grunt check` gets run and throws an error if there's an error (prevents you from bundling). Similarly, when a Javascript file changes, `grunt check:js` gets fired and warns you as you develop.

Related PR: https://github.com/bigcommerce/stencil/pull/464

@meenie @haubc @mickr @mcampa @hegrec 
