### PR TITLE
CHECKOUT-1553 always display optimized checkout panel in stencil dev environment

### DIFF
--- a/server/plugins/stencil-editor/stencil-editor.html
+++ b/server/plugins/stencil-editor/stencil-editor.html
@@ -37,7 +37,8 @@
                 themeName: '{{ themeName }}',
                 variationName: '{{ variationName }}',
                 displayVersion: '{{ displayVersion }}'
-            }
+            },
+            seededUcoEnabled: true
         });
 
     System.import('src/app/app.module.js').then(function() {


### PR DESCRIPTION
## What
as per title ^

<img width="1440" alt="screen shot 2017-02-24 at 9 59 43 am" src="https://cloud.githubusercontent.com/assets/8165665/23283039/0798541a-fa78-11e6-9068-50f26f7f21a7.png">

https://jira.bigcommerce.com/browse/CHECKOUT-1553

## Why
to always display Optimized Checkout stencil editor panel while in stencil development environment so the user can see all options available in stencil editor

@bigcommerce/checkout @bigcommerce/stencil-team 