### PR TITLE
Add support for Node 6 & 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
 
+os:
+  - linux
+  - osx
+
 node_js:
-- 4.4.7
+  - 4
+  - 6
+  - 7
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+environment:
+  matrix:
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "4"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install --production
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off

--- a/lib/theme-config.spec.js
+++ b/lib/theme-config.spec.js
@@ -1,40 +1,42 @@
-var Code = require('code'),
-    Fs = require('fs'),
-    Hoek = require('hoek'),
-    Lab = require('lab'),
-    Path = require('path'),
-    Sinon = require('sinon'),
-    ThemeConfig = require('./theme-config'),
-    lab = exports.lab = Lab.script(),
-    themePath = Path.join(process.cwd(), 'test/_mocks/themes/valid'),
-    missingVariationsThemePath = Path.join(process.cwd(), 'test/_mocks/themes/missing-variation'),
-    bareBonesThemePath = Path.join(process.cwd(), 'test/_mocks/themes/bare-bones'),
-    describe = lab.describe,
-    expect = Code.expect,
-    it = lab.it,
-    themeConfig;
+'use strict';
 
-describe('ThemeConfig', function() {
-    lab.beforeEach(function(done) {
+const Code = require('code');
+const Os = require('os');
+const Fs = require('fs');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Path = require('path');
+const Sinon = require('sinon');
+const ThemeConfig = require('./theme-config');
+const lab = exports.lab = Lab.script();
+const themePath = Path.join(process.cwd(), 'test/_mocks/themes/valid');
+const missingVariationsThemePath = Path.join(process.cwd(), 'test/_mocks/themes/missing-variation');
+const bareBonesThemePath = Path.join(process.cwd(), 'test/_mocks/themes/bare-bones');
+const describe = lab.describe;
+const expect = Code.expect;
+const it = lab.it;
+
+describe('ThemeConfig', () => {
+    let themeConfig;
+
+    lab.beforeEach(done => {
         themeConfig = ThemeConfig.getInstance(themePath).setVariationByName('First');
 
         done();
     });
 
-    describe('getInstance()', function() {
-        it ('should always return the same instance', function(done) {
+    describe('getInstance()', () => {
+        it ('should always return the same instance', done => {
             expect(themeConfig).to.equal(ThemeConfig.getInstance());
 
             done();
         });
 
-        it ('should allow overwriting of configPath, schemaPath, and variationName by calling getInstance with params', function(done) {
-            var secondConfigPath = '/fake/config.json';
-            var secondSchemaPath = '/fake/schema.json';
-            var secondVariationName = 'Second';
-            var secondThemeConfig;
-
-            secondThemeConfig = ThemeConfig.getInstance('/fake');
+        it ('should allow overwriting of configPath, schemaPath, and variationName by calling getInstance with params', done => {
+            const isWindows = Os.platform() === 'win32';
+            const secondConfigPath = isWindows ? '\\fake\\config.json' : '/fake/config.json';
+            const secondSchemaPath = isWindows ? '\\fake\\schema.json' : '/fake/schema.json';
+            const secondThemeConfig = ThemeConfig.getInstance('/fake');
 
             expect(secondThemeConfig.configPath).to.equal(secondConfigPath);
             expect(secondThemeConfig.schemaPath).to.equal(secondSchemaPath);
@@ -44,8 +46,8 @@ describe('ThemeConfig', function() {
         });
     });
 
-    describe('getConfig()', function() {
-        it('should return the correct config for the current variation', function(done) {
+    describe('getConfig()', () => {
+        it('should return the correct config for the current variation', done => {
             var config = ThemeConfig.getInstance().setVariationByName('Second').getConfig(),
                 originalSettingsToCompare = {
                     color: '#ffffff',
@@ -73,7 +75,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should throw an Error if there are no variations in config.json file', function(done) {
+        it('should throw an Error if there are no variations in config.json file', done => {
             var themeConfig = ThemeConfig.getInstance(missingVariationsThemePath);
 
             expect(themeConfig.getConfig).to.throw(Error);
@@ -81,7 +83,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should grab the first variation if none is passed in', function(done) {
+        it('should grab the first variation if none is passed in', done => {
             var themeConfig = ThemeConfig.getInstance();
 
             themeConfig.setVariationByName(null);
@@ -91,7 +93,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should grab a specific variation if passed in', function(done) {
+        it('should grab a specific variation if passed in', done => {
             var themeConfig = ThemeConfig.getInstance();
 
             themeConfig.setVariationByName('Second');
@@ -100,7 +102,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should throw an Error if the passed in variation name does not match any in the config.json', function(done) {
+        it('should throw an Error if the passed in variation name does not match any in the config.json', done => {
             var themeConfig = ThemeConfig.getInstance(themePath);
 
             function setVariation() {
@@ -112,7 +114,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should set proper default values if they do not exist', function(done) {
+        it('should set proper default values if they do not exist', done => {
             var themeConfig = ThemeConfig.getInstance(bareBonesThemePath),
                 config = themeConfig.getConfig();
 
@@ -126,13 +128,13 @@ describe('ThemeConfig', function() {
         });
     });
 
-    describe('updateConfig()', function() {
+    describe('updateConfig()', () => {
         var config,
             newSettings,
             originalSettings,
             themeConfig;
 
-        lab.beforeEach(function(done) {
+        lab.beforeEach(done => {
             themeConfig = ThemeConfig.getInstance();
             config = themeConfig.getConfig();
             originalSettings = Hoek.clone(config.settings);
@@ -147,7 +149,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should update the currentConfig with the new changes', function(done) {
+        it('should update the currentConfig with the new changes', done => {
             expect(originalSettings).not.to.deep.equal(newSettings);
 
             themeConfig.updateConfig(newSettings);
@@ -158,7 +160,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should not write to config file if saveToFile is falsey', function(done) {
+        it('should not write to config file if saveToFile is falsey', done => {
             Sinon.stub(Fs, 'writeFileSync');
 
             themeConfig.updateConfig(newSettings);
@@ -168,7 +170,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should write to config file if saveToFile is truthy', function(done) {
+        it('should write to config file if saveToFile is truthy', done => {
             Sinon.stub(Fs, 'writeFileSync');
 
             themeConfig.updateConfig(newSettings, true);
@@ -178,7 +180,7 @@ describe('ThemeConfig', function() {
             done();
         });
 
-        it('should just modify the variations section of the file', function(done) {
+        it('should just modify the variations section of the file', done => {
             var configPath = Path.join(themePath, 'config.json');
             var initialConfig = JSON.parse(Fs.readFileSync(configPath, {encoding: 'utf-8'}));
 
@@ -203,14 +205,14 @@ describe('ThemeConfig', function() {
         });
     });
 
-    describe('getSchema()', function() {
+    describe('getSchema()', () => {
 
-        it('should return the correct schema', function(done) {
+        it('should return the correct schema', done => {
 
             var themeConfig = ThemeConfig.getInstance();
             var originalSchema = require(Path.join(themePath, 'schema.json'));
 
-            themeConfig.getSchema(function(err, schema) {
+            themeConfig.getSchema((err, schema) => {
 
                 expect(err).to.be.null();
 
@@ -227,11 +229,11 @@ describe('ThemeConfig', function() {
             });
         });
 
-        it('should return an empty schema', function(done) {
+        it('should return an empty schema', done => {
 
             var themeConfig = ThemeConfig.getInstance(bareBonesThemePath);
 
-            themeConfig.getSchema(function(err, schema) {
+            themeConfig.getSchema((err, schema) => {
                 expect(schema).to.be.an.array();
                 expect(schema).to.have.length(0);
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
     "@bigcommerce/stencil-paper": "^2.0.2",
-    "@bigcommerce/stencil-styles": "^1.0.2",
+    "@bigcommerce/stencil-styles": "git://github.com/mcampa/stencil-styles#ARCH-221-node-sass-fork",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",
     "async": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
     "@bigcommerce/stencil-paper": "^2.0.2",
-    "@bigcommerce/stencil-styles": "git://github.com/mcampa/stencil-styles#ARCH-221-node-sass-fork",
+    "@bigcommerce/stencil-styles": "1.0.6",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",
     "async": "^1.3.0",


### PR DESCRIPTION
This uses the new `@bigcommerce/stencil-styles#1.0.6` which uses a [fork](https://github.com/bigcommerce-labs/node-sass) of `node-sass` compatible with node 6 & 7

Plus, adding AppVeyor for windows tests

@bigcommerce/stencil-team 