### PR TITLE
Add node 10 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 node_js:
   - 6
   - 8
+  - 10
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
#### What?

Adding Node 10 to the versions travis checks.

For now, this is mostly just to see what tests fail so we can start working on Node 10 support.