### PR TITLE
CHECKOUT-1234: Bump stencil-paper to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^1.1.9",
+    "@bigcommerce/stencil-paper": "^1.2.0",
     "@bigcommerce/stencil-styles": "^1.0.2",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",


### PR DESCRIPTION
## What?
* Bump `stencil-paper` to 1.2.0

## Why?
* Please see the release note of [1.2.0](https://github.com/bigcommerce/paper/releases/tag/1.2.0)

## Testing / Proof
* Please refer to the PRs listed [here](https://github.com/bigcommerce/paper/releases/tag/1.2.0)

@bigcommerce/stencil-team @bigcommerce/checkout 
