### PR TITLE
MERC-1493 stencil bundle fails if there is a directory in the project…

### DIFF
--- a/lib/theme-config.js
+++ b/lib/theme-config.js
@@ -318,7 +318,7 @@ ThemeConfig.prototype.getSchema = function (callback) {
         themeSchema = [];
     }
 
-    Glob(Path.join(this.themePath, '**/*.html'), function (err, files) {
+    Glob(Path.join(this.themePath, 'templates/**/*.html'), function (err, files) {
         if (err) {
             return callback(err);
         }


### PR DESCRIPTION
… path with .html in the name

Addresses this issue: https://github.com/bigcommerce/stencil-cli/issues/252

@lord2800 