### PR TITLE
fix: avoid caching of storefront api responses

### DIFF
--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -11,6 +11,7 @@ const internals = {
         renderer: '/{url*}',
         staticAssets: '/assets/{path*}',
         internalApi: '/internalapi/{path*}',
+        storefrontAPI: '/api/storefront/{path*}',
         cdnAssets: '/stencil/{versionId}/{fileName*}',
         cssFiles: '/stencil/{versionId}/css/{fileName}.css',
         favicon: '/favicon.ico',
@@ -93,6 +94,25 @@ internals.registerRoutes = function(server, next) {
         {
             method: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
             path: internals.paths.internalApi,
+            handler: {
+                proxy: {
+                    host: internals.options.storeUrl.replace(/http[s]?:\/\//, ''),
+                    rejectUnauthorized: false,
+                    protocol: 'https',
+                    port: 443,
+                    passThrough: true,
+                    xforward: true,
+                },
+            },
+            config: {
+                state: {
+                    failAction: 'log',
+                },
+            },
+        },
+        {
+            method: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+            path: internals.paths.storefrontAPI,
             handler: {
                 proxy: {
                     host: internals.options.storeUrl.replace(/http[s]?:\/\//, ''),


### PR DESCRIPTION
#### What?
Stencil cli caches get requests for performance optimisation of data requests. A side effect of this causes the response of storefront api calls like `api/storefront/checkout. This causes issues with signIn and signout functionality on all themes that are run using the cli and sending requests within the cache TTL(15 sec as of now). 

Added proxy passthrough for storefront API calls to avoid caching of responses for these requests. 

#### Tickets / Documentation
[Checkout Issue](https://jira.bigcommerce.com/browse/CHECKOUT-4576)

[Checkout sdk discussion](https://github.com/bigcommerce/checkout-sdk-js/issues/422)