### PR TITLE
Load SDK when preview_config_id cookie is set

### DIFF
--- a/server/plugins/StencilEditor/index.js
+++ b/server/plugins/StencilEditor/index.js
@@ -49,7 +49,7 @@ module.exports.register = function (server, options, next) {
     options.themeServer.ext('onRequest', function(request, reply) {
         request.app.decorators = request.app.decorators || [];
 
-        // Only add the SDK if stencilEditor is a query parameter
+        // Only add the SDK if stencilEditor is a query parameter or the cookie preview_config_id is set
         if (request.query.stencilEditor || (request.headers.cookie || '').indexOf('preview_config_id') !== -1) {
             request.app.decorators.push(internals.sdkDecorator);
         }


### PR DESCRIPTION
@deini @bc-jstoffan 

Bug fix: SDK was not loading if I navigate to other page after the first load.
I missed this some how.
