### PR TITLE
STENCIL-3575 - Don't permit theme deletion of active theme

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -146,7 +146,7 @@ utils.promptUserToDeleteThemesIfNecessary = (options, callback) => {
 
     const questions = [{
         choices: options.themes.map(theme => ({
-            disabled: !theme.is_private,
+            disabled: theme.is_active || !theme.is_private,
             name: theme.name,
             value: theme.uuid,
         })),


### PR DESCRIPTION
#### What?

* disables active theme deletion attempts by preventing selection of active themes

#### Ticket

- [STENCIL-3574](https://jira.bigcommerce.com/browse/STENCIL-3574)

#### Screenshot (`#13` is the active theme)

![screen shot 2017-08-24 at 4 55 55 pm](https://user-images.githubusercontent.com/1357197/29693901-280de5bc-88ed-11e7-835d-965a1efeadd2.png)

cc @bigcommerce/stencil-team 
