### PR TITLE
BIG-19552: Supporting changes for stencil-editor change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
       "jmdobry/angular-cache": "github:jmdobry/angular-cache@3.2.4",
       "kentcdodds/api-check": "github:kentcdodds/api-check@^7.5.0",
       "lodash": "npm:lodash@2.4.1",
-      "meenie/jschannel.git": "github:meenie/jschannel@0.0.5",
-      "meenie/ng-stencil-editor": "github:meenie/ng-stencil-editor@test-deploy",
+      "meenie/jschannel": "github:meenie/jschannel@0.0.5",
       "rubenv/angular-gettext": "github:rubenv/angular-gettext@1.1.4"
     },
     "devDependencies": {

--- a/public/config.js
+++ b/public/config.js
@@ -28,12 +28,12 @@ System.config({
     "api-check": "github:kentcdodds/api-check@7.5.0",
     "babel": "npm:babel-core@5.6.7",
     "babel-runtime": "npm:babel-runtime@5.6.7",
-    "bigcommerce-labs/bcapp-pattern-lab": "github:bigcommerce-labs/bcapp-pattern-lab@1.10.0",
+    "bigcommerce-labs/bcapp-pattern-lab": "github:bigcommerce-labs/bcapp-pattern-lab@1.11.0",
     "bigcommerce-labs/ng-common": "github:bigcommerce-labs/ng-common@2.5.1",
     "bigcommerce-labs/ng-stencil-editor": "github:bigcommerce-labs/ng-stencil-editor@master",
     "core-js": "npm:core-js@0.9.18",
     "jmdobry/angular-cache": "github:jmdobry/angular-cache@3.2.4",
-    "kentcdodds/api-check": "github:kentcdodds/api-check@7.5.0",
+    "kentcdodds/api-check": "github:kentcdodds/api-check@7.5.3",
     "lodash": "npm:lodash@2.4.1",
     "meenie/jschannel": "github:meenie/jschannel@0.0.5",
     "rubenv/angular-gettext": "github:rubenv/angular-gettext@1.1.4",
@@ -46,19 +46,38 @@ System.config({
     "github:angular/bower-angular-sanitize@1.3.7": {
       "angular": "github:angular/bower-angular@1.3.7"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
+    },
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-util@0.1.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:assert@1.3.0": {
+      "util": "npm:util@0.10.3"
     },
     "npm:babel-runtime@5.6.7": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
+    "npm:inherits@2.0.1": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:lodash@2.4.1": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:util@0.10.3": {
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     }
   }
 });

--- a/server/plugins/StencilEditor/index.js
+++ b/server/plugins/StencilEditor/index.js
@@ -110,7 +110,7 @@ internals.home = function(request, reply) {
  * @param reply
  */
 internals.updateConfig = function (request, reply) {
-    var saveToFile = !!request.query.publish,
+    var saveToFile = !!request.query.commit,
         response = {
             forceReload: internals.themeConfig.updateConfig(request.payload, saveToFile).forceReload,
             stylesheets: []

--- a/server/plugins/StencilEditor/templates/index.html
+++ b/server/plugins/StencilEditor/templates/index.html
@@ -28,7 +28,8 @@
                 angular.module('ng-common.bc-app', [])
                     .constant('BC_APP_CONFIG', {
                         cdnPath: '//localhost:8181',
-                        storeUrl: '{{{storeUrl}}}'
+                        storeUrl: '{{{storeUrl}}}',
+                        isProduction: false
                     })
                     .constant('BC_SEED_DATA', {});
 


### PR DESCRIPTION
I've updated the dependencies, and fixed a discrepancy on how jschannel was being brought in.  There are also changes to support the new "commit" param.

I've decided to use `commit` rather than `publish` since `publish` means something completely different in production.  While using the editor with the CLI, you only ever commit your changes to the `config.json`, there is no "publishing". 
