### PR TITLE
Add support for base_url and secure_base_url

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -392,6 +392,8 @@ internals.getPencilResponse = function (data, request, response, configuration) 
     data.context.settings.theme_config_id = Utils.int2uuid(request.app.themeConfig.variationIndex + 1);
     data.context.settings.theme_session_id = null;
     data.context.settings.maintenance = {secure_path: `http://localhost:${internals.options.stencilEditorPort}`};
+    data.context.settings.base_url = `http://${request.info.host}`;
+    data.context.settings.secure_base_url = `http://${request.info.host}`;
 
     return new Responses.PencilResponse({
         template_file: internals.getTemplatePath(request.path, data),

--- a/server/plugins/renderer/responses/pencil-response.js
+++ b/server/plugins/renderer/responses/pencil-response.js
@@ -76,14 +76,6 @@ internals.makeDecorator = function (request, context) {
         var regex,
             debugBar;
 
-        if (context.settings) {
-            regex = new RegExp(internals.escapeRegex(context.settings.base_url), 'g');
-            content = content.replace(regex, '');
-
-            regex = new RegExp(internals.escapeRegex(context.settings.secure_base_url), 'g');
-            content = content.replace(regex, '');
-        }
-
         if (request.query.debug === 'bar') {
             debugBar = '<pre style="background-color:#EEE; word-wrap:break-word;">';
             debugBar += internals.escapeHtml(JSON.stringify(context, null, 2)) + '</pre>';


### PR DESCRIPTION
base_url and secure_base_url are overwritten with empty strings in
pencil-response. this makes it impossible to use the values during local
theme development.

- add the current host value in renderer.module
- remove the empty values in pencil-response

#### What?

The base_url and secure_base_url were not available in [settings](https://stencil.bigcommerce.com/docs/settings-object) because they had been removed.

This re-adds them using the current stencil web-server host as a value.

#### Tickets / Documentation

- https://stencil.bigcommerce.com/docs/settings-object

#### Screenshots (if appropriate)

none