### PR TITLE
Reduce the requirements for a private theme.

### DIFF
--- a/lib/privateThemeConfig.schema.json
+++ b/lib/privateThemeConfig.schema.json
@@ -43,9 +43,7 @@
       "required": [
         "author_name",
         "author_email",
-        "author_support_url",
-        "price",
-        "documentation_url"
+        "author_support_url"
       ]
     },
     "settings": {
@@ -128,16 +126,12 @@
           "meta"
         ]
       },
-      "minItems": 1,
+      "minItems": 0,
       "maxItems": 4
     }
   },
   "required": [
-    "name",
-    "version",
-    "meta",
-    "settings",
-    "variations"
+    "meta"
   ],
   "additionalProperties": true
 }


### PR DESCRIPTION
In this PR, we want to allow the following to pass stencil-cli validation for private themes.

``` js
{
  "meta": {
    "author_name": "Bigcommerce Developers",
    "author_email": "support@bigcommerce.com",
    "author_support_url": "https://www.bigcommerce.com/support"
  }
}
```

We no longer require some fields, I will explain the removal of each with reasoning.
- **price**: We default every private theme to be a price of `0` regardless if it is present.
- **documentation_url**: I think its a little crazy to require this for someones private theme. Also we default this to goto the main stencil docs.
- **variations (min 0)**: If you do not supply any variations, we will build one by default at upload time with the base information needed to get through upload. If you do supply 1, it will go through the rest of the required fields for variations[meta] and variations root.
- **name**: We will default to using the zip file name for the name of the theme version
- **version**: We default this to `0.0.1`
- **settings**: This is not a hard requirement of building a theme
- **variations**: We do not want to require the key if we allow a min 0 for variations

ping @hegrec @mattolson 
