### PR TITLE
BIG-29681 stencil-paper version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^1.1.8",
+    "@bigcommerce/stencil-paper": "^1.1.9",
     "@bigcommerce/stencil-styles": "^1.0.2",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",


### PR DESCRIPTION
Fixes an issue with translation syntax errors

@lord2800 

depending on https://github.com/bigcommerce/paper/pull/105/files