### PR TITLE
feat: drop node 8 support since it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ os:
   - osx
 addons:
   ssh_known_hosts:
-    - github.com 
+    - github.com
 node_js:
-  - 8
   - 10
 
 cache:
   directories:
     - node_modules
 install:
-  - npm install 
+  - npm install
 script:
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "8"
     - nodejs_version: "10"
-
 platform:
   - x86
   - x64

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
-    "node": ">= 8.0.0 <11.0.0"
+    "node": ">= 10.0.0 <11.0.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
#### What?
drop node 8 support since it is EOL https://github.com/nodejs/Release#end-of-life-releases

@bigcommerce/storefront-team 