### PR TITLE
BIG-22192: SDK setting cookies and injecting Theme Preview banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "dependencies": {
       "angular": "github:angular/bower-angular@1.3.7",
       "angular-animate": "github:angular/bower-angular-animate@1.3.7",
+      "angular-cookies": "github:angular/bower-angular-cookies@1.3.7",
       "angular-formly": "github:formly-js/angular-formly@6.15.2",
       "angular-sanitize": "github:angular/bower-angular-sanitize@1.3.7",
       "angular-ui-router": "github:angular-ui/ui-router@0.2.13",
@@ -74,6 +75,7 @@
       "bigcommerce-labs/ng-common": "github:bigcommerce-labs/ng-common@2.5.1",
       "bigcommerce-labs/ng-stencil-editor": "github:bigcommerce-labs/ng-stencil-editor@1.0.0",
       "jmdobry/angular-cache": "github:jmdobry/angular-cache@3.2.4",
+      "js-cookie": "github:js-cookie/js-cookie@^2.0.3",
       "kentcdodds/api-check": "github:kentcdodds/api-check@^7.5.0",
       "lodash": "npm:lodash@2.4.1",
       "meenie/jschannel": "github:meenie/jschannel@0.0.5",

--- a/public/config.js
+++ b/public/config.js
@@ -22,6 +22,7 @@ System.config({
   "map": {
     "angular": "github:angular/bower-angular@1.3.7",
     "angular-animate": "github:angular/bower-angular-animate@1.3.7",
+    "angular-cookies": "github:angular/bower-angular-cookies@1.3.7",
     "angular-formly": "github:formly-js/angular-formly@6.15.2",
     "angular-sanitize": "github:angular/bower-angular-sanitize@1.3.7",
     "angular-ui-router": "github:angular-ui/ui-router@0.2.13",
@@ -33,6 +34,7 @@ System.config({
     "bigcommerce-labs/ng-stencil-editor": "github:bigcommerce-labs/ng-stencil-editor@1.0.0",
     "core-js": "npm:core-js@0.9.18",
     "jmdobry/angular-cache": "github:jmdobry/angular-cache@3.2.4",
+    "js-cookie": "github:js-cookie/js-cookie@2.0.3",
     "kentcdodds/api-check": "github:kentcdodds/api-check@7.5.3",
     "lodash": "npm:lodash@2.4.1",
     "meenie/jschannel": "github:meenie/jschannel@0.0.5",
@@ -41,6 +43,9 @@ System.config({
       "angular": "github:angular/bower-angular@1.3.7"
     },
     "github:angular/bower-angular-animate@1.3.7": {
+      "angular": "github:angular/bower-angular@1.3.7"
+    },
+    "github:angular/bower-angular-cookies@1.3.7": {
       "angular": "github:angular/bower-angular@1.3.7"
     },
     "github:angular/bower-angular-sanitize@1.3.7": {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,4 @@
+import 'angular-cookies';
 import 'angular-animate';
 import 'angular-sanitize';
 import 'angular-ui-router';

--- a/public/js/stencil-editor.js
+++ b/public/js/stencil-editor.js
@@ -1,32 +1,193 @@
-var chan = Channel.build({window: window.parent, origin: '*', scope: 'stencilEditor'});
+'use strict';
 
-setInterval(function focusBody(){
-    document.body.focus();
-}, 250);
+(function stencilEditorSDK(window, Channel) {
+    var cookieName= 'stencil_editor_enabled',
+        _editorToken;
 
-chan.bind('reload-stylesheets', function reloadStylesheets(trans, stylesheets) {
-    var linkElements = Array.prototype.slice.call(document.getElementsByTagName('link'));
+    function init() {
+        if (runningInIframe()) {
+            registerJsChannelEvents();
+        } else {
+            insertBanner();
+        }
+    }
 
-    stylesheets = JSON.parse(stylesheets);
+    init();
 
-    linkElements.forEach(function iterateLinkElements(element) {
-        var href = element.getAttribute('href'),
-            queryIndex = href.indexOf('?');
+    /**
+     * Removes the cookie and reloads the page
+     */
+    function closePreview(event) {
+        event.preventDefault();
 
-        if (queryIndex !== -1) {
-            href = href.substring(0, queryIndex);
+        Cookies.remove(cookieName);
+        reloadPage();
+    }
+
+    /**
+     * Getter for editorToken
+     * This token value is used for the cookie
+     * @returns {string}
+     */
+    function getEditorToken() {
+        return _editorToken;
+    }
+
+    /**
+     * Creates and prepends the Preview banner to the document body.
+     */
+    function insertBanner() {
+        var banner = document.createElement('div'),
+            bannerHeight,
+            bodyMarginTop;
+
+        banner.className = 'stencilEditorPreview-banner';
+        banner.innerHTML =
+            '<style>' +
+                '.stencilEditorPreview-banner { ' +
+                    'background-color: #556273;' +
+                    'display: table;' +
+                    'height: 62px;' +
+                    'padding: 0 20px;' +
+                    'position: absolute;' +
+                    'top: -63px;' +
+                    'width: 100%;' +
+                '}' +
+                '.stencilEditorPreview-close {' +
+                    'color: #FFFFFF;' +
+                    'display: table-cell;' +
+                    'text-align: right;' +
+                    'text-decoration: none;' +
+                    'vertical-align: middle;' +
+                '}' +
+                '.stencilEditorPreview-logo {' +
+                    'display: table-cell;' +
+                    'height: 55px;' +
+                    'vertical-align: middle;' +
+                    'width: 55px;' +
+                '}' +
+                '.stencilEditorPreview-text {' +
+                    'color: #FFFFFF;' +
+                    'display: table-cell;' +
+                    'vertical-align: middle' +
+                '}' +
+            '</style>' +
+
+            '<div class="stencilEditorPreview-logo">' +
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -8 65 65">' +
+                    '<g opacity=".6" fill="#00A9C7">' +
+                        '<path d="M16 21.1c5 0 9.5 1.4 13 3.6 1.5-1.9 2.4-4.2 2.4-6.6 0-7.1-7.7-12.9-17.1-12.9C4.8 5.2 3.5 11 3.5 18.1c0 3.3.3 6.2 1.5 8.5 1.6-3.3 4.8-5.5 11-5.5z"/>' +
+                        '<path d="M29 24.7c-3 3.8-8.4 6.3-14.7 6.3-5.1 0-7.8-1.7-9.3-4.4-1.2 2.6-1.5 5.9-1.5 9.4C3.5 44.3 5 51 16 51s19.9-6.7 19.9-15c0-4.5-2.7-8.5-6.9-11.3z"/>' +
+                    '</g>' +
+                    '<path fill="#00A9C7" d="M5 26.7c1.4 2.7 4.1 4.4 9.3 4.4 6.3 0 11.7-2.5 14.7-6.3-3.5-2.3-8-3.6-13-3.6-6.2-.1-9.4 2.1-11 5.5z"/>' +
+                '</svg>' +
+            '</div>' +
+            '<h1 class="stencilEditorPreview-text">Theme Preview</h1>' +
+            '<a id="editor-close-preview" class="stencilEditorPreview-close" href="#">Close</a>';
+
+        document.body.appendChild(banner);
+
+        bannerHeight = banner.offsetHeight;
+        bodyMarginTop = window.parseInt(document.body.style.marginTop, 10);
+
+        if (window.isNaN(bodyMarginTop)) {
+            bodyMarginTop = 0;
         }
 
-        if(stylesheets.indexOf(href) !== -1) {
-            element.setAttribute('href', href + '?' + Date.now());
+        document.body.style.marginTop = (bannerHeight + bodyMarginTop) + 'px';
+        document.getElementById('editor-close-preview').onclick = closePreview;
+    }
+
+    /**
+     * Ran when the jsChannel channel is ready and sets the editorToken cookie
+     * @param trans - jsChannel transaction
+     * @param data
+     */
+    function onReady(trans, data) {
+        data = JSON.parse(data);
+
+        setEditorToken(data.token);
+        setCookie();
+    }
+
+    /*
+     * Registers JsChannel subscriptions
+     */
+    function registerJsChannelEvents() {
+        var chan = Channel.build({window: window.parent, origin: '*', scope: 'stencilEditor'});
+
+        chan.bind('on-ready', onReady);
+        chan.bind('reload-stylesheets', reloadStylesheets);
+        chan.bind('reload-page', reloadPage);
+        chan.bind('window-active', setCookie);
+    }
+
+    /**
+     * Reloads the current page
+     * @returns {boolean}
+     */
+    function reloadPage() {
+        document.location.reload(true);
+
+        return true;
+    }
+
+    /**
+     * Reloads stylesheets by appending Date.now() to their href
+     * @param trans - jsChannel transaction
+     * @param stylesheets - stringified array of stylesheet names
+     * @returns {boolean}
+     */
+    function reloadStylesheets(trans, stylesheets) {
+        var linkElements = Array.prototype.slice.call(document.getElementsByTagName('link'));
+
+        try {
+            stylesheets = JSON.parse(stylesheets);
+        } catch(e) {
+            stylesheets = [];
         }
-    });
 
-    return true;
-});
+        linkElements.forEach(function iterateLinkElements(element) {
+            var href = element.getAttribute('href'),
+                queryIndex = href.indexOf('?');
 
-chan.bind('reload-page', function reloadPage() {
-    document.location.reload(true);
+            if (queryIndex !== -1) {
+                href = href.substring(0, queryIndex);
+            }
 
-    return true;
-});
+            if(stylesheets.indexOf(href) !== -1) {
+                element.setAttribute('href', href + '?' + Date.now());
+            }
+        });
+
+        return true;
+    }
+
+    /**
+     * Checks if the current window is being run inside an iframe
+     * @returns {boolean}
+     */
+    function runningInIframe() {
+        try {
+            return window.self !== window.top;
+        } catch(e) {
+            return true;
+        }
+    }
+
+    /**
+     * Sets the cookie with the current value of _editorToken
+     */
+    function setCookie() {
+        Cookies.set(cookieName, getEditorToken());
+    }
+
+    /**
+     * Setter for editorToken
+     * This token value is used for the cookie
+     * @param token
+     */
+    function setEditorToken(token) {
+        _editorToken = token;
+    }
+})(window, Channel);

--- a/server/plugins/Renderer/index.js
+++ b/server/plugins/Renderer/index.js
@@ -19,15 +19,6 @@ module.exports.register = function (server, options, next) {
 
     server.expose('implementation', internals.implementation);
 
-    server.state('stencil_editor_enabled', {
-        ttl: null,
-        isSecure: true,
-        isHttpOnly: true,
-        encoding: 'base64json',
-        clearInvalid: true, // remove invalid cookies
-        strictHeader: true // don't allow violations of RFC 6265
-    });
-
     next();
 };
 

--- a/server/plugins/Renderer/responses/pencilResponse.js
+++ b/server/plugins/Renderer/responses/pencilResponse.js
@@ -68,10 +68,6 @@ module.exports = function (data) {
         response = reply(output);
         response.code(data.statusCode);
 
-        if (request.query.stencilEditor) {
-            response.state('stencil_editor_enabled', true);
-        }
-
         if (data.headers['set-cookie']) {
             response.header('set-cookie', data.headers['set-cookie']);
         }
@@ -107,6 +103,7 @@ internals.makeDecorator = function (request, context) {
 
         if (request.query.stencilEditor || request.state.stencil_editor_enabled) {
             stencilEditorSDK = '<script src="http://localhost:8181/public/jspm_packages/github/meenie/jschannel@0.0.5/src/jschannel.js"></script>';
+            stencilEditorSDK += '<script src="http://localhost:8181/public/jspm_packages/github/js-cookie/js-cookie@2.0.3/src/js.cookie.js"></script>';
             stencilEditorSDK += '<script src="http://localhost:8181/public/js/stencil-editor.js"></script>';
 
             content = content.replace(new RegExp('</body>'), stencilEditorSDK + '\n</body>');

--- a/server/plugins/StencilEditor/index.js
+++ b/server/plugins/StencilEditor/index.js
@@ -98,7 +98,7 @@ internals.home = function(request, reply) {
         reply.view('index', {
             cssFiles: assets.cssFiles,
             jsFiles: assets.jsFiles,
-            storeUrl: 'http://localhost:' + internals.options.stencilServerPort + '?stencilEditor=true'
+            storeUrl: 'http://localhost:' + internals.options.stencilServerPort + '?stencilEditor=stencil-cli'
         });
     });
 };


### PR DESCRIPTION
## BIG-22192

In this PR:
- Refactored / Cleaned the SDK
- `stencil_editor_enabled` cookie is now set by the client
- `stencil_editor_enabled` is now also used to store the token (we can change this to use 2 cookies if we want to)
- The token value is obtained when the jsChannel is ready
- The token is set when `window-active` even fires
- Inserts a banner for the theme preview if is loaded outside of an iframe (designs are not ready yet)
- Clears cookie when the user clicks the close banner button

This needs some changes in `ng-stencil-editor` too, will mention the PR here when ready.

@meenie @mcampa :pray: :mag_right: 
