### PR TITLE
fix: bump paper to 3.0.0-rc20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,11 +80,11 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0-rc.19",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.19.tgz",
-      "integrity": "sha512-AEeajaEMHFp+LGHEv0aqk4yvm0ufABTvgeSHP5TkmAP4l5naEtHDL2sUwYyfMm2vTOmbiA3AAh+svCh0alcnRw==",
+      "version": "3.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.20.tgz",
+      "integrity": "sha512-U0U2E5pDJV9JpGOUKkCfRx3ltcFp8ile8l60r85ykyOqNJWRwDPb7QpVTZdzM8MSva90zl9J4nwA9s/E/DbhMQ==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "~4.2.0",
+        "@bigcommerce/stencil-paper-handlebars": "~4.2.1",
         "accept-language-parser": "~1.4.1",
         "lodash": "~3.10.1",
         "messageformat": "~0.2.2"
@@ -98,9 +98,9 @@
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.2.0.tgz",
-      "integrity": "sha512-I5WPgPto+fFN+X6jI++sy6vB+k7COitcm3UfzuepCcH5Ibi9rXPrZB42xUsgTfkpX2ejgtPhu4fPgi8uua5Olg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.2.1.tgz",
+      "integrity": "sha512-045hDHS5MVcCuhFnYa07aRpsQLVjKGnJtp3l1McT81iqTEHgUi9huEx8MHwBB6wi589oe0rjds7aN3ZJ4t3a8A==",
       "requires": {
         "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#89c779943955795b4f6d40cdb71a6aeb4b5d312c",
         "handlebars": "3.0.7",
@@ -9661,6 +9661,17 @@
             "hoek": "2.x.x",
             "joi": "6.x.x",
             "wreck": "5.x.x"
+          },
+          "dependencies": {
+            "wreck": {
+              "version": "5.6.1",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+              "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+              "requires": {
+                "boom": "2.x.x",
+                "hoek": "2.x.x"
+              }
+            }
           }
         },
         "heavy": {
@@ -9671,6 +9682,19 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
+          },
+          "dependencies": {
+            "joi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+              "requires": {
+                "hoek": "^2.2.x",
+                "isemail": "1.x.x",
+                "moment": "2.x.x",
+                "topo": "1.x.x"
+              }
+            }
           }
         },
         "hoek": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "3.0.0-rc.19",
+    "@bigcommerce/stencil-paper": "3.0.0-rc.20",
     "@bigcommerce/stencil-styles": "1.1.0",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",


### PR DESCRIPTION
Bump paper to 3.0.0-rc20 to pull in this fix: 

https://github.com/bigcommerce/paper-handlebars/commit/0ffd5a1b96e48e2945275be56d3863187a40957f