### PR TITLE
STRF-4472 - Allow forward slash in store url

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -52,7 +52,7 @@ utils.readStencilConfigFile = (options, callback) => {
 utils.getStoreHash = (options, callback) => {
     options = validateOptions(options, ['config.normalStoreUrl']);
 
-    Wreck.get(`${options.config.normalStoreUrl}/admin/oauth/info`, { json: true, rejectUnauthorized: false }, (error, response, payload) => {
+    Wreck.get(`https://${options.config.normalStoreUrl.replace(/http(s?):\/\//, '').split('/')[0]}/admin/oauth/info`, { json: true, rejectUnauthorized: false }, (error, response, payload) => {
         if (error) {
             error.name = 'StoreHashReadError';
             return callback(error);


### PR DESCRIPTION
#### What?

* replaces a slash if present at the end of the store url so it's allowed and doesn't throw an error

#### Tickets / Documentation

- [STRF-4472](https://jira.bigcommerce.com/browse/STRF-4472)
- https://github.com/bigcommerce/stencil-cli/issues/360

#### Screenshots

* before
<img width="910" alt="screen shot 2018-02-20 at 4 08 25 pm" src="https://user-images.githubusercontent.com/1357197/36456140-4fb55584-1658-11e8-96ea-f9a95cbf0d64.png">

* after
<img width="936" alt="screen shot 2018-02-20 at 4 07 53 pm" src="https://user-images.githubusercontent.com/1357197/36456146-55d36064-1658-11e8-90e2-05eaa625b78e.png">

@bigcommerce/storefront-team 
