### PR TITLE
feat(dependencies): remove script-loader as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.3.0.tgz",
       "integrity": "sha512-UnmtVG3o4Dnu09XHZMDBt6Ih6BO0DnY4YUgSAK5sTahWIAleGrBZ3XCt/z1aF5d//7HhEJXbI/TLhPlPbO1lqA==",
       "requires": {
-        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#89c779943955795b4f6d40cdb71a6aeb4b5d312c",
+        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#v4.0.14",
         "handlebars": "3.0.7",
         "handlebars-helpers": "0.8.4",
         "handlebars-utils": "^1.0.6",
@@ -133,7 +133,7 @@
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.0.tgz",
       "integrity": "sha512-TucH6AP42Uy/vrZnhrtqg7XHur5yNsumdbeea53hcnVyD7J6/xJ2WrI+izUHmnl/HS2VRW9IWjmLtFmJxbM8pg==",
       "requires": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
         "lodash": "^3.10.1",
         "postcss": "^5.2.14"
@@ -4392,7 +4392,8 @@
     "dateformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
@@ -6273,7 +6274,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6291,11 +6293,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6308,15 +6312,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6419,7 +6426,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6429,6 +6437,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6441,17 +6450,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6468,6 +6480,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6540,7 +6553,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6550,6 +6564,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6625,7 +6640,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6655,6 +6671,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6672,6 +6689,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6710,11 +6728,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9293,6 +9313,17 @@
             "hoek": "2.x.x",
             "joi": "6.x.x",
             "wreck": "5.x.x"
+          },
+          "dependencies": {
+            "wreck": {
+              "version": "5.6.1",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+              "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+              "requires": {
+                "boom": "2.x.x",
+                "hoek": "2.x.x"
+              }
+            }
           }
         },
         "heavy": {
@@ -9303,6 +9334,19 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
+          },
+          "dependencies": {
+            "joi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+              "requires": {
+                "hoek": "^2.2.x",
+                "isemail": "1.x.x",
+                "moment": "2.x.x",
+                "topo": "1.x.x"
+              }
+            }
           }
         },
         "hoek": {
@@ -17612,12 +17656,6 @@
         }
       }
     },
-    "raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-      "dev": true
-    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -18895,15 +18933,6 @@
         "ignorefs": "^1.0.0",
         "safefs": "^3.1.2",
         "taskgroup": "^4.0.5"
-      }
-    },
-    "script-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
-      "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
-      "dev": true,
-      "requires": {
-        "raw-loader": "~0.5.1"
       }
     },
     "scss-tokenizer": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "js-cookie": "^2.1.1",
     "npm-which": "^3.0.1",
     "object-to-spawn-args": "^1.1.1",
-    "script-loader": "^0.7.0",
     "sinon": "^7.1.1",
     "webpack": "^1.13.0",
     "webpack-livereload-plugin": "^0.8.1"


### PR DESCRIPTION
#### What?

remove script-loader as a direct dependency since it is not used and it is deprecated https://github.com/webpack-contrib/script-loader

@bigcommerce/storefront-team 