### PR TITLE
Provide CDN URL to stencil-styles (compileCss)

### DIFF
--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -1,9 +1,15 @@
 const Boom = require('boom');
 const CssAssembler = require('../../../lib/css-assembler');
-const Utils = require('../../lib/utils');
+const Fs = require('fs');
 const Hoek = require('hoek');
+const jsonLint = require('../../../lib/json-lint');
 const Path = require('path');
+const Pkg = require('../../../package.json');
+const stencilToken = require('../../lib/stencil-token');
 const StencilStyles = require('@bigcommerce/stencil-styles');
+const Url = require('url');
+const Utils = require('../../lib/utils');
+const Wreck = require('wreck');
 const internals = {
     options: {},
 };
@@ -68,28 +74,59 @@ internals.cssHandler = function (request, reply) {
     const pathToFile = Path.join(fileParts.dir, fileParts.name + '.scss');
     const basePath = Path.join(internals.getThemeAssetsPath(), 'scss');
 
-    CssAssembler.assemble(pathToFile, basePath, 'scss', (err, files) => {
-        const configuration = request.app.themeConfig.getConfig();
+    // Setup request to obtain CDN URL
+    const staplerUrlObject = request.app.staplerUrl ? Url.parse(request.app.staplerUrl) : Url.parse(request.app.storeUrl);
 
-        var params = {
-            data: files[pathToFile],
-            files: files,
-            dest: Path.join('/assets/css', fileName),
-            themeSettings: configuration.settings,
-            sourceMap: true,
-            autoprefixerOptions: {
-                cascade: configuration.autoprefixer_cascade,
-                browsers: configuration.autoprefixer_browsers,
-            },
-        };
+    const httpOpts = {
+        rejectUnauthorized: false,
+        headers: internals.getHeaders(request, {
+            get_data_only: true,
+        }),
+        payload: null,
+    };
+    httpOpts.headers.host = staplerUrlObject.host;
+    httpOpts.headers.accept = 'text/html';
 
-        internals.stencilStyles.compileCss('scss', params, (err, css) => {
-            if (err) {
-                console.error(err);
-                return reply(Boom.badData(err));
-            }
+    const url = Url.format({
+        protocol: staplerUrlObject.protocol,
+        host: staplerUrlObject.host,
+        pathname: '/'
+    });
 
-            reply(css).type('text/css');
+    Wreck.get(url, httpOpts, function (err, response, data) {
+        var cdnUrl;
+
+        try {
+            data = JSON.parse(data);
+            cdnUrl = data.context.settings.cdn_url;
+        } catch (e) {
+            cdnUrl = '';
+        }
+
+        CssAssembler.assemble(pathToFile, basePath, 'scss', (err, files) => {
+            const configuration = request.app.themeConfig.getConfig();
+
+            var params = {
+                data: files[pathToFile],
+                files: files,
+                dest: Path.join('/assets/css', fileName),
+                themeSettings: configuration.settings,
+                cdnUrl: cdnUrl,
+                sourceMap: true,
+                autoprefixerOptions: {
+                    cascade: configuration.autoprefixer_cascade,
+                    browsers: configuration.autoprefixer_browsers,
+                },
+            };
+
+            internals.stencilStyles.compileCss('scss', params, (err, css) => {
+                if (err) {
+                    console.error(err);
+                    return reply(Boom.badData(err));
+                }
+
+                reply(css).type('text/css');
+            });
         });
     });
 };
@@ -106,7 +143,43 @@ internals.assetHandler = function (request, reply) {
     reply.file(filePath);
 };
 
-
 internals.getThemeAssetsPath = () => {
     return Path.join(internals.options.themePath, 'assets');
+};
+
+internals.getHeaders = function (request, options) {
+    var currentOptions = {},
+        headers,
+        dotStencilFile,
+        dotStencilFilePath;
+
+    options = options || {};
+
+    try {
+        dotStencilFilePath = Path.join(process.cwd(), '.stencil');
+        dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
+        dotStencilFile = jsonLint.parse(dotStencilFile, dotStencilFilePath);
+    } catch (e) {
+        dotStencilFile = {};
+    }
+
+    headers = {
+        'stencil-cli': Pkg.version,
+        'stencil-version': Pkg.config.stencil_version,
+        'stencil-options': JSON.stringify(Hoek.applyToDefaults(options, currentOptions)),
+        'accept-encoding': 'identity',
+    };
+
+    if (dotStencilFile.clientId && dotStencilFile.accessToken) {
+        headers['X-Auth-Client'] = dotStencilFile.clientId;
+        headers['X-Auth-Token'] = dotStencilFile.accessToken;
+    } else {
+        headers['Authorization'] = 'Basic ' + stencilToken.generate(dotStencilFile.username, dotStencilFile.token);
+    }
+
+    if (request.app.staplerUrl) {
+        headers['stencil-store-url'] = request.app.storeUrl;
+    }
+
+    return Hoek.applyToDefaults(request.headers, headers);
 };

--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -90,7 +90,7 @@ internals.cssHandler = function (request, reply) {
     const url = Url.format({
         protocol: staplerUrlObject.protocol,
         host: staplerUrlObject.host,
-        pathname: '/'
+        pathname: '/',
     });
 
     Wreck.get(url, httpOpts, function (err, response, data) {


### PR DESCRIPTION
#### What?

This PR is a "proof of concept" companion to https://github.com/bigcommerce/stencil-styles/issues/27

The proposed custom SASS function `stencilWebDAV` needs the base CDN URL, to be able to provide the WebDAV URL for assets.

Here, we are obtaining the CDN URL and passing it to the `compileCss` function defined at `stencil-styles`, so it can be used by `stencilWebDAV` custom SASS function. Just like already happens for the theme settings.

For local development using `stencil-cli`, this is not necessary, because an empty `cdnUrl` will result in a `/content` URL, exactly how the Handlebars `cdn` + `webdav` helper already does locally. The local server proxies the request, and the asset is returned in response.

This is why this PR is a "proof of concept". It is not necessary. But it fulfills the requirement of passing `cdnUrl` as an option to `compileCss`.

If it is easy to fulfill this requirement from client-side, it shall be even easier from server-side, where the CDN base URL must be readily available.

#### Tickets / Documentation

See  https://github.com/bigcommerce/stencil-styles/issues/27
