### PR TITLE
Auto-generated screenshot command

### DIFF
--- a/bin/stencil
+++ b/bin/stencil
@@ -7,5 +7,7 @@ program
     .version(pkg.version)
     .command('init', 'Interactively create a .stencil file which configures how to run a Bigcommerce store locally.')
     .command('start', 'Starts up Bigcommerce store using theme files in the current directory.')
+    .command('screenshots', 'Generates marketplace compatible screenshots for your theme')
     .command('bundle', 'Bundles up the theme into a zip file which can be uploaded to Bigcommerce.')
+
     .parse(process.argv);

--- a/bin/stencil-screenshots
+++ b/bin/stencil-screenshots
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+var Pageres = require('pageres');
+var themePath = process.cwd();
+var Path = require('path');
+var Fs = require('fs');
+var Url = require('url');
+var dotStencilFilePath = Path.join(themePath, '.stencil');
+var metaPath = Path.join(themePath, 'meta');
+var pageResOptions = {
+    crop: true
+};
+var dotStencilFile;
+var localUrl;
+
+require('colors');
+
+function fileExist(path) {
+    try {
+        return Fs.statSync(path);
+    }
+    catch (e) {
+        return false;
+    }
+}
+
+if (!fileExist(dotStencilFilePath)) {
+    return console.error('Error: Please run'.red + ' $ stencil init'.cyan + ' first.'.red);
+}
+
+try {
+    Fs.statSync(metaPath).isDirectory()
+} catch (e) {
+    console.log('Creating \'meta\' folder to store screenshots');
+    Fs.mkdirSync(metaPath);
+}
+
+
+dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
+dotStencilFile = JSON.parse(dotStencilFile);
+
+localUrl = Url.format({
+    protocol: 'http',
+    hostname: 'localhost',
+    port: dotStencilFile.port
+});
+
+
+console.log('Generating screenshots for: "' + localUrl + '"');
+
+new Pageres({
+        delay: 2,
+        headers: {
+            'Accept-Language': 'en'
+        }
+    })
+    .src(localUrl, ['2048x2600', '304x540', '600x760'], pageResOptions)
+    .dest(metaPath)
+    .run(function (err) {
+    if (err) {
+        console.log(err);
+    }
+    console.log('Done.');
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "bin": {
     "stencil": "./bin/stencil",
     "stencil-start": "./bin/stencil-start",
-    "stencil-init": "./bin/stencil-init"
+    "stencil-init": "./bin/stencil-init",
+    "stencil-screenshots": "./bin/stencil-screenshots"
   },
   "config": {
     "stencil_version": "1.0"
@@ -51,6 +52,7 @@
     "less": "^2.5.0",
     "lodash": "^3.9.0",
     "npm": "^2.7.5",
+    "pageres": "^2.1.0",
     "recursive-readdir": "^1.2.1",
     "stencil-paper": "bigcommerce/paper",
     "stencil-styles": "bigcommerce/stencil-styles",


### PR DESCRIPTION
Running `stencil screenshots` will generate theme registry compatible screenshots with the correct dimensions without needing to fiddle around with photoshop and print screen commands. Mostly intended for developers to quickly submit test themes during the dev preview phase so we can validate PxU themes are working in theme registry.

Thanks for the idea/code Patrick

@mcampa @mickr @haubc @pedelman 
