### PR TITLE
STENCIL-3429 Fix tunnel issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
@@ -36,7 +36,7 @@
     "async": "^1.3.0",
     "babel-eslint": "^7.1.1",
     "boom": "^2.7.0",
-    "browser-sync": "^2.6.4",
+    "browser-sync": "git://github.com/mcampa/browser-sync.git#tunnelBug",
     "cheerio": "^0.19.0",
     "code": "^1.4.0",
     "colors": "^1.0.3",


### PR DESCRIPTION
This uses a fork to fix a `browser-sync` bug
I filled a PR on `browser-sync` https://github.com/BrowserSync/browser-sync/pull/1370
As a temporary solution we can merge this while we wait for `browser-sync` to merge and deploy the fix.

https://jira.bigcommerce.com/browse/STENCIL-3429

@bigcommerce/stencil-team 