### PR TITLE
Change features schema to array of any non-empty strings

### DIFF
--- a/lib/privateThemeConfig.schema.json
+++ b/lib/privateThemeConfig.schema.json
@@ -34,7 +34,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["fully_responsive", "mega_navigation", "multi_tiered_sidebar_menu", "masonry_design", "frontpage_slideshow", "quick_add_to_cart", "switchable_product_view", "product_comparison_table", "complex_search_filtering", "customizable_product_selector", "cart_suggested_products", "free_customer_support", "free_theme_upgrades", "high_res_product_images", "product_filtering", "advanced_quick_view", "product_showcase", "persistent_cart", "one_page_check_out", "customized_checkout", "product_videos", "google_amp"]
+            "minLength": 1
           },
           "uniqueItems": true,
           "minItems": 0


### PR DESCRIPTION
We want merchants to be able to view custom features in the detail page for a private theme, if, say, they purchase a private theme from a third-party marketplace that has a non-standard feature listed in the theme metadata there.

We still want marketplace theme features to be validated against a whitelist.

Part of https://jira.bigcommerce.com/browse/STENCIL-3282.

Edited, third time's the charm.