### PR TITLE
feat: bump paper to 3.0.0-rc.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-          "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+          "version": "3.7.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+          "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
           "optional": true,
           "requires": {
             "commander": "~2.20.3",
@@ -80,11 +80,11 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0-rc.26",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.26.tgz",
-      "integrity": "sha512-lNEx4TDHhkOWzaD4wyzVXpPPXyell1u5hy/okt1Gqiuu7fdHuQR1JQzAOkGfzT+47zellqhOuo5Fh0SJUh7Axw==",
+      "version": "3.0.0-rc.27",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.27.tgz",
+      "integrity": "sha512-G2qQBD08O8HnBwxiYNWLnrQVcWzzU0d7KUnwvMaTswKbAoGLk9PdrbPp864LQAmldcKokOD6ZuDn5D0u23f5BA==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "4.2.3",
+        "@bigcommerce/stencil-paper-handlebars": "4.3.0",
         "accept-language-parser": "~1.4.1",
         "lodash": "~3.10.1",
         "messageformat": "~0.2.2"
@@ -98,14 +98,15 @@
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.2.3.tgz",
-      "integrity": "sha512-Ua+lEcDJOYD9aZO9XjDHacCGEnxpgL+207BmHVWrWiI5pMVOSCGx6bVpENBwWQNkuRnJuqpoiNRxEuipd5Jw5Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.3.0.tgz",
+      "integrity": "sha512-UnmtVG3o4Dnu09XHZMDBt6Ih6BO0DnY4YUgSAK5sTahWIAleGrBZ3XCt/z1aF5d//7HhEJXbI/TLhPlPbO1lqA==",
       "requires": {
-        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#v4.0.14",
+        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#89c779943955795b4f6d40cdb71a6aeb4b5d312c",
         "handlebars": "3.0.7",
         "handlebars-helpers": "0.8.4",
         "handlebars-utils": "^1.0.6",
+        "he": "^1.2.0",
         "lodash": "^4.17.13",
         "stringz": "^0.1.1"
       },
@@ -132,7 +133,7 @@
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.0.tgz",
       "integrity": "sha512-TucH6AP42Uy/vrZnhrtqg7XHur5yNsumdbeea53hcnVyD7J6/xJ2WrI+izUHmnl/HS2VRW9IWjmLtFmJxbM8pg==",
       "requires": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
         "autoprefixer": "^6.7.3",
         "lodash": "^3.10.1",
         "postcss": "^5.2.14"
@@ -820,25 +821,30 @@
         "typechecker": "^4.3.0"
       },
       "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "typechecker": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
-          "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.11.0.tgz",
+          "integrity": "sha512-lz39Mc/d1UBcF/uQFL5P8L+oWdIn/stvkUgHf0tPRW4aEwGGErewNXo2Nb6We2WslWifn00rhcHbbRWRcTGhuw==",
           "requires": {
-            "editions": "^2.1.0"
+            "editions": "^2.2.0"
           },
           "dependencies": {
             "editions": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/editions/-/editions-2.2.0.tgz",
-              "integrity": "sha512-RYg3iEA2BDLCNVe8PUkD+ox5vAKxB9XS/mAhx1bdxGCF0CpX077C0pyTA9t5D6idCYA3avl5/XDHKPsHFrygfw==",
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
+              "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
               "requires": {
-                "errlop": "^1.1.2",
+                "errlop": "^2.0.0",
                 "semver": "^6.3.0"
               }
             }
@@ -4716,9 +4722,20 @@
       }
     },
     "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
+      "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
+      "requires": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -4828,28 +4845,9 @@
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errlop": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.2.tgz",
-      "integrity": "sha512-djkRp+urJ+SmqDBd7F6LUgm4Be1TTYBxia2bhjNdFBuBDQtJDHExD2VbxR6eyst3h1TZy3qPRCdqb6FBoFttTA==",
-      "requires": {
-        "editions": "^2.1.3"
-      },
-      "dependencies": {
-        "editions": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.2.0.tgz",
-          "integrity": "sha512-RYg3iEA2BDLCNVe8PUkD+ox5vAKxB9XS/mAhx1bdxGCF0CpX077C0pyTA9t5D6idCYA3avl5/XDHKPsHFrygfw==",
-          "requires": {
-            "errlop": "^1.1.2",
-            "semver": "^6.3.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.0.0.tgz",
+      "integrity": "sha512-z00WIrQhtOMUnjdTG0O4f6hMG64EVccVDBy2WwgjcF8S4UB1exGYuc2OFwmdQmsJwLQVEIHWHPCz/omXXgAZHw=="
     },
     "errno": {
       "version": "0.1.7",
@@ -6267,8 +6265,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6286,13 +6283,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6305,18 +6300,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6419,8 +6411,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6430,7 +6421,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6443,20 +6433,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6473,7 +6460,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6546,8 +6532,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6557,7 +6542,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6633,8 +6617,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6664,7 +6647,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6682,7 +6664,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6721,13 +6702,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9155,9 +9134,9 @@
           "optional": true
         },
         "handlebars": {
-          "version": "4.4.5",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-          "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+          "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
           "requires": {
             "neo-async": "^2.6.0",
             "optimist": "^0.6.1",
@@ -9179,9 +9158,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-          "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+          "version": "3.7.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+          "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
           "optional": true,
           "requires": {
             "commander": "~2.20.3",
@@ -9200,9 +9179,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -9653,6 +9632,11 @@
         "sntp": "1.x.x"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "helper-date": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
@@ -10027,18 +10011,21 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "ignorefs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
-      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.4.1.tgz",
+      "integrity": "sha512-1whgvOsPWFZRNA/5OFhIk56C9Y39+/CYaRVNvsZZkLymacOSqqdSU53xk8CP3G2u5gz2PX6RLxqKPcsIpDriog==",
       "requires": {
-        "editions": "^1.3.3",
-        "ignorepatterns": "^1.1.0"
+        "editions": "^2.2.0",
+        "ignorepatterns": "^1.4.0"
       }
     },
     "ignorepatterns": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
-      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.4.0.tgz",
+      "integrity": "sha512-YPBIFRB25iZD0WiLxmToe80+QU+mZI+bUlEh3Ze/4gbhlXHdQFk0SwAFQtPOiBAoDv3FvhtSTDUCD9DKFsHTRA==",
+      "requires": {
+        "editions": "^2.2.0"
+      }
     },
     "image-size": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^3.0.0-rc.26",
+    "@bigcommerce/stencil-paper": "^3.0.0-rc.27",
     "@bigcommerce/stencil-styles": "1.2.0",
     "accept-language-parser": "^1.0.2",
     "archiver": "^0.14.4",


### PR DESCRIPTION
## What? Why?
Bump paper to 3.0.0-rc.27 to pull in `encodeHtmlEntities` helper

## How was it tested?
Tests and will test locally.