### PR TITLE
Increase timeout for build worker process to be ready

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -73,7 +73,7 @@ function prodWorker(done) {
         return process.nextTick(() => callback('noworker'));
     }
 
-    const timeout = setTimeout(() => callback('timeout'), 1000);
+    const timeout = setTimeout(() => callback('timeout'), 5000);
 
     onWorkerReady(() => {
         clearTimeout(timeout);


### PR DESCRIPTION
#### What?

Detailed description has been written and discussed at issue #379

This change will prevent the issue to happen in most scenarios, if not all.

#### Tickets / Documentation

- [bigcommerce/stencil-cli GitHub issue 379](https://github.com/bigcommerce/stencil-cli/issues/379)
