### PR TITLE
skip problematic files when looking for theme settings while bundling

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -98,6 +98,7 @@ Bundle.prototype.getCssAssembleTask = function (compiler) {
             }, function (err, results) {
                 var ret = {};
                 if (err) {
+                    console.log('failed'.red + ' -- %s Parsing');
                     return callback(err);
                 }
 
@@ -139,6 +140,7 @@ Bundle.prototype.assembleTemplatesTask = function (callback) {
 
             ], function (err) {
                 if (err) {
+                    console.log('failed'.red + ' -- Template Parsing');
                     callback(err);
                 }
 
@@ -154,6 +156,7 @@ Bundle.prototype.assembleSchema = function (callback) {
 
     this.themeConfig.getSchema(function (err, schema) {
         if (err) {
+            console.log('failed'.red + ' -- Building Theme Schema File');
             callback(err);
         }
 
@@ -167,6 +170,7 @@ Bundle.prototype.assembleLangTask = function (callback) {
     console.log('Language Files Parsing Started...');
     LangAssembler.assemble(function (err, results) {
         if (err) {
+            console.log('failed'.red + ' -- Language Files Parsing');
             return callback(err);
         }
 
@@ -200,6 +204,7 @@ Bundle.prototype.getJspmBundleTask = function (jspmConfig) {
             console.error = oldConsoleError;
             callback(null, true);
         }).catch(function (err) {
+            console.log('failed'.red + ' -- JavaScript Bundling');
             callback(err);
         });
     }
@@ -214,6 +219,7 @@ Bundle.prototype.generateManifest = function (callback) {
 
     rr(self.templatesBasePath, ['!*.html'], function (err, filePaths) {
         if (err) {
+            console.log('failed'.red + ' -- Manifest Generation');
             return callback(err);
         }
 

--- a/lib/theme-config.js
+++ b/lib/theme-config.js
@@ -355,12 +355,12 @@ ThemeConfig.prototype.getSchema = function (callback) {
 function fetchThemeSettings(path, callback) {
     var themeSettingsRegexPattern = /\Wtheme_settings\.(.+?)\W/g;
     var themeSettings = {};
-
     Fs.readFile(path, 'utf8', function (err, content) {
         var match;
 
         if (err) {
-            return callback(err);
+            // just skip the file if we can't read it
+            return callback(null, themeSettings);
         }
 
         while (match = themeSettingsRegexPattern.exec(content)) {


### PR DESCRIPTION
If run from the theme root, the `stencil bundle` command scans the entirety of the project directory (including everything in node_modules) when looking for HTML files with embedded theme settings.

Is this the desired behavior? In any case, this patch bandaids the problem by skipping (rather than crashing on) files with an html extension that can't be read. It fixes #252, which causes `stencil bundle` to fail, due to a transitive dependency ("inert") containing a directory named "index.html": `node_modules/hapi/node_modules/inert/test/directory/invalid/index.html/`

It also adds some error messages to the stencil bundle command indicating which bundling step failed. It hasn't been tested as the test suite for this module depends on private github repos.