### PR TITLE
CHECKOUT-1234: Release v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
## What?
* Bump version to `1.5.0`

## Why?
To include the following changes (I think? Maybe a good idea to keep a changelog and push git tags for this project as well):
* STENCIL-3000 commit the changelog file #276
* STENCIL-3000 add new draft #277
* STENCIL-3070 - Expose config version #278
* CHECKOUT-1234: Bump stencil-paper to 1.2.0 #279

## Testing / Proof
* Please refer to the relevant PRs.

@bigcommerce/stencil-team @bigcommerce/checkout 
