### PR TITLE
Fix: correcting url for deploy issues docs

### DIFF
--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -108,7 +108,7 @@ function printErrorMessages(errors_array) {
         }
     }
 
-    console.log('Please visit the troubleshooting page https://stencil.bigcommerce.com/docs/uploading-a-custom-theme');
+    console.log('Please visit the troubleshooting page https://developer.bigcommerce.com/stencil-docs/deploying-a-theme/troubleshooting-theme-uploads');
     return true
 }
 


### PR DESCRIPTION
#### What?

Updating a docs url that is no longer active.  The docs are for upload/deploy issues of theme.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [JIRA](https://jira.bigcommerce.com/browse/STRF-7461)
