### PR TITLE
fix: more detailed theme variation error

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -294,6 +294,9 @@ utils.getVariations = (options, callback) => {
         };
         if (options.activate !== true && options.activate !== undefined) {
             const findVariation = result.variations.find(item => item.name === options.activate);
+            if (!findVariation || !findVariation.uuid) {
+                throw new Error(`Invalid theme variation provided!. Available options${result.variations.map(item => ` ${item.name}`).join(',')}...`);
+            }
             callback(null, Object.assign({}, options, { variationId: findVariation.uuid }));
         } else if (options.activate === true) {
             callback(null, Object.assign({}, options, { variationId: result.variations[0].uuid }));


### PR DESCRIPTION
#### What?

When trying to push a theme using `stencil push -a "Theme Variation"`, if the theme variation is typed incorrectly or missing, it gives off a cryptic error message -

```TypeError: Cannot read property 'uuid' of undefined```

This PR added a readable error message in the case a theme variation is not found or invalid.

#### Tickets / Documentation
- #459 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/15646039/71770927-92be3d00-2f33-11ea-89d6-88d4b49d1f64.png)

