### PR TITLE
MERC-1049 & MERC-1064 bug fixes

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -281,7 +281,6 @@ function bundleTaskRunner(tasks, cb) {
             'Gruntfile.js',
             'karma.conf.js',
             'lang/*',
-            'manifest.json',
             'meta/**/*',
             'package.json',
             'README.md',

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -267,7 +267,7 @@ internals.getResourceConfig = function (data, request, configuration) {
         frontmatterContent,
         rawTemplate,
         resourcesConfig = {},
-        templatePath = internals.getTemplatePath(request.path, data);
+        templatePath = data.template_file;
 
     // If the requested template is not an array, we parse the Frontmatter
     // If it is an array, then it's an ajax request using `render_with` with multiple components


### PR DESCRIPTION
Changes:
- Bug: do not include `manifest.json` file in the bundle. It is auto generated by the bundle process
- Use the default template file for getting front-matter configuration to match production behavior 

MERC-1049 & MERC-1064

@lord2800 @sherrybc 