### PR TITLE
ability to locally save bundled theme after push

### DIFF
--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -9,12 +9,18 @@ var ThemeConfig = require('../lib/theme-config');
 var dotStencilFilePath = './.stencil';
 var versionCheck = require('../lib/version-check');
 
-Program
+var program = Program
     .version(pkg.version)
+    .option('-a, --auto [filename]', 'name of the credentials.txt file')
     .parse(process.argv);
 
 if (!versionCheck()) {
     return;
 }
 
-stencilInit(JspmAssembler, ThemeConfig, dotStencilFilePath);
+if (program.auto === true) {
+    console.log('Please specify a filename when using the auto command');
+    return;
+}
+
+stencilInit(JspmAssembler, ThemeConfig, dotStencilFilePath, program.auto);

--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -22,7 +22,8 @@ if (!versionCheck()) {
 
 stencilPush(Object.assign({}, options, {
     apiHost: Program.host || apiHost,
-    bundleZipPath: Program.file
+    bundleZipPath: Program.file,
+    saveBundleName: Program.save
 }), (err, result) => {
     if (err) {
         console.log('not ok'.red + ` -- ${err}`);

--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -13,6 +13,7 @@ Program
     .version(pkg.version)
     .option('--host [hostname]', 'specify the api host', apiHost)
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
+    .option('-s, --save [filename]', 'specify the filename to save the bundle as')
     .parse(process.argv);
 
 if (!versionCheck()) {

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -57,11 +57,39 @@ internals.parseAnswers = function(JspmAssembler, ThemeConfig, dotStencilFile, do
     });
 };
 
-internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePath) {
+internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePath, credentialsFilePath) {
     var dotStencilFile;
     var questions;
+    var credentialsConfig;
 
-    if (Fs.existsSync(dotStencilFilePath)) {
+    var resolvedCredentialsFilePath = credentialsFilePath;
+    if (credentialsFilePath) {
+        if (Path.extname(credentialsFilePath) !== '.txt') {
+            resolvedCredentialsFilePath += '.txt';
+        }
+        resolvedCredentialsFilePath = Path.join(process.cwd(), resolvedCredentialsFilePath);
+    }
+
+    credentialsConfig = {};
+    if (Fs.existsSync(resolvedCredentialsFilePath)) {
+        
+        var credentialsFile = Fs.readFileSync(resolvedCredentialsFilePath, {encoding: 'utf-8'});
+
+        function getValueFromKey(credentialKey) {
+            var keyRegex = new RegExp(`${credentialKey}\\:\\s+\\b\\w+\\b`, 'i');
+            var credentialMatch = credentialsFile.match(keyRegex);
+
+            if (credentialMatch) {
+                var lineData = credentialMatch[0].split(/\:\s+/);
+                var lineKey = lineData[0].replace(/\s+/g, '').toLowerCase();
+                credentialsConfig[lineKey] = lineData[1];
+            }
+        };
+
+        getValueFromKey('ACCESS TOKEN');
+        getValueFromKey('CLIENT ID');
+
+    } else if (Fs.existsSync(dotStencilFilePath)) {
         dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
         try {
             dotStencilFile = jsonLint.parse(dotStencilFile, dotStencilFilePath);
@@ -103,7 +131,7 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             type: 'input',
             name: 'clientId',
             message: 'What is your Stencil OAuth Client ID? (See https://stencil.bigcommerce.com/docs/creating-an-api-account)',
-            default: dotStencilFile && dotStencilFile.clientId,
+            default: credentialsConfig.clientid || (dotStencilFile && dotStencilFile.clientId),
             filter: function(val) {
                 return val.trim();
             },
@@ -112,7 +140,7 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             type: 'input',
             name: 'accessToken',
             message: 'What is your Stencil OAuth Access Token?',
-            default: dotStencilFile && dotStencilFile.accessToken,
+            default: credentialsConfig.clientid || (dotStencilFile && dotStencilFile.clientId),
             filter: function(val) {
                 return val.trim();
             },

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -89,15 +89,23 @@ utils.getThemes = (options, callback) => {
 
 utils.generateBundle = (options, callback) => {
     let bundle;
+    let output = {
+        dest: os.tmpdir(),
+        name: uuid(),
+    };
 
     if (options.bundleZipPath) {
         return async.nextTick(callback.bind(null, null, options));
     }
 
-    bundle = new Bundle(themePath, themeConfig, themeConfig.getRawConfig(), {
-        dest: os.tmpdir(),
-        name: uuid(),
-    });
+    if (options.saveBundleName) {
+        output = {
+            dest: themePath,
+            name: options.saveBundleName
+        };
+    }
+
+    bundle = new Bundle(themePath, themeConfig, themeConfig.getRawConfig(), output);
 
     bundle.initBundle((err, bundleZipPath) => {
         if (err) {


### PR DESCRIPTION
#### What?

When doing a normal stencil push (without specifying the filename of the bundle to upload), it first generates a bundle before pushing it to the store. The bundled file then gets thrown into a temp folder with no convenient way to retrieve it.

This commit adds a "save" option to save the bundled file into the current project folder. The current method is to do a stencil bundle first, then a stencil push with the name of the bundled file, but this skips those extra steps.

#### Screenshots

If no filename given, the bundle will have default filename:
![example-1](https://user-images.githubusercontent.com/13035560/38010100-8378999c-3225-11e8-94e4-1093b7e99ab5.png)

Filename of bundle if a filename is given
![example-2](https://user-images.githubusercontent.com/13035560/38010106-8bdb6d3a-3225-11e8-934a-be23c09296d8.png)

