### PR TITLE
Remove eslint-config-airbnb dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "dateformat": "^2.0.0",
     "decompress-zip": "^0.2.0",
     "eslint": "^2.2.0",
-    "eslint-config-airbnb": "^6.0.2",
     "front-matter": "^1.0.0",
     "github": "^8.1.0",
     "glob": "^5.0.14",


### PR DESCRIPTION
This dependency is not used and is showing a warning to users

see https://github.com/bigcommerce/stencil-cli/issues/306