### PR TITLE
fix: added fix for scss compilation issue

### DIFF
--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -11,8 +11,6 @@ const internals = {
 module.exports.register = function (server, options, next) {
     internals.options = Hoek.applyToDefaults(internals.options, options);
 
-    internals.stencilStyles = new StencilStyles();
-
     server.expose('cssHandler', internals.cssHandler);
     server.expose('assetHandler', internals.assetHandler);
 
@@ -83,7 +81,8 @@ internals.cssHandler = function (request, reply) {
             },
         };
 
-        internals.stencilStyles.compileCss('scss', params, (err, css) => {
+        let stencilStyles = new StencilStyles();
+        stencilStyles.compileCss('scss', params, (err, css) => {
             if (err) {
                 console.error(err);
                 return reply(Boom.badData(err));


### PR DESCRIPTION


#### What?

When multiple css/scss files have to be rendered and assembled,
we have to create separate instances of `StencilStyles` since
each `StencilStyles` needs its own file cache for import statements
to work properly.

#### Tickets / Documentation

- [ISSUE 404](https://github.com/bigcommerce/stencil-cli/issues/404)



