### PR TITLE
Allow empty values for clientId and accessToken fields

### DIFF
--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -107,13 +107,6 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             filter: function(val) {
                 return val.trim();
             },
-            validate: function(val) {
-                if (!val.trim()) {
-                    return 'You must enter a Client ID';
-                }
-
-                return true;
-            },
         },
         {
             type: 'input',
@@ -122,13 +115,6 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             default: dotStencilFile && dotStencilFile.accessToken,
             filter: function(val) {
                 return val.trim();
-            },
-            validate: function(val) {
-                if (!val.trim()) {
-                    return 'You must enter an Access Token';
-                }
-
-                return true;
             },
         },
     ];


### PR DESCRIPTION
## WHAT
* Allow empty values for clientId and accessToken fields

## WHY
* so that `stencil init` may be run without entering these fields, in case the manual entry of the Basic Auth credentials is to be done after `init`.