### PR TITLE
feat: add flag to auto-delete oldest theme during stencil push

### DIFF
--- a/bin/stencil-push
+++ b/bin/stencil-push
@@ -16,6 +16,7 @@ Program
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
     .option('-s, --save [filename]', 'specify the filename to save the bundle as')
     .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
+    .option('-d, --delete', 'delete oldest private theme if upload limit reached')
     .parse(process.argv);
 
 if (!versionCheck()) {
@@ -26,7 +27,8 @@ stencilPush(Object.assign({}, options, {
     apiHost: Program.host || apiHost,
     bundleZipPath: Program.file,
     activate: Program.activate,
-    saveBundleName: Program.save
+    saveBundleName: Program.save,
+    deleteOldest: Program.delete,
 }), (err, result) => {
     if (err) {
         console.log("\n\n" + 'not ok'.red + ` -- ${err} see details below:`);

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -131,7 +131,6 @@ utils.uploadBundle = (options, callback) => {
             error.name = 'ThemeUploadError';
             return callback(error);
         }
-
         callback(null, Object.assign({}, options, {
             jobId: result.jobId,
             themeLimitReached: !!result.themeLimitReached,
@@ -140,7 +139,7 @@ utils.uploadBundle = (options, callback) => {
 };
 
 utils.notifyUserOfThemeLimitReachedIfNecessary = (options, callback) => {
-    if (options.themeLimitReached) {
+    if (options.themeLimitReached && !options.deleteOldest) {
         console.log('warning'.yellow + ` -- You have reached your upload limit.  In order to proceed, you'll need to delete at least one theme.`);
     }
 
@@ -150,6 +149,14 @@ utils.notifyUserOfThemeLimitReachedIfNecessary = (options, callback) => {
 utils.promptUserToDeleteThemesIfNecessary = (options, callback) => {
     if (!options.themeLimitReached) {
         return async.nextTick(callback.bind(null, null, options));
+    }
+
+    if (options.deleteOldest) {
+        const oldestTheme =  options.themes
+        .filter(theme => theme.is_private  && !theme.is_active)
+        .map(theme => ({uuid: theme.uuid, updated_at : new Date(theme.updated_at).valueOf()}))
+        .reduce((prev, current) =>  prev.updated_at < current.updated_at ? prev : current)
+        return callback(null, Object.assign({}, options, {themeIdsToDelete: [oldestTheme.uuid]}));
     }
 
     const questions = [{


### PR DESCRIPTION
#### What?

Adding --delete and -d flags to stencil push. This flag will automatically delete the oldest private theme if the upload limit is reached.

#### Tickets / Documentation

https://github.com/bigcommerce/stencil-cli/issues/429

#### Screenshots (if appropriate)

Before:
![before](https://user-images.githubusercontent.com/20911717/72011971-91855c80-3220-11ea-8b33-52353738faca.gif)

After:
![after-2](https://user-images.githubusercontent.com/20911717/72013132-eb872180-3222-11ea-87d2-448dca8e0767.gif)

