### PR TITLE
feat: update stencil-paper to add getImageSrcset helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,14 +39,15 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-2.0.13.tgz",
-      "integrity": "sha512-ZPwEbK8BplJqsfxXOK9845kNH4aM+2wPGlhbgBjZ/rENpBARp7RfmMWb2eWmSE0pCqIjvfbXNtziAd5QFU/rDw==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-2.0.17.tgz",
+      "integrity": "sha512-4G2hSeZ60b78lzZPbAJwsr9nFYoyJ3g/0ArjvZsP45iPDu2wgWE7jyvJP56dLMU2xsr6J7TdOca9fvN87GUSIg==",
       "requires": {
         "accept-language-parser": "^1.0.2",
         "async": "^1.4.2",
-        "handlebars": "^3.0.1",
+        "handlebars": "3.0.7",
         "handlebars-helpers": "^0.8.0",
+        "handlebars-utils": "^1.0.6",
         "lodash": "^3.6.0",
         "messageformat": "^0.2.2",
         "stringz": "^0.1.1",
@@ -57,6 +58,16 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "handlebars": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.7.tgz",
+          "integrity": "sha512-Pb/VCTFwbcm3KbD5rIzVVsbVBk7XMfhS4ZIJUfXdMF7H+UngtsofnUBfop/i24GSr3HCDG1PL0KoIX0YqEsXTg==",
+          "requires": {
+            "optimist": "^0.6.1",
+            "source-map": "^0.1.40",
+            "uglify-js": "^2.6"
+          }
         }
       }
     },
@@ -9052,14 +9063,30 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.5.15",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
-          "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
           "optional": true,
           "requires": {
             "commander": "~2.20.0",
             "source-map": "~0.6.1"
           }
+        }
+      }
+    },
+    "handlebars-utils": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/handlebars-utils/-/handlebars-utils-1.0.6.tgz",
+      "integrity": "sha512-d5mmoQXdeEqSKMtQQZ9WkiUcO1E3tPbWxluCK9hVgIDPzQa9WsKo3Lbe/sGflTe7TomHEeZaOgwIkyIr1kfzkw==",
+      "requires": {
+        "kind-of": "^6.0.0",
+        "typeof-article": "^0.1.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -9163,17 +9190,6 @@
             "hoek": "2.x.x",
             "joi": "6.x.x",
             "wreck": "5.x.x"
-          },
-          "dependencies": {
-            "wreck": {
-              "version": "5.6.1",
-              "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
-              "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
-              "requires": {
-                "boom": "2.x.x",
-                "hoek": "2.x.x"
-              }
-            }
           }
         },
         "heavy": {
@@ -9184,19 +9200,6 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
-          },
-          "dependencies": {
-            "joi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
-              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
-              "requires": {
-                "hoek": "^2.2.x",
-                "isemail": "1.x.x",
-                "moment": "2.x.x",
-                "topo": "1.x.x"
-              }
-            }
           }
         },
         "hoek": {
@@ -20426,6 +20429,14 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typeof-article": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/typeof-article/-/typeof-article-0.1.1.tgz",
+      "integrity": "sha1-nwfnM8P7tkb/qeYcCN66zUYOBq8=",
+      "requires": {
+        "kind-of": "^3.1.0"
+      }
     },
     "ua-parser-js": {
       "version": "0.7.12",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^2.0.13",
+    "@bigcommerce/stencil-paper": "^2.0.17",
     "@bigcommerce/stencil-styles": "1.1.0",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",


### PR DESCRIPTION
#### What?

Bringing in latest stencil-paper so that new a new helper (`getImageSrcset`) can be used for local dev.