### PR TITLE
Fix for issue #318

### DIFF
--- a/bin/stencil-start
+++ b/bin/stencil-start
@@ -283,7 +283,7 @@ function assembleTemplates(templatePath, callback) {
             return file.replace(templatePath + Path.sep, '').replace('.html', '');
         });
 
-        Async.map(files, templateAssembler.assemble, function (err, results) {
+        Async.map(files, templateAssembler.assemble.bind(null, templatePath), function (err, results) {
             if (err) {
                 callback(err);
             }


### PR DESCRIPTION
## WHAT
* this is a fix for #318 

## WHY
* the `assemble` method now requires a `templatesFolder` parameter (https://github.com/bigcommerce/stencil-cli/commit/49bcdc6fd79ecf09b70c080a8ea0ae1359d05c57#diff-4d9ab04ab5e144dcef049c51ef7a71fcR21)

cc @bigcommerce/stencil-team @flyingL123