### PR TITLE
fix: avoid EMFILE errors

### DIFF
--- a/lib/template-assembler.js
+++ b/lib/template-assembler.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const Async = require('async');
-const Fs = require('fs');
+const Fs = require('graceful-fs');
 const Path = require('path');
 const Upath = require('upath');
 const partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9\/]+)[^{]*?}}/g;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "glue": "^2.0.0",
     "good": "^5.1.2",
     "good-console": "^4.1.0",
+    "graceful-fs": "^4.1.11",
     "handlebars": "^3.0.3",
     "hapi": "^8.4.0",
     "hoek": "^2.12.0",


### PR DESCRIPTION
#### What?

`template-assembler.js` can cause `stencil build` to exceed the OS limit on open files.
With this change, we rely on [the `graceful-fs` module](https://github.com/isaacs/node-graceful-fs) to correctly handle `EMFILE` errors, by placing them in a queue and retrying when other files are closed.

#### Tickets / Documentation

- Issue #324 
- Issue #335 
- An [unanswered question on SO](https://stackoverflow.com/q/40273512/2014893)

#### Screenshots (if appropriate)

_n/a_