### PR TITLE
feat: accept url, token, and port as arguments on stencil init

### DIFF
--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -11,10 +11,13 @@ var versionCheck = require('../lib/version-check');
 
 Program
     .version(pkg.version)
+    .option('-u, --url [url]', 'Store URL')
+    .option('-t, --token [token]', 'Access Token')
+    .option('-p, --port [port]', 'Port')
     .parse(process.argv);
 
 if (!versionCheck()) {
     return;
 }
 
-stencilInit(JspmAssembler, ThemeConfig, dotStencilFilePath);
+stencilInit(JspmAssembler, ThemeConfig, dotStencilFilePath, Program.url, Program.token, Program.port);

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -57,7 +57,7 @@ internals.parseAnswers = function(JspmAssembler, ThemeConfig, dotStencilFile, do
     });
 };
 
-internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePath) {
+internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
     var dotStencilFile;
     var questions;
 
@@ -82,13 +82,22 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
                     return 'You must enter a URL';
                 }
             },
-            default: dotStencilFile && dotStencilFile.normalStoreUrl || undefined,
+            default: url || dotStencilFile && dotStencilFile.normalStoreUrl || undefined,
+        },
+        {
+            type: 'input',
+            name: 'accessToken',
+            message: 'What is your Stencil OAuth Access Token?',
+            default: token || dotStencilFile && dotStencilFile.accessToken,
+            filter: function(val) {
+                return val.trim();
+            },
         },
         {
             type: 'input',
             name: 'port',
             message: 'What port would you like to run the server on?',
-            default: dotStencilFile && dotStencilFile.port || 3000,
+            default: port || dotStencilFile && dotStencilFile.port || 3000,
             validate: function (val) {
                 if (isNaN(val)) {
                     return 'You must enter an integer';
@@ -97,15 +106,6 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
                 } else {
                     return true;
                 }
-            },
-        },
-        {
-            type: 'input',
-            name: 'accessToken',
-            message: 'What is your Stencil OAuth Access Token?',
-            default: dotStencilFile && dotStencilFile.accessToken,
-            filter: function(val) {
-                return val.trim();
             },
         },
     ];


### PR DESCRIPTION
#### What?

Accept a `--url` and `--token` argument on `stencil init` to make it easier to start stencil with a one-liner. This pre-fills those options you would normally have to enter.

I think we can use this to make a CP feature to make it easier to instantiate stencil-cli.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-7240](https://jira.bigcommerce.com/browse/STRF-7240)

#### Screenshots (if appropriate)

![In Action](https://i.imgur.com/314yrPI.gif)
