### PR TITLE
feat: remove hapi as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9653,6 +9653,17 @@
             "hoek": "2.x.x",
             "joi": "6.x.x",
             "wreck": "5.x.x"
+          },
+          "dependencies": {
+            "wreck": {
+              "version": "5.6.1",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+              "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+              "requires": {
+                "boom": "2.x.x",
+                "hoek": "2.x.x"
+              }
+            }
           }
         },
         "heavy": {
@@ -9663,6 +9674,19 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
+          },
+          "dependencies": {
+            "joi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+              "requires": {
+                "hoek": "^2.2.x",
+                "isemail": "1.x.x",
+                "moment": "2.x.x",
+                "topo": "1.x.x"
+              }
+            }
           }
         },
         "hoek": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "good-console": "^4.1.0",
     "graceful-fs": "^4.1.11",
     "handlebars": "^3.0.3",
-    "hapi": "^8.4.0",
     "hoek": "^2.12.0",
     "image-size": "^0.4.0",
     "inquirer": "^0.8.2",


### PR DESCRIPTION
#### What?
remove hapi as a direct dependency. It is required in the context of glue and we load it as a dependency for it. So we don't need it to be a hardcoded dependency.


@bigcommerce/storefront-team 