### PR TITLE
STENCIL-2984 - Replace Basic Auth with OAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-node_modules
-jspm_packages
 .idea/
+jspm_packages
+node_modules
+npm-debug.log
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016, BigCommerce Inc.
+Copyright (c) 2015-2017, BigCommerce Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/bin/stencil-bundle.spec.js
+++ b/bin/stencil-bundle.spec.js
@@ -66,7 +66,7 @@ describe('Stencil Bundle', () => {
         AsyncStub.callsArgWith(2, null, ['this is dog']);
 
         const callback = (err, result) => {
-            expect(result).to.deep.equal({'theme.scss': 'this is dog'});
+            expect(result).to.equal({'theme.scss': 'this is dog'});
             AsyncStub.restore();
             done();
         };
@@ -124,7 +124,7 @@ describe('Stencil Bundle', () => {
 
     it('should assemble the Schema', done => {
         Bundle.assembleSchema((err, result) => {
-            expect(result).to.deep.equal(themeSchema);
+            expect(result).to.equal(themeSchema);
             done();
         });
     });

--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -106,11 +106,15 @@ if (dotStencilFile.staplerUrl) {
 Wreck.get(
     Url.resolve(staplerUrl, '/stencil-version-check?v=' + Pkg.version),
     {
-        headers: headers
+        headers: headers,
+        rejectUnauthorized: false,
     },
     function (err, res, payload) {
         var retError = err !== null,
-            bundleTask;
+            bundleTask,
+            options = {
+                sslUrl: payload.sslUrl
+            }
 
         try {
             payload = jsonLint.parse(payload);
@@ -132,34 +136,24 @@ Wreck.get(
                 '$ npm install -g @bigcommerce/stencil-cli'.cyan
             );
         } else {
-            stencilToken.getAuth({
-                username: dotStencilFile.username,
-                token: dotStencilFile.token,
-                host: payload.sslUrl
-            }, function (err, response) {
-                if (response.authorized) {
-                    dotStencilFile.storeUrl = payload.sslUrl;
-                    dotStencilFile.normalStoreUrl = payload.baseUrl;
-                    dotStencilFile.stencilServerPort = stencilServerPort;
+            dotStencilFile.storeUrl = payload.sslUrl;
+            dotStencilFile.normalStoreUrl = payload.baseUrl;
+            dotStencilFile.stencilServerPort = stencilServerPort;
 
-                    if (configuration.jspm && Program.test) {
-                        bundleTask = JspmAssembler.assemble(
-                            {
-                                bootstrap: configuration.jspm.bootstrap
-                            },
-                            themePath
-                        );
+            if (configuration.jspm && Program.test) {
+                bundleTask = JspmAssembler.assemble(
+                    {
+                        bootstrap: configuration.jspm.bootstrap
+                    },
+                    themePath
+                );
 
-                        bundleTask(function (result) {
-                            return startServer();
-                        });
-                    } else {
-                        return startServer();
-                    }
-                } else {
-                    return console.error('Unauthorized, please use a valid username/token'.red);
-                }
-            })
+                bundleTask(function (result) {
+                    return startServer();
+                });
+            } else {
+                return startServer();
+            }
         }
     }
 );

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -101,12 +101,15 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
         },
         {
             type: 'input',
-            name: 'username',
-            message: 'What is your Stencil Username?',
-            default: dotStencilFile && dotStencilFile.username,
+            name: 'clientId',
+            message: 'What is your Stencil OAuth Client ID? (See https://stencil.bigcommerce.com/docs/creating-an-api-account-oauth)',
+            default: dotStencilFile && dotStencilFile.clientId,
+            filter: function(val) {
+                return val.trim();
+            },
             validate: function(val) {
-                if (!val) {
-                    return 'You must enter a username';
+                if (!val.trim()) {
+                    return 'You must enter a Client ID';
                 }
 
                 return true;
@@ -114,12 +117,15 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
         },
         {
             type: 'input',
-            name: 'token',
-            message: 'What is your Stencil Token?',
-            default: dotStencilFile && dotStencilFile.token,
+            name: 'accessToken',
+            message: 'What is your Stencil OAuth Access Token?',
+            default: dotStencilFile && dotStencilFile.accessToken,
+            filter: function(val) {
+                return val.trim();
+            },
             validate: function(val) {
-                if (!val) {
-                    return 'Please enter a valid token';
+                if (!val.trim()) {
+                    return 'You must enter an Access Token';
                 }
 
                 return true;

--- a/lib/theme-config.spec.js
+++ b/lib/theme-config.spec.js
@@ -68,9 +68,9 @@ describe('ThemeConfig', () => {
                     thumb: { width: 10, height: 10 },
                 };
 
-            expect(config.settings).to.deep.equal(settingsToCompare);
-            expect(config.images).to.deep.equal(imagesToCompare);
-            expect(ThemeConfig.getInstance().globalSettings).to.deep.equal(originalSettingsToCompare);
+            expect(config.settings).to.equal(settingsToCompare);
+            expect(config.images).to.equal(imagesToCompare);
+            expect(ThemeConfig.getInstance().globalSettings).to.equal(originalSettingsToCompare);
 
             done();
         });
@@ -118,11 +118,11 @@ describe('ThemeConfig', () => {
             var themeConfig = ThemeConfig.getInstance(bareBonesThemePath),
                 config = themeConfig.getConfig();
 
-            expect(config.settings).to.deep.equal({});
-            expect(config.images).to.deep.equal({});
+            expect(config.settings).to.equal({});
+            expect(config.images).to.equal({});
             expect(config.css_compiler).to.equal('scss');
             expect(config.autoprefixer_cascade).to.equal(true);
-            expect(config.autoprefixer_browsers).to.deep.equal(['> 1%', 'last 2 versions', 'Firefox ESR']);
+            expect(config.autoprefixer_browsers).to.equal(['> 1%', 'last 2 versions', 'Firefox ESR']);
 
             done();
         });
@@ -150,12 +150,12 @@ describe('ThemeConfig', () => {
         });
 
         it('should update the currentConfig with the new changes', done => {
-            expect(originalSettings).not.to.deep.equal(newSettings);
+            expect(originalSettings).not.to.equal(newSettings);
 
             themeConfig.updateConfig(newSettings);
 
-            expect(themeConfig.getConfig().settings).not.to.deep.equal(originalSettings);
-            expect(themeConfig.getConfig().settings).to.deep.equal(newSettings);
+            expect(themeConfig.getConfig().settings).not.to.equal(originalSettings);
+            expect(themeConfig.getConfig().settings).to.equal(newSettings);
 
             done();
         });
@@ -189,12 +189,12 @@ describe('ThemeConfig', () => {
             function testSave(path, newConfig) {
                 newConfig = JSON.parse(newConfig);
 
-                expect(newConfig).not.to.deep.equal(initialConfig);
+                expect(newConfig).not.to.equal(initialConfig);
 
                 delete newConfig.variations;
                 delete initialConfig.variations;
 
-                expect(newConfig).to.deep.equal(initialConfig);
+                expect(newConfig).to.equal(initialConfig);
 
                 done();
             }
@@ -218,12 +218,12 @@ describe('ThemeConfig', () => {
 
                 expect(schema).to.be.an.array();
 
-                expect(schema[0]).to.deep.equal(originalSchema[0]);
+                expect(schema[0]).to.equal(originalSchema[0]);
                 expect(schema).to.have.length(2);
 
-                expect(schema[1].settings[0].force_reload).to.deep.true();
-                expect(schema[1].settings[1].force_reload).to.deep.true();
-                expect(schema[1].settings[2].force_reload).to.deep.true();
+                expect(schema[1].settings[0].force_reload).to.true();
+                expect(schema[1].settings[1].force_reload).to.true();
+                expect(schema[1].settings[2].force_reload).to.true();
 
                 done();
             });

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "boom": "^2.7.0",
     "browser-sync": "git://github.com/mcampa/browser-sync.git#tunnelBug",
     "cheerio": "^0.19.0",
-    "code": "^1.4.0",
+    "code": "^4.0.0",
     "colors": "^1.0.3",
     "commander": "^2.7.1",
     "confidence": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,8 @@ module.exports = function(options, callback) {
     config.plugins['./plugins/renderer/renderer.module'].useCache = options.useCache;
     config.plugins['./plugins/renderer/renderer.module'].username = options.dotStencilFile.username;
     config.plugins['./plugins/renderer/renderer.module'].token = options.dotStencilFile.token;
+    config.plugins['./plugins/renderer/renderer.module'].clientId = options.dotStencilFile.clientId;
+    config.plugins['./plugins/renderer/renderer.module'].accessToken = options.dotStencilFile.accessToken;
     config.plugins['./plugins/renderer/renderer.module'].customLayouts = options.dotStencilFile.customLayouts;
     config.plugins['./plugins/renderer/renderer.module'].stencilEditorPort = options.stencilEditorPort;
 

--- a/server/lib/stencil-token.js
+++ b/server/lib/stencil-token.js
@@ -1,5 +1,3 @@
-var wreck = require('wreck');
-
 module.exports = {
     /**
      * Simple function to create the needed base64 token for Stencil Authorization
@@ -12,48 +10,5 @@ module.exports = {
         }
 
         return new Buffer(username + ':' + token).toString('base64');
-    },
-
-    /**
-     * Request Authorization from the V2 Api
-     * @param {object} options
-     * @param {function} callback
-     */
-    getAuth: function (options, callback) {
-        if (typeof callback !== 'function') {
-            throw new Error('Callback must be a function');
-        }
-
-        options = options || {};
-
-        var self = this;
-        var apiUrl = options.host + '/api/v2/time';
-
-        try {
-            var httpsOpts = {
-                rejectUnauthorized: false,
-                headers: {
-                    'Authorization': 'Basic ' + self.generate(options.username, options.token),
-
-                },
-            };
-
-        } catch (e) {
-            return console.error(
-                e.message.red +
-                ' Please re-run stencil init to enter a valid username and token'.cyan
-            );
-        }
-        wreck.request('get', apiUrl, httpsOpts, function (err, authRepsonse) {
-            if (err) {
-                return callback(err);
-            }
-
-            if (authRepsonse.statusCode !== 401) {
-                return callback(null, {authorized: true, statusCode: authRepsonse.statusCode})
-            } else {
-                return callback(null, {authorized: false,  statusCode: authRepsonse.statusCode})
-            }
-        })
     },
 };

--- a/server/lib/stencil-token.spec.js
+++ b/server/lib/stencil-token.spec.js
@@ -2,8 +2,6 @@ var Code = require('code'),
     Lab = require('lab'),
     lab = exports.lab = Lab.script(),
     describe = lab.describe,
-    Wreck = require('wreck'),
-    sinon = require('sinon'),
     stencilToken = require('./stencil-token'),
     expect = Code.expect,
     it = lab.it;
@@ -14,7 +12,6 @@ describe('stencilToken', function () {
         token: '12345689DEADBEEF',
         validToken: 'dGVzdFVzZXI6MTIzNDU2ODlERUFEQkVFRg==',
     };
-
 
     it('should return a base64 encoded string', function (done) {
         expect(stencilToken.generate(options.username, options.token)).to.be.equal(options.validToken);
@@ -30,68 +27,4 @@ describe('stencilToken', function () {
 
         done();
     });
-
-    it('should return a successful Auth', function (done) {
-        var wreckStub = sinon.stub(Wreck, 'request');
-
-        wreckStub.callsArgWith(3, null, {
-            statusCode: 200,
-        });
-
-        stencilToken.getAuth({
-            username: options.username,
-            token: options.token,
-        }, function (err, response) {
-            console.log(response);
-            expect(response.authorized).to.equal(true);
-            wreckStub.restore();
-
-            done();
-        });
-    });
-
-    it('should return an unsuccessful Auth', function (done) {
-        var wreckStub = sinon.stub(Wreck, 'request');
-
-        wreckStub.callsArgWith(3, null, {
-            statusCode: 401,
-        });
-
-        stencilToken.getAuth({
-            username: options.username,
-            token: options.token,
-        }, function (err, response) {
-            expect(response.authorized).to.equal(false);
-            wreckStub.restore();
-
-            done();
-        });
-    });
-
-    it('should throw return an error', function (done) {
-        var wreckStub = sinon.stub(Wreck, 'request');
-
-        wreckStub.callsArgWith(3, new Error('Error'), null);
-
-        stencilToken.getAuth({
-            username: options.username,
-            token: options.token,
-        }, function (err, response) {
-            expect(err).to.not.be.undefined();
-            expect(response).to.be.undefined();
-            wreckStub.restore();
-
-            done();
-        });
-    });
-
-    it('should require a function as a callback', function (done) {
-        var throws = function () {
-            stencilToken.getAuth({});
-        };
-
-        expect(throws).throw(Error);
-
-        done();
-    })
 });

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -437,8 +437,14 @@ internals.getHeaders = function (request, options, config) {
         'stencil-version': Pkg.config.stencil_version,
         'stencil-options': JSON.stringify(Hoek.applyToDefaults(options, currentOptions)),
         'accept-encoding': 'identity',
-        'Authorization': 'Basic ' + stencilToken.generate(internals.options.username, internals.options.token),
     };
+
+    if (internals.options.clientId && internals.options.accessToken) {
+        headers['X-Auth-Client'] = internals.options.clientId;
+        headers['X-Auth-Token'] = internals.options.accessToken;
+    } else {
+        headers['Authorization'] = 'Basic ' + stencilToken.generate(internals.options.username, internals.options.token);
+    }
 
     // Development
     if (request.app.staplerUrl) {


### PR DESCRIPTION
### WHAT
* Updates CLI's `init` method to require Client Id and Access Token instead of username and token (but still allows `stencil start` to run if the OAuth credentials aren't present)

## LINKS
* [STENCIL-2984](https://jira.bigcommerce.com/browse/STENCIL-2984)

@bigcommerce/stencil-team 