### PR TITLE
Exclude assets/cdn from stencil bundle

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -273,6 +273,7 @@ function bundleTaskRunner(tasks, cb) {
         var output;
         var pathsToZip = [
             'assets/**/*',
+            '!assets/cdn/**',
             '!assets/jspm_packages/**', // Don't want jspm_packages if it's there
             'CHANGELOG.md',
             'config.json',


### PR DESCRIPTION
This PR excludes the folder `assets/cdn` from the zip file created by running `stencil bundle`.

As a theme developer, I might want to include large assets that push the size of my theme's bundle past the 50MB mark. If I want to exclude my assets from the bundle, they'd need to be outside the `assets` directory. This results in the inability to use the stencil server to serve those assets. This change enables the theme developer to use a special folder, named `cdn` within their assets folder which is then excluded from the bundle.

This PR can stand on its own, but I think it makes a lot more sense in the context of my other PR (bigcommerce/paper#97), which enables theme developers to conditionally serve assets from the CDN folder when in a local environment, and from a third-party CDN when in production.
