### PR TITLE
fix: added npm install to gulp task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-<a name="1.15.6"></a>
-## <small>1.15.6 (2019-02-26)</small>
-
-* docs: updated paper to 2.0.11 + checked package-lock (#446) ([54ddad0](https://github.com/bigcommerce/stencil-cli/commit/54ddad0))
-* fix: revert paper_2.0.11 pr (#445) ([adf424f](https://github.com/bigcommerce/stencil-cli/commit/adf424f))
-* Docs: upgraded paper (#441) ([26b3937](https://github.com/bigcommerce/stencil-cli/commit/26b3937))
-* feat(theme): add csrf protection to the list of valid features ([fe4b795](https://github.com/bigcommerce/stencil-cli/commit/fe4b795))
-
-
-
 <a name="1.15.5"></a>
 ## <small>1.15.5 (2019-02-05)</small>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ const git = require('gulp-git-streamed');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const gutil = require('gulp-util');
+const supportedLockFileVersion = [1];
 const prompt = require('gulp-prompt');
 const semver = require('semver');
 
@@ -74,7 +75,13 @@ function bumpTask() {
             targetVersion = (res.type !== 'custom') ? semver.inc(currentVersion, res.type) : res['custom-version'];
             responses = res;
 
-            return gulp.src('package.json')
+            const packageLock = require('./package-lock.json');
+
+            if (!supportedLockFileVersion.includes(packageLock["lockfileVersion"])) {
+                throw new Error(`Release script only supports version ${supportedLockFileVersion}`);
+            }
+
+            return gulp.src(['package.json', 'package-lock.json'])
                 // bump the version number in those files
                 .pipe(bump({ version: targetVersion }))
                 // save it back to filesystem
@@ -100,7 +107,7 @@ function uninstallPrivateDependencies() {
 }
 
 function pushTask() {
-    return gulp.src(['package.json', 'CHANGELOG.md', 'server/plugins/stencil-editor/public/dist/app.js', 'server/plugins/stencil-editor/public/dist/ng-stencil-editor/css/ng-stencil-editor.min.css', 'server/plugins/stencil-editor/public/dist/stencil-preview-sdk.js'])
+    return gulp.src(['package.json', 'package-lock.json', 'CHANGELOG.md', 'server/plugins/stencil-editor/public/dist/app.js', 'server/plugins/stencil-editor/public/dist/ng-stencil-editor/css/ng-stencil-editor.min.css', 'server/plugins/stencil-editor/public/dist/stencil-preview-sdk.js'])
         // Add files
         .pipe(git.add())
         // Commit the changed version number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "1.15.6",
+  "version": "1.15.5",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
#### What?
After starting to check in package-lock.json, we should adjust the gulp task for releasing to run npm install prior the push of the release to github.

#### Screenshots
<img width="1089" alt="screen shot 2019-02-27 at 2 20 06 pm" src="https://user-images.githubusercontent.com/41761536/53527247-44324d80-3a9b-11e9-8bbe-3b6c72046eb2.png">


