### PR TITLE
feat(dependencies): remove decompress-zip as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4311,51 +4311,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
-    "decompress-zip": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
-      "integrity": "sha512-v+Na3Ck86Px7s2ix+f77pMQC3GlkxHHN+YyvnkEW7+xX5F39pcDpIV/VFvGYk8MznTFcMoPjL3XNWEJLXWoSPw==",
-      "requires": {
-        "binary": "^0.3.0",
-        "graceful-fs": "^4.1.3",
-        "mkpath": "^0.1.0",
-        "nopt": "^3.0.1",
-        "q": "^1.1.2",
-        "readable-stream": "^1.1.8",
-        "touch": "0.0.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "colors": "^1.0.3",
     "commander": "^2.7.1",
     "confidence": "^1.0.0",
-    "decompress-zip": "^0.2.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
     "front-matter": "^1.0.0",


### PR DESCRIPTION
#### What?
remove decompress-zip as a dependency

```
juned.kazi at C02WF0AQHTDH in ~/Codebases/stencil-cli on remove-decompress-zip▲
$ npm ci
npm WARN prepare removing existing node_modules/ before installation

> uws@9.14.0 install /Users/juned.kazi/Codebases/stencil-cli/node_modules/uws
> node-gyp rebuild > build_log.txt 2>&1 || exit 0


> fsevents@1.2.7 install /Users/juned.kazi/Codebases/stencil-cli/node_modules/fsevents
> node install

node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.10.3
node-pre-gyp info using node@10.16.3 | darwin | x64
node-pre-gyp WARN Using request for node-pre-gyp https download
node-pre-gyp info check checked for "/Users/juned.kazi/Codebases/stencil-cli/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node" (not found)
node-pre-gyp http GET https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.2.7/fse-v1.2.7-node-v64-darwin-x64.tar.gz
node-pre-gyp http 200 https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.2.7/fse-v1.2.7-node-v64-darwin-x64.tar.gz
node-pre-gyp info install unpacking node-v64-darwin-x64/fse.node
node-pre-gyp info tarball done parsing tarball
[fsevents] Success: "/Users/juned.kazi/Codebases/stencil-cli/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node" is installed via remote
node-pre-gyp info ok

> spawn-sync@1.0.15 postinstall /Users/juned.kazi/Codebases/stencil-cli/node_modules/spawn-sync
> node postinstall


> @bigcommerce/node-sass@3.5.0 install /Users/juned.kazi/Codebases/stencil-cli/node_modules/@bigcommerce/node-sass
> node scripts/install.js

Binary downloaded and installed at /Users/juned.kazi/Codebases/stencil-cli/node_modules/@bigcommerce/node-sass/vendor/darwin-x64-64/binding.node

> @bigcommerce/node-sass@3.5.0 postinstall /Users/juned.kazi/Codebases/stencil-cli/node_modules/@bigcommerce/node-sass
> node scripts/build.js

` /Users/juned.kazi/Codebases/stencil-cli/node_modules/@bigcommerce/node-sass/vendor/darwin-x64-64/binding.node ` exists.
 testing binary.
Binary is fine; exiting.

> typechecker@2.0.8 preinstall /Users/juned.kazi/Codebases/stencil-cli/node_modules/extract-opts/node_modules/typechecker
> node ./cyclic.js


> typechecker@2.0.8 preinstall /Users/juned.kazi/Codebases/stencil-cli/node_modules/extendr/node_modules/typechecker
> node ./cyclic.js


> husky@1.3.1 install /Users/juned.kazi/Codebases/stencil-cli/node_modules/husky
> node husky install

husky > setting up git hooks
husky > done

> node-sass@4.12.0 install /Users/juned.kazi/Codebases/stencil-cli/node_modules/gulp-sass/node_modules/node-sass
> node scripts/install.js

Downloading binary from https://github.com/sass/node-sass/releases/download/v4.12.0/darwin-x64-64_binding.node
Download complete
Binary saved to /Users/juned.kazi/Codebases/stencil-cli/node_modules/gulp-sass/node_modules/node-sass/vendor/darwin-x64-64/binding.node

> node-sass@4.12.0 postinstall /Users/juned.kazi/Codebases/stencil-cli/node_modules/gulp-sass/node_modules/node-sass
> node scripts/build.js

(node:56758) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added. Use emitter.setMaxListeners() to increase limit
Binary found at /Users/juned.kazi/Codebases/stencil-cli/node_modules/gulp-sass/node_modules/node-sass/vendor/darwin-x64-64/binding.node
Testing binary
Binary is fine
added 2223 packages in 110.958s
juned.kazi at C02WF0AQHTDH in ~/Codebases/stencil-cli on remove-decompress-zip▲

```

@bigcommerce/storefront-team 