### PR TITLE
adding regex replace to remove .scss extension

### DIFF
--- a/lib/css-assembler.js
+++ b/lib/css-assembler.js
@@ -44,7 +44,7 @@ function assemble(cssFiles, absolutePath, type, options, callback) {
     });
 
     function parseImports(cssFileAlias, callback) {
-        cssFileAlias = cssFileAlias.replace(/(\.scss)/g, '');
+        cssFileAlias = cssFileAlias.replace(/(\.scss)$/g, '');
         var file = Path.join(absolutePath, cssFileAlias + ext),
             cssFileAliasDir = Path.parse(cssFileAlias).dir;
 

--- a/lib/css-assembler.js
+++ b/lib/css-assembler.js
@@ -44,6 +44,7 @@ function assemble(cssFiles, absolutePath, type, options, callback) {
     });
 
     function parseImports(cssFileAlias, callback) {
+        cssFileAlias = cssFileAlias.replace(/(\.scss)/g, '');
         var file = Path.join(absolutePath, cssFileAlias + ext),
             cssFileAliasDir = Path.parse(cssFileAlias).dir;
 


### PR DESCRIPTION
#### What?
Currently the css-assembler appends the .scss extension to the files its processing. This is fine in most cases since the default BigCommerce scss imports do not specify an extension. 

There are some frameworks/libraries that do specify the .scss extension such as UIkit(https://getuikit.com/docs/sass). 

If you attempt to import these scss files the cli will throw a file not found error. Removing the extension will resolve this but, you would need to do this for every import statement and every time the framework is updated. This creates extra friction when developing on stencil if you are integrating another framework.

#### Tickets / Documentation
Adding a simple replace regex to remove the .scss extension from an import before trying to find the file allows developers to use both.

#### Screenshots (if appropriate)
Before:
![screen shot 2018-01-09 at 12 56 02 pm](https://user-images.githubusercontent.com/15128906/34737773-b4583e3a-f53c-11e7-9fb9-9ae5a30b3d4b.png)

After:
![screen shot 2018-01-09 at 12 57 28 pm](https://user-images.githubusercontent.com/15128906/34737779-b7ac5602-f53c-11e7-960f-bc0730fea83b.png)

