### PR TITLE
BIG-23294: Add schema.json to the stencil bundle.

### DIFF
--- a/bin/stencil-bundle
+++ b/bin/stencil-bundle
@@ -78,7 +78,8 @@ Async.parallel(tasks, function(err, assembledData) {
             'README.md',
             'CHANGELOG.md',
             'config.json',
-            'package.json'
+            'package.json',
+            'schema.json'
         ],
         archive = Archiver('zip');
 


### PR DESCRIPTION
Theme Registry will begin storage of the schema.json file on a per
version basis. This will add the file into the bundle so after we
unzip, we can do any validation, then store the contents of the file
in the theme registry db.
