### PR TITLE
Downgrade jspm due to crashing when bundling themes

### DIFF
--- a/lib/jspm-assembler.js
+++ b/lib/jspm-assembler.js
@@ -13,7 +13,8 @@ var Async = require('async'),
  */
 function assemble(jspmOptions, themePath) {
     return function(callback) {
-        var jspmDepLocation,
+        var oldConsoleError = console.error,
+            jspmDepLocation,
             depLocation;
 
         // Look for development configuration
@@ -27,6 +28,15 @@ function assemble(jspmOptions, themePath) {
 
         console.log('JavaScript Bundling Started...');
 
+        // Need to suppress annoying errors from Babel.
+        // They will be gone in the next minor version of JSPM (0.16.0).
+        // Until then, this will stay in place
+        console.error = function (error) {
+            if (!/Deprecated option metadataUsedHelpers/.test(error)) {
+                oldConsoleError(error);
+            }
+        };
+
         // Delete old dependency file if it exists
         if (Fs.existsSync(depLocation)) {
             Fs.unlinkSync(depLocation);
@@ -35,6 +45,7 @@ function assemble(jspmOptions, themePath) {
         Jspm.setPackagePath(themePath);
         Jspm.bundle(jspmOptions.bootstrap, jspmDepLocation, {minify: true, sourceMaps: true}).then(function () {
             console.log('ok'.green + ' -- JavaScript Bundling Finished');
+            console.error = oldConsoleError;
             callback(null, true);
         });
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
@@ -57,7 +57,7 @@
     "install": "^0.1.8",
     "jsonlint": "^1.6.2",
     "jsonschema": "^1.0.2",
-    "jspm": "^0.16.46",
+    "jspm": "^0.15.7",
     "jspm-git": "^0.6.0",
     "lab": "^5.5.1",
     "less": "^2.5.0",


### PR DESCRIPTION
`stencil bundle` crashes when running `Jspm.bundleSFX()` for no unknown reason.

Downgrading to a known working version while I investigate

@lord2800