### PR TITLE
PxU Bug: error 400 Invalid cookie error on TE startup

### DIFF
--- a/server/plugins/StencilEditor/index.js
+++ b/server/plugins/StencilEditor/index.js
@@ -18,6 +18,11 @@ var _ = require('lodash'),
             publicPath: Path.join(__dirname, '../../../public'),
             metaPath: Path.join(process.cwd(), 'meta'),
             stencilThemeHost: ''
+        },
+        routesConfig: {
+            state: {
+                parse: false // do not parse cookies 
+            }
         }
     };
 
@@ -59,6 +64,7 @@ module.exports.register = function (server, options, next) {
         {
             method: 'GET',
             path: '/',
+            config: internals.routesConfig,
             handler: function(request, reply) {
                 reply.redirect('/ng-stencil-editor/theme/' + variationId + '/' + variationId);
             }
@@ -66,11 +72,13 @@ module.exports.register = function (server, options, next) {
         {
             method: 'GET',
             path: '/ng-stencil-editor/{versionId}/{variationId}/{configId}',
+            config: internals.routesConfig,
             handler: handlers.home
         },
         {
             method: 'GET',
             path: '/public/{path*}',
+            config: internals.routesConfig,
             handler: {
                 directory: {
                     path: internals.options.publicPath
@@ -80,6 +88,7 @@ module.exports.register = function (server, options, next) {
         {
             method: 'GET',
             path: '/meta/{path*}',
+            config: internals.routesConfig,
             handler: {
                 directory: {
                     path: internals.options.metaPath
@@ -89,21 +98,25 @@ module.exports.register = function (server, options, next) {
         {
             method: 'GET',
             path: internals.options.basePath + '/variations/{variationId}',
+            config: internals.routesConfig,
             handler: require('./api/getVariations')(internals.options, internals.themeConfig)
         },
         {
             method: 'GET',
             path: internals.options.basePath + '/configurations/{configurationId}',
+            config: internals.routesConfig,
             handler: require('./api/getConfigurations')(internals.options, internals.themeConfig)
         },
         {
             method: 'POST',
             path: internals.options.basePath + '/configurations',
+            config: internals.routesConfig,
             handler: require('./api/postConfigurations')(internals.options, internals.themeConfig)
         },
         {
             method: 'GET',
             path: internals.options.basePath + '/versions/{versionId}',
+            config: internals.routesConfig,
             handler: require('./api/getVersions')(internals.options, internals.themeConfig)
         }
     ]);


### PR DESCRIPTION
BcApp does not follow RFC cookies standards, when using brackets in cookie names. In this case ``viewPosts[limit]`.

Hapi is very strict on parsing cookies and because of that it crashes. 

The solution here to tell hapi not to parse cookies for theme editor server.

@bc-jstoffan @deini @hegrec 
