### PR TITLE
STENCIL-3317 - Update autoprefixer_browsers default to match the serv…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can compile Sass (node-sass) scss files in assets/scss into CSS. For example
 Stencil CLI comes packaged with [Autoprefixer](https://github.com/postcss/autoprefixer). You can set which browsers should be targeted, as well as if it should cascade the generated rules in the theme's config.json file with these options:
 
 - `autoprefixer_cascade` - Defaults to `true`.
-- `autoprefixer_browsers` - Defaults to `["> 5% in US"]`.
+- `autoprefixer_browsers` - Defaults to `["> 1%", "last 2 versions", "Firefox ESR"]`.
 
 ## How to get help or report a bug
 
@@ -63,7 +63,7 @@ If you need any help or experience any bugs, please create a GitHub issue in thi
 
 ## License
 
-Copyright (c) 2015-2016, BigCommerce Inc.
+Copyright (c) 2015-2017, BigCommerce Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/theme-config.js
+++ b/lib/theme-config.js
@@ -66,7 +66,7 @@ ThemeConfig.prototype.getConfig = function () {
     // Set some defaults
     config.css_compiler = config.css_compiler || 'scss';
     config.autoprefixer_cascade = config.autoprefixer_cascade || true;
-    config.autoprefixer_browsers = config.autoprefixer_browsers || ['> 5% in US'];
+    config.autoprefixer_browsers = config.autoprefixer_browsers || ['> 1%', 'last 2 versions', 'Firefox ESR'];
 
     // Merge in the variation settings and images objects
     config.settings = Hoek.applyToDefaults(config.settings || {}, this.currentVariationSettings);

--- a/lib/theme-config.spec.js
+++ b/lib/theme-config.spec.js
@@ -120,7 +120,7 @@ describe('ThemeConfig', function() {
             expect(config.images).to.deep.equal({});
             expect(config.css_compiler).to.equal('scss');
             expect(config.autoprefixer_cascade).to.equal(true);
-            expect(config.autoprefixer_browsers).to.deep.equal(['> 5% in US']);
+            expect(config.autoprefixer_browsers).to.deep.equal(['> 1%', 'last 2 versions', 'Firefox ESR']);
 
             done();
         });


### PR DESCRIPTION
…er side default

While the default of `["> 5% in US"]` was used in stencil-cli for local development, this was not being honored server side where a default of `["> 1%", "last 2 versions", "Firefox ESR"]` was being implicitly used instead.

cc @bigcommerce/stencil-team 