### PR TITLE
Proper error handling for bundle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The BigCommerce server emulator for local theme development.
 
 ## Install
-_Note: Stencil requires the Node.js runtime environment, version 6.x or later. We have tested Stencil on selected Node.js versions, from 6.10.3 to 7.9.0_
+_Note: Stencil requires the Node.js runtime environment, version 6.x or later. We have tested Stencil on selected Node.js versions, from 6.10.3 to 8.12.0_
 
 Run `npm install -g @bigcommerce/stencil-cli`.
 

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -56,7 +56,7 @@ function devWorker(browserSync) {
     if (!worker) {
         return;
     }
-    // send a message to the worker to start watching 
+    // send a message to the worker to start watching
     // and wait for message to reload the browser
     worker.send('development');
     worker.on('message', message => {
@@ -70,10 +70,13 @@ function prodWorker(done) {
     const callback = _.once(done);
 
     if (!worker) {
-        return process.nextTick(() => callback('noworker'));
+        return process.nextTick(() => callback('worker initialization failed'));
     }
 
-    const timeout = setTimeout(() => callback('timeout'), 5000);
+    const timeout = setTimeout(() => {
+        worker.kill();
+        callback('worker timed out');
+    }, 20000);
 
     onWorkerReady(() => {
         clearTimeout(timeout);
@@ -87,5 +90,5 @@ function prodWorker(done) {
         });
     });
 
-    worker.on('close', () => callback('noworker'));
+    worker.on('close', () => callback('worker terminated'));
 }

--- a/lib/build-config.spec.js
+++ b/lib/build-config.spec.js
@@ -66,7 +66,7 @@ describe('stencilBuildConfig', () => {
 
             expect(buildConfig.production).to.be.a.function();
             buildConfig.initWorker().production(message => {
-                expect(message).to.equal('noworker');
+                expect(message).to.equal('worker terminated');
                 done();
             });
         });

--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -61,7 +61,11 @@ function Bundle(themePath, themeConfig, rawConfig, options) {
     if (typeof buildConfig.production === 'function') {
         tasks.theme = callback => {
             console.log('Theme task Started...');
-            buildConfig.initWorker().production(() => {
+            buildConfig.initWorker().production(err => {
+                if (err) {
+                    return callback(err);
+                }
+
                 console.log('ok'.green + ' -- Theme task Finished');
                 callback();
             });
@@ -283,7 +287,6 @@ function bundleTaskRunner(callback) {
     if (!this.configuration.name) {
         defaultName = 'Theme.zip';
     }
-
 
     Async.parallel(this.tasks, (err, taskResults) => {
         if (err) {


### PR DESCRIPTION
#### What?
Add error handling for the theme's build task. Previously, if an error occurred in the theme's build task (such as Cornerstone's webpack build), we swallow the error and proceed. Additionally, if the task timeout out (took longer than 5 seconds, we'd swallow the error and continue, leading to incomplete bundles.

* Fixes #379 
* Fixes #325 