### PR TITLE
feat(dependencies): remove dateformat as a direct dependency

### DIFF
--- a/lib/release/questions.js
+++ b/lib/release/questions.js
@@ -2,7 +2,11 @@
 
 const inquirer = require('inquirer');
 const semver = require('semver');
-const dateformat = require('dateformat');
+const dateFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+};
 
 function askQuestions(themeConfig, githubToken, remotes, callback) {
     const remoteChoices = remotes.map(remote => {
@@ -48,7 +52,7 @@ function askQuestions(themeConfig, githubToken, remotes, callback) {
             name: 'version',
             type: 'input',
             message: 'What specific version would you like',
-            when: answers => answers['version'] == 'custom',
+            when: answers => answers['version'] === 'custom',
             validate: value => {
                 const valid = semver.valid(value) && true;
 
@@ -87,7 +91,7 @@ function askQuestions(themeConfig, githubToken, remotes, callback) {
             return callback(new Error('Operation cancelled'));
         }
 
-        answers.date = dateformat(new Date(), 'yyyy-mm-dd');
+        answers.date = new Date().toLocaleString('en-US', dateFormatOptions).split('/').join('-');
 
         callback(null, answers);
     });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "colors": "^1.0.3",
     "commander": "^2.7.1",
     "confidence": "^1.0.0",
-    "dateformat": "^2.0.0",
     "decompress-zip": "^0.2.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",


### PR DESCRIPTION
#### What?
Remove direct dependency for dateformat npm package. Also switching the date format for changelog from `yyyy-mm-dd` to `mm-dd-yyyy`.

#### Screenshots (if appropriate)

Attach images or add image links here.
<img width="984" alt="Screen Shot 2020-01-29 at 3 11 16 PM" src="https://user-images.githubusercontent.com/319659/73406205-b6fb0880-42aa-11ea-89c9-c65ddebb8abf.png">

@bigcommerce/storefront-team 