### PR TITLE
BIG-23519 Improve Stencil CLI Errors

### DIFF
--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -6,6 +6,7 @@ var Fs = require('fs'),
     Inquirer = require('inquirer'),
     Jspm = require('jspm'),
     JspmAssembler = require('../lib/jspmAssembler'),
+    jsonLint = require('../lib/jsonLint'),
     Path = require('path'),
     Program = require('commander'),
     ThemeConfig = require('../lib/themeConfig'),
@@ -21,7 +22,11 @@ Program
 
 if (Fs.existsSync(dotStencilFilePath)) {
     dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
-    dotStencilFile = JSON.parse(dotStencilFile);
+    try {
+        dotStencilFile = jsonLint.parse(dotStencilFile, dotStencilFilePath);
+    } catch (e) {
+        return console.error(e.fileName, e.stack);
+    }
 }
 
 var questions = [

--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -11,12 +11,14 @@ var _ = require('lodash'),
     ThemeConfig = require('../lib/themeConfig'),
     Url = require('url'),
     Wreck = require('wreck'),
+    jsonLint = require('./../lib/jsonLint'),
     themePath = process.cwd(),
     allowedCssCompilers = ['scss', 'less'],
     browserSyncPort,
     cssCompilerDir,
     cssWatchBaseDir = Path.join(themePath, 'assets/'),
     dotStencilFilePath = Path.join(themePath, '.stencil'),
+    themeConfigPath = Path.join(themePath, 'config.json'),
     dotStencilFile,
     isTopLevelCssRegex,
     stencilServerPort,
@@ -59,13 +61,18 @@ if (Program.variation) {
         themeConfig.setVariationByName(Program.variation);
     } catch (err) {
         return console.error('Error: The variation '.red + Program.variation + ' does not exists in your config.json file'.red);
-    }   
+    }
 }
 
 configuration = themeConfig.getConfig();
 
 dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
-dotStencilFile = JSON.parse(dotStencilFile);
+
+try {
+    dotStencilFile = jsonLint.parse(dotStencilFile, dotStencilFilePath);
+} catch (e) {
+    return console.error(e.stack);
+}
 
 if (allowedCssCompilers.indexOf(configuration.css_compiler) === -1) {
     return console.error('Error: Only %s are allowed as CSS Compilers'.red, allowedCssCompilers.join(', '));
@@ -105,7 +112,7 @@ Wreck.get(
             bundleTask;
 
         try {
-            payload = JSON.parse(payload);
+            payload = jsonLint.parse(payload);
         } catch (e) {
             retError = true;
         }
@@ -159,6 +166,9 @@ function startServer() {
         if (err) {
             throw err;
         }
+
+        // Display Set up information
+        console.log(startUpInformation());
 
         /**
          * Watch the appropriate css directory based on which compiler was chosen.
@@ -299,4 +309,29 @@ function fileExist(path) {
     catch (e) {
         return false;
     }
+}
+
+/**
+* Displays information about your environment and configuration.
+* @return {string}
+*/
+function startUpInformation() {
+    var information = '\n';
+
+    information += '-----------------Startup Information-------------\n'.gray;
+    information += '\n';
+    information += '.stencil location: ' + dotStencilFilePath.cyan + '\n';
+    information += 'config.json location: ' + themeConfigPath.cyan + '\n';
+    information += 'Store URL: ' + dotStencilFile.normalStoreUrl.cyan + '\n';
+
+    if (dotStencilFile.staplerUrl) {
+        information += 'Stapler URL: ' + staplerUrl.cyan + '\n';
+    }
+
+    information += 'SSL Store URL: ' + dotStencilFile.storeUrl.cyan + '\n';
+    information += 'Node Version: ' + process.version + '\n';
+    information += '\n';
+    information += '-------------------------------------------------\n'.gray;
+
+    return information;
 }

--- a/lib/jsonLint.js
+++ b/lib/jsonLint.js
@@ -1,0 +1,13 @@
+var jsonLint = require('jsonlint');
+
+module.exports = {
+    parse: function (jsonString, file) {
+        file = file || '';
+
+        try {
+            return jsonLint.parse(jsonString);
+        } catch (e) {
+            throw new Error(file + ' - ' + e.message);
+        }
+    }
+};

--- a/lib/themeConfig.js
+++ b/lib/themeConfig.js
@@ -4,7 +4,7 @@ var Hoek = require('hoek');
 var Path = require('path');
 var Glob = require('glob');
 var Async = require('async');
-var JsonLint = require('jsonlint');
+var jsonLint = require('./jsonLint');
 var Validator = require('jsonschema').Validator;
 
 var themeConfigInstance;
@@ -24,7 +24,7 @@ function getInstance(themePath) {
 
         return themeConfigInstance;
     }
-    
+
     if (themePath) {
         themeConfigInstance.setThemePath(themePath);
     }
@@ -306,7 +306,7 @@ ThemeConfig.prototype.validateConfigSchema = function () {
 
 /**
  * Scans the theme template directory for theme settings that need force reload
- * 
+ *
  * @param {Function} callback
  */
 ThemeConfig.prototype.getSchema = function (callback) {
@@ -321,11 +321,11 @@ ThemeConfig.prototype.getSchema = function (callback) {
 
     if (themeSchemaContent) {
         try {
-            themeSchema = JsonLint.parse(themeSchemaContent);
+            themeSchema = jsonLint.parse(themeSchemaContent, this.schemaPath);
         } catch (err) {
             return callback(err);
         }
-    }        
+    }
 
     if (!_.isArray(themeSchema)) {
         themeSchema = [];
@@ -390,7 +390,7 @@ function fetchThemeSettings(path, callback) {
  * @return {object}
  */
 function getRawConfig() {
-    return JsonLint.parse(Fs.readFileSync(this.configPath, {encoding: 'utf-8'}));
+    return jsonLint.parse(Fs.readFileSync(this.configPath, {encoding: 'utf-8'}), this.configPath);
 }
 
 /**

--- a/test/lib/jsonLint.js
+++ b/test/lib/jsonLint.js
@@ -1,0 +1,32 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.describe,
+    jsonLint = require('../../lib/jsonLint'),
+    expect = Code.expect,
+    it = lab.it;
+
+describe('json-lint', function () {
+    var badJsonFilename = '/path/to/badfile.json',
+        badJson = '{"foo":"bar" "fizz": "buzz"}',
+        file = new RegExp(badJsonFilename);
+
+
+    it('should add file name to error', function (done) {
+        var throws = function () {
+            jsonLint.parse(badJson, badJsonFilename);
+        };
+
+        expect(throws).throw(Error, file);
+        done();
+    });
+
+    it('should not need a file name', function (done) {
+        var throws = function () {
+            jsonLint.parse(badJson);
+        };
+
+        expect(throws).throw(Error, !file);
+        done();
+    })
+});


### PR DESCRIPTION
@hegrec @haubc 
BIG-23519 - Improve Stencil CLI Errors
- Created a small wrapper for json-lint that would also take a file name. This will make it easier to identify
  the file that was parsed and displaying that filename with the error.
- Added tests for small utility.
- Added small function in stencil-start that will display a few config file locations
