### PR TITLE
fix: fix origin sent with graphql requests

### DIFF
--- a/bin/stencil-bundle.spec.js
+++ b/bin/stencil-bundle.spec.js
@@ -22,7 +22,7 @@ describe('Stencil Bundle', () => {
     let Bundle;
 
     lab.beforeEach(done => {
-        sandbox = Sinon.sandbox.create();
+        sandbox = Sinon.createSandbox();
         const themeConfigStub = getThemeConfigStub();
         const rawConfig = {
             "name": "Cornerstone",

--- a/bin/stencil-init.spec.js
+++ b/bin/stencil-init.spec.js
@@ -14,7 +14,7 @@ describe('stencil init', () => {
     let sandbox;
 
     lab.beforeEach(done => {
-        sandbox = Sinon.sandbox.create();
+        sandbox = Sinon.createSandbox();
         sandbox.stub(console, 'log');
         sandbox.stub(console, 'error');
         done();

--- a/lib/build-config.spec.js
+++ b/lib/build-config.spec.js
@@ -21,7 +21,7 @@ describe('stencilBuildConfig', () => {
     }
 
     lab.beforeEach(done => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         done();
     });
 

--- a/lib/regions.spec.js
+++ b/lib/regions.spec.js
@@ -18,7 +18,7 @@ describe('Stencil Bundle', () => {
     let Bundle;
 
     lab.beforeEach(done => {
-        sandbox = Sinon.sandbox.create();
+        sandbox = Sinon.createSandbox();
         const themeConfigStub = {
             configExists: sandbox.stub().returns(true),
             getRawConfig: sandbox.stub().returns({}),

--- a/lib/stencil-push.spec.js
+++ b/lib/stencil-push.spec.js
@@ -25,7 +25,7 @@ describe('stencil push', () => {
 
     lab.beforeEach(done => {
         mockDb.data = {};
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
 
         sandbox.stub(Wreck, 'get').callsFake(requestStub);
         sandbox.stub(Wreck, 'post').callsFake(requestStub);

--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -16,6 +16,7 @@ const internals = {
         favicon: '/favicon.ico',
         stencilEditor: '/stencil-editor',
         updateParam: '/stencil-editor/update-param',
+        graphQL: '/graphql',
     },
 };
 
@@ -124,6 +125,33 @@ internals.registerRoutes = function(server, next) {
             method: 'GET',
             path: internals.paths.cssFiles,
             handler: server.plugins.ThemeAssets.cssHandler,
+            config: {
+                state: {
+                    failAction: 'log',
+                },
+            },
+        },
+        {
+            method: ['GET', 'POST'],
+            path: internals.paths.graphQL,
+            handler: {
+                proxy: {
+                    mapUri: function (req, cb) {
+                        return cb(
+                            null,
+                            `${internals.options.storeUrl}${req.path}`,
+                            Object.assign( // Add 'origin' and 'host' headers to request before proxying
+                                req.headers,
+                                {
+                                    origin: internals.options.storeUrl,
+                                    host: internals.options.storeUrl.replace(/http[s]?:\/\//, ''),
+                                }
+                            )
+                        );
+                    },
+                    passThrough: true,
+                },
+            },
             config: {
                 state: {
                     failAction: 'log',

--- a/server/plugins/router/router.module.spec.js
+++ b/server/plugins/router/router.module.spec.js
@@ -89,4 +89,21 @@ describe('Router', () => {
             done();
         });
     });
+
+    it('should inject host and origin headers for GraphQL requests', done => {
+        server.inject({
+            method: 'POST',
+            url: '/graphql',
+            headers: { 'authorization': 'abc123' },
+        }, response => {
+            expect(response.request.payload.headers).to.include(
+                {
+                    authorization: 'abc123',
+                    origin: 'https://store-abc123.mybigcommerce.com',
+                    host: 'store-abc123.mybigcommerce.com',
+                }
+            );
+            done();
+        });
+    });
 });


### PR DESCRIPTION
#### What?

The JWT auth used for [GraphQL Storefront API](https://developer.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-overview) relies on the `origin` header sent by the browser to understand if the request should be allowed. For CLI, this origin was being sent as `localhost`, which was being rejected.

This PR uses CLI's proxying capabilities to overwrite/forge the correct `origin` header for the request so that GraphQL works again.
