### PR TITLE
MRKT-359 Update Pixel Union Theme Features To Include Pixelpop

### DIFF
--- a/lib/themeConfig.schema.json
+++ b/lib/themeConfig.schema.json
@@ -34,7 +34,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["fully_responsive", "mega_navigation", "multi_tiered_sidebar_menu", "masonry_design", "frontpage_slideshow", "quick_add_to_cart", "switchable_product_view", "product_comparison_table", "complex_search_filtering", "customizable_product_selector", "cart_suggested_products", "free_customer_support", "free_theme_upgrades", "high_res_product_images", "product_filtering", "advanced_quick_view", "product_showcase", "persistent_cart", "one_page_check_out", "customized_checkout", "product_videos", "google_amp"]
+            "enum": ["fully_responsive", "mega_navigation", "multi_tiered_sidebar_menu", "masonry_design", "frontpage_slideshow", "quick_add_to_cart", "switchable_product_view", "product_comparison_table", "complex_search_filtering", "customizable_product_selector", "cart_suggested_products", "free_customer_support", "free_theme_upgrades", "high_res_product_images", "product_filtering", "advanced_quick_view", "product_showcase", "persistent_cart", "one_page_check_out", "customized_checkout", "product_videos", "google_amp", "pixel_pop"]
           },
           "uniqueItems": true,
           "minItems": 1


### PR DESCRIPTION
#### What?
Add Pixelpop to features available to a theme.

#### How To Test
Check if it processes the theme when the key is preset.

#### Tickets / Documentation
- [MRKT-359](https://jira.bigcommerce.com/browse/MRKT-359)
- Theme Registry PR: https://github.com/bigcommerce/theme-registry/pull/804

@bigcommerce/stencil-team 