### PR TITLE
Support definition of custom template mappings using an array

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -346,8 +346,17 @@ internals.getTemplatePath = function (path, data) {
 
     if (internals.validCustomTemplatePageTypes.indexOf(pageType) >= 0 && _.isPlainObject(customLayouts[pageType])) {
         templatePath = _.findKey(customLayouts[pageType], function(p) {
-            // remove trailing slashes to compare
-            return p.replace(/\/$/, '') === path.replace(/\/$/, '');
+            // normalize input to an array
+            if (typeof p === 'string') {
+              p = [p];
+            }
+
+            var matches = p.filter(function(url) {
+              // remove trailing slashes to compare
+              return url.replace(/\/$/, '') === path.replace(/\/$/, '');
+            });
+
+            return matches.length > 0;
         });
 
         if (templatePath) {


### PR DESCRIPTION
When mapping pages to custom templates locally, developers may want to apply a custom template to more than one URL. This PR modifies the matching algorithm to accept either a string URL, or an array of string URLs to match.

If merged, the following would be valid:
```json
{
  "customLayouts": {
    "product": {
      "featured-product.html": ["/special-product-one", "/special-product-two"],
      "clearance-product.html": "/clearance-product"
    },
    "search": {},
    "brands": {},
    "categories": {}
  }
}
```

Also, I'd love to make sure there's tests for this functionality, but I couldn't quite figure out how to expose the render module's internals to a test script. If anyone could point me in the right direction regarding that, I'd be happy to update the PR with tests!