### PR TITLE
STRF-6383 Update stencil bundle to check size for generated parsed parsed/templates

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -1,6 +1,6 @@
 'use strict';
-
-const MAX_SIZE_BUNDLE = 1048576 * 50; //50MB
+const MEGABYTE=1048576;
+const MAX_SIZE_BUNDLE = MEGABYTE * 50; //50MB
 const PATHS_TO_ZIP = [
     'assets/**/*',
     '!assets/cdn/**',
@@ -308,8 +308,11 @@ function bundleTaskRunner(callback) {
             bundleThemeFiles(archive, this.themePath, this.configuration);
 
             // zip all generated files
-            bundleParsedFiles(archive, taskResults);
-
+            const failedTemplatesArr=bundleParsedFiles(archive, taskResults);
+            
+            if (failedTemplatesArr.length > 0) {
+                return console.error(`Error: Your bundle failed as the templates generated from the files below are greater than ${MEGABYTE} bytes:\n${failedTemplatesArr.join('\n')}`);
+            }
             fileStream.on('close', () => {
                 const stats = Fs.statSync(bundleZipPath);
                 const size = stats['size'];
@@ -317,7 +320,7 @@ function bundleTaskRunner(callback) {
                 if (size > MAX_SIZE_BUNDLE) {
                     return console.error(`Error: Your bundle of size ${size} bytes is above the max size of ${MAX_SIZE_BUNDLE} bytes`);
                 }
-
+                
                 console.log('ok'.green + ' -- Zipping Files Finished');
 
                 return callback(null, bundleZipPath);
@@ -354,14 +357,16 @@ function bundleThemeFiles(archive, themePath, configuration) {
  * Archive all generated files (ex. parsed files)
  * @param {Archive} archive
  * @param {Object} taskResults
+ * @returns {Array} 
  */
 function bundleParsedFiles(archive, taskResults) {
     const archiveJsonFile = (data, name) => {
         archive.append(JSON.stringify(data), { name });
     }
-
+    const templatesArr=[];
     for (let task in taskResults) {
         let data = taskResults[task];
+        
         switch(task) {
         case 'css':
             // Create the parsed tree files
@@ -375,6 +380,10 @@ function bundleParsedFiles(archive, taskResults) {
             for (let filename in data) {
                 let hash = Crypto.createHash('md5').update(filename).digest('hex');
                 archiveJsonFile(data[filename], `parsed/templates/${hash}.json`);
+
+                if (JSON.stringify(data[filename]).length >= MEGABYTE) {
+                    templatesArr.push(filename);
+                }
             }
             break;
 
@@ -394,6 +403,7 @@ function bundleParsedFiles(archive, taskResults) {
             break;
         }
     }
+    return templatesArr;
 }
 
 module.exports = Bundle;


### PR DESCRIPTION
#### What?
Add checks for template size.  Refactored bundleParsedFiles function to return an array.  The contents of this array are determined by checking the size of the data that is being added to a parsed template file and if the size is greater than a megabyte which is determined by the length of the stringified data as 1 byte is 1 char then the filename is added to the templatesArr.  Also refactored bundleTaskRunner to accept the returned array from bundleParsedFiles and check to see if the length of the array is greater than 0  if it is then we console.error and list the failed filenames.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-6383

