### PR TITLE
MERC-769 Custom Templates in Stencil-CLI

### DIFF
--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -14,10 +14,10 @@ internals.parseAnswers = function(JspmAssembler, ThemeConfig, dotStencilFile, do
     // If already set, do nothing otherwise write the empty configurations
     if (!dotStencilFile || dotStencilFile && !dotStencilFile.customLayouts) {
         answers.customLayouts = {
-            'products': {},
-            'search': {},
-            'brands': {},
-            'categories': {}
+            'brand': {},
+            'category': {},
+            'page': {},
+            'product': {}
         };
     }
 

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -359,7 +359,7 @@ internals.findDeepTemplate = function (haystack, needle) {
             // object, recursive find
             template = internals.findDeepTemplate(val, needle);
             if (template) {
-                template = _.trimRight(key + '/' + template, '.html');
+                template = (key + '/' + template).replace('.html', '');
                 return false; // break out of loop
             }
         } else if (typeof val === 'string') {


### PR DESCRIPTION
MERC-769
### Why?
When associating a template to a path the trimRight method was trimming off the last letter of the template name if it ended with h t m l individually and trimRight has since been deprecated in lodash.

* Removing lodash trimRight for just a vanilla replace.
* Change generated format for customLayouts object in stencil-init.