### PR TITLE
Revert "Remove eslint-config-airbnb dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dateformat": "^2.0.0",
     "decompress-zip": "^0.2.0",
     "eslint": "^2.2.0",
+    "eslint-config-airbnb": "^6.0.2",
     "front-matter": "^1.0.0",
     "github": "^8.1.0",
     "glob": "^5.0.14",


### PR DESCRIPTION
Reverts bigcommerce/stencil-cli#307

We going to have to revert this since themes are requiring this dependency from `stencil-cli` because of the way we call `eslint` from the cli codebase.

@bigcommerce/stencil-team 