### PR TITLE
Bundle all webpack files + release 1.15.0

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -19,7 +19,7 @@ const PATHS_TO_ZIP = [
     '.scss-lint.yml',
     'stencil.conf.js',
     'templates/**/*',
-    'webpack.conf.js',
+    'webpack.*.js',
 ];
 
 const Upath = require('upath');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
#### What?
* Bundle all webpack config files. In Cornerstone 2.0, we split these up per environment, so we need to update the pattern used to select files for bundling.
* Bump version to 1.15.0 to prepare for release

#### Tickets / Documentation
- [Jira](https://jira.bigcommerce.com/browse/STRF-4971)
- [Cornerstone issue](https://github.com/bigcommerce/cornerstone/issues/1251)
