### PR TITLE
feat: Add support for base_url and secure_base_url

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -392,6 +392,9 @@ internals.getPencilResponse = function (data, request, response, configuration) 
     data.context.settings.theme_config_id = Utils.int2uuid(request.app.themeConfig.variationIndex + 1);
     data.context.settings.theme_session_id = null;
     data.context.settings.maintenance = {secure_path: `http://localhost:${internals.options.stencilEditorPort}`};
+    data.context.settings.base_url = `http://${request.info.host}`;
+    // intentionally not secure, stencil-cli doesn't have an ssl-bound port
+    data.context.settings.secure_base_url = `http://${request.info.host}`;
 
     return new Responses.PencilResponse({
         template_file: internals.getTemplatePath(request.path, data),

--- a/server/plugins/renderer/responses/pencil-response.js
+++ b/server/plugins/renderer/responses/pencil-response.js
@@ -76,14 +76,6 @@ internals.makeDecorator = function (request, context) {
         var regex,
             debugBar;
 
-        if (context.settings) {
-            regex = new RegExp(internals.escapeRegex(context.settings.base_url), 'g');
-            content = content.replace(regex, '');
-
-            regex = new RegExp(internals.escapeRegex(context.settings.secure_base_url), 'g');
-            content = content.replace(regex, '');
-        }
-
         if (request.query.debug === 'bar') {
             debugBar = '<pre style="background-color:#EEE; word-wrap:break-word;">';
             debugBar += internals.escapeHtml(JSON.stringify(context, null, 2)) + '</pre>';


### PR DESCRIPTION
### What?

The base_url and secure_base_url were not available in settings because they had been explicitly removed. This patch adds them using the current stencil web-server host as a value.

### Tickets / Documentation
https://developer.bigcommerce.com/stencil-docs/stencil-object-model-reference/stencil-objects/global-objects/settings
