### PR TITLE
Add contributing file and github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+### Expected behavior
+
+
+### Actual behavior
+
+
+### Steps to reproduce behavior
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+#### What?
+
+A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.
+
+#### Tickets / Documentation
+
+Add links to any relevant tickets and documentation.
+
+- [Link 1](http://example.com)
+- ...
+
+#### Screenshots (if appropriate)
+
+Attach images or add image links here.
+
+![Example Image](http://placehold.it/300x200)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Stencil CLI
+
+Thanks for showing interest in contributing!
+
+The following is a set of guidelines for contributing to the Stencil CLI. These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+By contributing to Stencil CLI, you agree that your contributions will be licensed as listed under the [README.md](https://github.com/bigcommerce/stencil-cli/blob/master/README.md).
+
+#### Table of Contents
+
+[Stencil Documentation](https://stencil.bigcommerce.com/docs)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Pull Requests](#pull-requests)
+
+[Styleguides](#styleguides)
+  * [Git Commit Messages](#git-commit-messages)
+  * [JavaScript Styleguide](#javascript-styleguide)
+
+### Your First Code Contribution
+
+Unsure where to begin contributing to Stencil CLI? Check our [forums](https://forum.bigcommerce.com/s/group/0F91300000029tpCAA) or our [stackoverflow](https://stackoverflow.com/questions/tagged/bigcommerce) tag. 
+
+### Pull Requests
+
+* Fill in [the required template](https://github.com/bigcommerce/stencil-cli/pull/new/master)
+* Include screenshots and animated GIFs in your pull request whenever possible.
+* End files with a newline.
+
+## Styleguides
+
+### Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference pull requests and external links liberally
+
+### JavaScript Styleguide
+
+All JavaScript must adhere to [AirBnB Javascript Styleguide](https://github.com/airbnb/javascript).


### PR DESCRIPTION
### What?
See title

### Why?
To provide consistency in community opened issues and pull requests as well as provide contribution guidelines