### PR TITLE
feat(themeEditor): connect stencil editor redirection to stencil editor

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -26,6 +26,7 @@ module.exports = function(options, callback) {
     config.plugins['./plugins/renderer/renderer.module'].username = options.dotStencilFile.username;
     config.plugins['./plugins/renderer/renderer.module'].token = options.dotStencilFile.token;
     config.plugins['./plugins/renderer/renderer.module'].customLayouts = options.dotStencilFile.customLayouts;
+    config.plugins['./plugins/renderer/renderer.module'].stencilEditorPort = options.stencilEditorPort;
 
     Glue.compose(config, {relativeTo: __dirname}, function (err, server) {
         if (err) {

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -391,6 +391,7 @@ internals.getPencilResponse = function (data, request, response, configuration) 
     data.context.settings['theme_version_id'] = 'theme';
     data.context.settings['theme_config_id'] = request.app.themeConfig.variationIndex + 1;
     data.context.settings['theme_session_id'] = null;
+    data.context.settings['maintenance'] = {secure_path: `http://localhost:${internals.options.stencilEditorPort}`};
 
     return new Responses.PencilResponse({
         template_file: internals.getTemplatePath(request.path, data),

--- a/server/plugins/stencil-editor/stencil-editor.module.js
+++ b/server/plugins/stencil-editor/stencil-editor.module.js
@@ -3,6 +3,7 @@ const Hoek = require('hoek');
 const Path = require('path');
 const ThemeConfig = require('../../../lib/theme-config');
 const handlers = {};
+const querystring = require('querystring');
 const internals = {
     options: {},
 };
@@ -40,6 +41,15 @@ module.exports.register = (server, options, next) => {
             path: '/',
             config: routesConfig,
             handler: (request, reply) => reply.redirect(`/theme-editor/theme/${variationId}/${configurationId}`),
+        },
+        {
+            method: 'GET',
+            path: '/manage/theme-editor',
+            config: routesConfig,
+            handler: (request, reply) => {
+                const params = querystring.stringify(request.query);
+                reply.redirect(`/theme-editor/theme/${variationId}/${configurationId}?${params}`)
+            },
         },
         {
             method: 'GET',


### PR DESCRIPTION
### What
Locally, connect the new Storefront Admin bar `CRO-97` redirection to stencil editor

### Why
So can test the redirection from localhost:3000 (storefront) to localhost:8181 (stencil editor)

<img width="1375" alt="screen shot 2017-04-21 at 1 57 29 pm" src="https://cloud.githubusercontent.com/assets/9175276/25296459/3e61ffe0-269d-11e7-8580-6db20fd760be.png">

@mcampa @bigcommerce/cp-dt 