### PR TITLE
fix: schema.json formatting

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -362,7 +362,7 @@ function bundleThemeFiles(archive, themePath, configuration) {
  */
 function bundleParsedFiles(archive, taskResults) {
     const archiveJsonFile = (data, name) => {
-        archive.append(JSON.stringify(data), { name });
+        archive.append(JSON.stringify(data, null, 2), { name });
     }
     const failedTemplates = [];
     for (let task in taskResults) {


### PR DESCRIPTION
#### What?

Download or bundle the theme, the file `schema.json` appears to be on a single line, the bundling process uses `JSON.stringify`  without any spacing like the other `JSON`


#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/15646039/71769468-1d963c00-2f22-11ea-9085-5d29c429c084.png)

