### PR TITLE
fix: strf-6383 add check for template size

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -1,6 +1,6 @@
 'use strict';
-
-const MAX_SIZE_BUNDLE = 1048576 * 50; //50MB
+const MEGABYTE = 1048576
+const MAX_SIZE_BUNDLE = MEGABYTE * 50; 
 const PATHS_TO_ZIP = [
     'assets/**/*',
     '!assets/cdn/**',
@@ -308,11 +308,15 @@ function bundleTaskRunner(callback) {
             bundleThemeFiles(archive, this.themePath, this.configuration);
 
             // zip all generated files
-            bundleParsedFiles(archive, taskResults);
+            const failedTemplates = bundleParsedFiles(archive, taskResults);
 
             fileStream.on('close', () => {
                 const stats = Fs.statSync(bundleZipPath);
                 const size = stats['size'];
+
+                if (failedTemplates.length) {
+                    return console.error(`Error: Your bundle failed as templates generated from the files below are greater than or equal to 1 megabyte in size:\n${failedTemplates.join('\n')}`);
+                }
 
                 if (size > MAX_SIZE_BUNDLE) {
                     return console.error(`Error: Your bundle of size ${size} bytes is above the max size of ${MAX_SIZE_BUNDLE} bytes`);
@@ -354,12 +358,13 @@ function bundleThemeFiles(archive, themePath, configuration) {
  * Archive all generated files (ex. parsed files)
  * @param {Archive} archive
  * @param {Object} taskResults
+ * @returns {Array}
  */
 function bundleParsedFiles(archive, taskResults) {
     const archiveJsonFile = (data, name) => {
         archive.append(JSON.stringify(data), { name });
     }
-
+    const failedTemplates = [];
     for (let task in taskResults) {
         let data = taskResults[task];
         switch(task) {
@@ -373,8 +378,13 @@ function bundleParsedFiles(archive, taskResults) {
         case 'templates':
             // Create the parsed tree files
             for (let filename in data) {
-                let hash = Crypto.createHash('md5').update(filename).digest('hex');
-                archiveJsonFile(data[filename], `parsed/templates/${hash}.json`);
+                const hash = Crypto.createHash('md5').update(filename).digest('hex');
+                const fileData = data[filename];
+                archiveJsonFile(fileData, `parsed/templates/${hash}.json`);
+                // if file size is greater than 1 megabyte push filename to failedTemplates
+                if (JSON.stringify(fileData).length >= MEGABYTE) {
+                    failedTemplates.push(filename);
+                }
             }
             break;
 
@@ -394,6 +404,7 @@ function bundleParsedFiles(archive, taskResults) {
             break;
         }
     }
+    return failedTemplates;
 }
 
 module.exports = Bundle;


### PR DESCRIPTION
#### What?

Description
We need to validate the size of generated parsed/templates and make sure each of them are under 1MB.

We should fail the bundle process and notify on the terminal which generated files are greater than 1MB.

We are seeing a bunch of cases where zip files are under 50MB but the uploads still fail due to generated parsed/templates files greater than 1MB.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

https://jira.bigcommerce.com/browse/STRF-6383