### PR TITLE
fix: bump stencil-styles to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@bigcommerce/stencil-styles": {
-      "version": "1.2.0-rc1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.0-rc1.tgz",
-      "integrity": "sha512-m5SO/AxNSlB3Qjd849A30n2xB+8EoNzn1yrTV/Ti9EozC9AsYOIsMafiF5sS7dFeN979B7Fxfe8okHWy+f1TPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.0.tgz",
+      "integrity": "sha512-TucH6AP42Uy/vrZnhrtqg7XHur5yNsumdbeea53hcnVyD7J6/xJ2WrI+izUHmnl/HS2VRW9IWjmLtFmJxbM8pg==",
       "requires": {
         "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
@@ -2797,9 +2797,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000999",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000999.tgz",
-      "integrity": "sha512-NzRdDmSmg/kp+eNIE1FT+/aXsyGy0PPoAmSrRAR4kFFOs+P19csnJWx4OeIKo6sxurr4xzlsso3rO7SkK71SGw=="
+      "version": "1.0.30001010",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001010.tgz",
+      "integrity": "sha512-frpo0HYuu8tOQqTq/B4LVBDUHFwAeEHLHmSMzG90Ymgq4ll4EArwpqFzNANfQaQwD/q3IIZqQYxftbprZnt8pA=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -4726,9 +4726,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.280",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
-      "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ=="
+      "version": "1.3.306",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
+      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A=="
     },
     "emitter-steward": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
     "@bigcommerce/stencil-paper": "^3.0.0-rc.26",
-    "@bigcommerce/stencil-styles": "1.2.0-rc1",
+    "@bigcommerce/stencil-styles": "1.2.0",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",
     "async": "^2.4.0",


### PR DESCRIPTION
#### What?
Bumps the version of `stencil-styles` to 1.2.0 to support flat and nested keys

#### Tickets / Documentation
[MERC-5836](https://jira.bigcommerce.com/browse/MERC-5836)
