### PR TITLE
Adding -a and --activate flags to stencil push

### DIFF
--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -14,6 +14,7 @@ Program
     .option('--host [hostname]', 'specify the api host', apiHost)
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
     .option('-s, --save [filename]', 'specify the filename to save the bundle as')
+    .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
     .parse(process.argv);
 
 if (!versionCheck()) {
@@ -23,6 +24,7 @@ if (!versionCheck()) {
 stencilPush(Object.assign({}, options, {
     apiHost: Program.host || apiHost,
     bundleZipPath: Program.file,
+    activate: Program.activate,
     saveBundleName: Program.save
 }), (err, result) => {
     if (err) {

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -261,16 +261,20 @@ utils.checkIfJobIsComplete = (options, callback) => {
 };
 
 utils.promptUserWhetherToApplyTheme = (options, callback) => {
-    const questions = [{
-        type: 'confirm',
-        name: 'applyTheme',
-        message: `Would you like to apply your theme to your store at ${options.config.normalStoreUrl}?`,
-        default: false,
-    }];
+    if (options.activate) {
+        callback(null, Object.assign({}, options, { applyTheme: true }));
+    } else {
+        const questions = [{
+            type: 'confirm',
+            name: 'applyTheme',
+            message: `Would you like to apply your theme to your store at ${options.config.normalStoreUrl}?`,
+            default: false,
+        }];
 
-    Inquirer.prompt(questions, answers => {
-        callback(null, Object.assign({}, options, { applyTheme: answers.applyTheme }));
-    });
+        Inquirer.prompt(questions, answers => {
+            callback(null, Object.assign({}, options, { applyTheme: answers.applyTheme }));
+        });
+    };
 };
 
 utils.getVariations = (options, callback) => {
@@ -287,9 +291,15 @@ utils.getVariations = (options, callback) => {
     }, (error, result) => {
         if (error) {
             return callback(error);
-        }
-
-        callback(null, Object.assign({}, options, result));
+        };
+        if (options.activate !== true && options.activate !== undefined) {
+            const findVariation = result.variations.find(item => item.name === options.activate);
+            callback(null, Object.assign({}, options, { variationId: findVariation.uuid }));
+        } else if (options.activate === true) {
+            callback(null, Object.assign({}, options, { variationId: result.variations[0].uuid }));
+        } else {
+            callback(null, Object.assign({}, options, result));
+        };
     });
 };
 
@@ -298,16 +308,20 @@ utils.promptUserForVariation = (options, callback) => {
         return async.nextTick(callback.bind(null, null, options))
     }
 
-    const questions = [{
-        type: 'list',
-        name: 'variationId',
-        message: 'Which variation would you like to apply?',
-        choices: options.variations.map(variation => ({ name: variation.name, value: variation.uuid })),
-    }];
+    if (options.variationId) {
+        callback(null, options);
+    } else {
+        const questions = [{
+            type: 'list',
+            name: 'variationId',
+            message: 'Which variation would you like to apply?',
+            choices: options.variations.map(variation => ({ name: variation.name, value: variation.uuid })),
+        }];
 
-    Inquirer.prompt(questions, answers => {
-        callback(null, Object.assign({}, options, answers));
-    });
+        Inquirer.prompt(questions, answers => {
+            callback(null, Object.assign({}, options, answers));
+        });
+    };
 };
 
 utils.requestToApplyVariationWithRetrys = () => {


### PR DESCRIPTION
#### What?

Adding `--activate` and `-a` flags to the stencil push command. This will skip the prompts that normally come up asking if you would like to activate the theme and to specify a variation.

You can either specify the variation name after the flag or leave it blank to select the first variation (Light for Cornerstone).

This should resolve issue [364](https://github.com/bigcommerce/stencil-cli/issues/364)
#### Screenshots (if appropriate)

Example of not specifing bundle or theme variation:
![stencil_activate](https://user-images.githubusercontent.com/20911717/39605416-f6799210-4ef5-11e8-9bf3-5d4024d07015.gif)

Example with bundle zip and variation:
![screen shot 2018-05-03 at 5 18 46 pm](https://user-images.githubusercontent.com/20911717/39605465-394e3442-4ef6-11e8-88ed-7bbaa3422d35.png)
