### PR TITLE
Ability to locally save bundled theme after push (properly this time?)

### DIFF
--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -13,6 +13,7 @@ Program
     .version(pkg.version)
     .option('--host [hostname]', 'specify the api host', apiHost)
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
+    .option('-s, --save [filename]', 'specify the filename to save the bundle as')
     .parse(process.argv);
 
 if (!versionCheck()) {
@@ -21,7 +22,8 @@ if (!versionCheck()) {
 
 stencilPush(Object.assign({}, options, {
     apiHost: Program.host || apiHost,
-    bundleZipPath: Program.file
+    bundleZipPath: Program.file,
+    saveBundleName: Program.save
 }), (err, result) => {
     if (err) {
         console.log('not ok'.red + ` -- ${err}`);

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -89,15 +89,23 @@ utils.getThemes = (options, callback) => {
 
 utils.generateBundle = (options, callback) => {
     let bundle;
+    let output = {
+        dest: os.tmpdir(),
+        name: uuid(),
+    };
 
     if (options.bundleZipPath) {
         return async.nextTick(callback.bind(null, null, options));
     }
 
-    bundle = new Bundle(themePath, themeConfig, themeConfig.getRawConfig(), {
-        dest: os.tmpdir(),
-        name: uuid(),
-    });
+    if (options.saveBundleName) {
+        output = {
+            dest: themePath,
+            name: options.saveBundleName
+        };
+    }
+
+    bundle = new Bundle(themePath, themeConfig, themeConfig.getRawConfig(), output);
 
     bundle.initBundle((err, bundleZipPath) => {
         if (err) {


### PR DESCRIPTION
#### Closed previous pull request because I'm a git novice and mistakes were made. This pull request is now in its own branch and won't conflict with unintentional commits.

#### What?

When doing a normal stencil push (without specifying the filename of the bundle to upload), it first generates a bundle before pushing it to the store. The bundled file then gets thrown into a temp folder with no convenient way to retrieve it.

This commit adds a "save" option to save the bundled file into the current project folder. The current method is to do a stencil bundle first, then a stencil push with the name of the bundled file, but this skips those extra steps.

#### Screenshots

If no filename given, the bundle will have default filename:
![example-1](https://user-images.githubusercontent.com/13035560/38010100-8378999c-3225-11e8-94e4-1093b7e99ab5.png)

Filename of bundle if a filename is given
![example-2](https://user-images.githubusercontent.com/13035560/38010106-8bdb6d3a-3225-11e8-934a-be23c09296d8.png)