### PR TITLE
Use a more relevant default bundle name

### DIFF
--- a/bin/stencil-bundle
+++ b/bin/stencil-bundle
@@ -164,7 +164,8 @@ Async.series([
     function(cb) {
         Async.parallel(tasks, function (err, assembledData) {
             var outputFolder = Program.dest ? Program.dest : themePath,
-                outputName = Program.filename ? Program.filename : 'stencil-bundle.zip',
+                defaultName = themeConfig.getName() + '-' + themeConfig.getVersion() + '.zip',
+                outputName = Program.filename ? Program.filename : defaultName,
                 output = Fs.createWriteStream(Path.join(outputFolder, outputName)),
                 pathsToZip = [
                     'assets/**/*',
@@ -356,7 +357,7 @@ function assembleTemplatesTask(callback) {
 
 function assembleSchema(callback) {
     console.log('Building Theme Schema File...');
-    
+
     themeConfig.getSchema(function(err, schema) {
         console.log('ok'.green + ' -- Theme Schema Building Finished');
 


### PR DESCRIPTION
Running this on the master branch yields:

`Bundled saved to: /Users/christopher.hegre/Workspace/stencil/Stencil-1.0.2.zip`

@mickr @haubc 
