### PR TITLE
log push errors to the console

### DIFF
--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -8,6 +8,7 @@ const pkg = require('../package.json');
 const Program = require('commander');
 const stencilPush = require('../lib/stencil-push');
 const versionCheck = require('../lib/version-check');
+const themeApiClient = require('../lib/theme-api-client');
 
 Program
     .version(pkg.version)
@@ -28,8 +29,9 @@ stencilPush(Object.assign({}, options, {
     saveBundleName: Program.save
 }), (err, result) => {
     if (err) {
-        console.log('not ok'.red + ` -- ${err}`);
-        console.log('Please try again. If this error persists, please visit https://github.com/bigcommerce/stencil-cli/issues and submit an issue.');
+        console.log("\n\n" + 'not ok'.red + ` -- ${err} see details below:`);
+        themeApiClient.printErrorMessages(err.messages)
+        console.log('If this error persists, please visit https://github.com/bigcommerce/stencil-cli/issues and submit an issue.');
     } else {
         console.log('ok'.green + ` -- ${result}`);
     }

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -9,6 +9,7 @@ const themeApiClient = {
     activateThemeByVariationId,
     deleteThemeById,
     getJob,
+    printErrorMessages,
     getVariationsByThemeId,
     getThemes,
     postTheme,
@@ -76,6 +77,7 @@ function getJob(options, callback) {
         if (res.statusCode !== 200 || payload.data.status === 'FAILED') {
             error = new Error('Job Failed');
             error.name = "JobCompletionStatusCheckError";
+            error.messages = payload.data.errors
             return callback(error);
         }
 
@@ -89,6 +91,25 @@ function getJob(options, callback) {
             themeId: payload.data.result.theme_id,
         }));
     });
+}
+
+function printErrorMessages(errors_array) {
+    if (!Array.isArray(errors_array)) {
+        console.log("unknown error".red)
+        return false
+    }
+
+    for (var i = 0; i < errors_array.length; i++) { 
+        try{
+            console.log(errors_array[i].message.red + '\n'); 
+        }
+        catch(err) {
+            continue;
+        }
+    }
+
+    console.log('Please visit the troubleshooting page https://stencil.bigcommerce.com/docs/uploading-a-custom-theme');
+    return true  
 }
 
 function getThemes(options, callback) {

--- a/lib/theme-api-client.spec.js
+++ b/lib/theme-api-client.spec.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const expect = Code.expect;
+const themeApiClient = require('./theme-api-client');
+const it = lab.it;
+const sinon = require('sinon');
+
+describe('theme-api-client', () => {
+	describe('printErrorMessages()', () => { 
+		var consoleLogStub;
+
+		lab.before(done => {
+            consoleLogStub = sinon.stub(console, 'log');
+            done();
+    	});
+
+		lab.after((done) => {
+		    console.log.restore();
+		    done();
+		});  
+
+	    it('should log unknown error and return if input is not an array', done => {
+	        expect(themeApiClient.printErrorMessages("string")).to.be.equal(false);
+	        expect(consoleLogStub.calledOnce).to.be.equal(true);
+	        consoleLogStub.resetHistory();
+	        expect(themeApiClient.printErrorMessages({ "key": "value" })).to.be.equal(false);
+	        expect(consoleLogStub.calledOnce).to.be.equal(true);
+			consoleLogStub.resetHistory();
+			expect(themeApiClient.printErrorMessages(null)).to.be.equal(false);
+			expect(consoleLogStub.calledOnce).to.be.equal(true);
+	        done();
+	    });
+
+	    it('should log error message for each error in the array', done => {
+			consoleLogStub.resetHistory();
+			var arrayInput = [{ "message": "first_error" }, { "message": "2nd_error" }];
+			expect(themeApiClient.printErrorMessages(arrayInput)).to.be.equal(true);
+			expect(consoleLogStub.calledThrice).to.be.equal(true);
+			done();
+	    });
+
+	    it('should skip non object elements in the input array', done => {
+			consoleLogStub.resetHistory();
+			var arrayInput = [{ "message": "first_error" }, "string", { "message": "2nd_error" }];
+			expect(themeApiClient.printErrorMessages(arrayInput)).to.be.equal(true);
+			expect(consoleLogStub.calledThrice).to.be.equal(true);
+			done();
+	    });
+    });
+ });


### PR DESCRIPTION
#### What?
currently if stencil push fails there are no logs that describe the error.
The change is adding error details.

#### Tickets / Documentation

- [Troubleshooting Theme Uploads](https://stencil.bigcommerce.com/docs/uploading-a-custom-theme)

#### Screenshots (if appropriate)
##### Single error
<img width="869" alt="screen shot 2018-08-07 at 5 00 36 pm" src="https://user-images.githubusercontent.com/41761536/43809068-e7e9124c-9a64-11e8-9e9a-d9f45e4d8305.png">

##### Multiple error
<img width="1037" alt="screen shot 2018-08-07 at 5 03 47 pm" src="https://user-images.githubusercontent.com/41761536/43809077-002c31c2-9a65-11e8-916c-e105a3eb703d.png">
