### PR TITLE
fix: strf-8574, bump version of "github" package to fix security issues + refactor the related JS file

### DIFF
--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -4,115 +4,66 @@ const os = require('os');
 const uuid = require('uuid4');
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 const themePath = process.cwd();
-const git = require('simple-git')(themePath);
+const git = require('simple-git/promise')(themePath);
 const themeConfig = require('../theme-config').getInstance(themePath);
-const questions = require('./questions');
+const askQuestions = require('./questions');
 const { Octokit } = require('@octokit/rest');
 const Bundle = require('../stencil-bundle');
 
-module.exports = () => {
+module.exports = async () => {
+    const gitData = await getGitData();
 
-    getGitData((err, gitData) => {
-        if (err) {
-            throw err;
-        }
+    if (!checkGitData(gitData)) {
+        return;
+    }
 
-        if (gitData.remotes.length === 0) {
-            return printError('No git remote repository found');
-        }
+    try {
+        const answers = await util.promisify(askQuestions)(themeConfig, getGithubToken(), gitData.remotes);
 
-        if (gitData.current !== 'master') {
-            return printError('Not on master branch, please checkout master branch to proceed');
-        }
+        saveGithubToken(answers.githubToken);
 
-        if (gitData.dirty) {
-            return printError('git tree is dirty, please commit changes to proceed');
-        }
+        await doRelease(answers);
 
-        if (gitData.behind !== 0) {
-            return printError(`Your branch is behind by ${gitData.behind} commits`);
-        }
-
-        if (gitData.ahead !== 0) {
-            printWarning(`your branch is ahead by ${gitData.ahead} commits`);
-        }
-
-        questions(themeConfig, getGithubToken(), gitData.remotes, (err, answers) => {
-            if (err) {
-                return printError(err.message);
-            }
-
-            saveGithubToken(answers.githubToken);
-
-            doRelease(answers, err => {
-                if (err) {
-                    return printError(err.message);
-                }
-
-                console.log('done'.green);
-            });
-        });
-    });
+        console.log('done'.green);
+    } catch (err) {
+        return printError(err.message);
+    }
 };
 
-function doRelease(options, callback) {
+async function doRelease(options) {
     // Update changelog and get text for release notes
     const changelog = parseChangelog(options.version, options.date);
 
     bumpJsonFileVersion(path.join(themePath, 'config.json'), options.version);
     bumpJsonFileVersion(path.join(themePath, 'package.json'), options.version);
 
-    bundleTheme((err, bundlePath) => {
-        if (err) {
-            return callback(err);
+    const bundlePath = await bundleTheme();
+
+    try {
+        const commit = await commitAndPush(options.version, options.remote);
+
+        if (options.createGithubRelease) {
+            await createGithubRelease(commit, options.version, changelog, options.remote, bundlePath);
         }
-
-        commitAndPush(options.version, options.remote, (err, commit) => {
-            if (err) {
-                fs.unlinkSync(bundlePath);
-                return callback(err);
-            }
-
-            createRelease(options, commit, bundlePath, changelog, err => {
-                fs.unlinkSync(bundlePath);
-                if (err) {
-                    return callback(err);
-                }
-
-                callback();
-            });
-        });
-    });
-}
-
-function commitAndPush(version, remote, callback) {
-    git.add(['config.json', 'package.json', 'CHANGELOG.md']).commit(`Releasing ${version}`, (err, summary) => {
-        if (err) {
-            return callback(err);
-        }
-
-        console.log(`Pushing Changes to ${remote.name}...`);
-
-        git.push(remote.name, 'master', err => {
-            if (err) {
-                return callback(err);
-            }
-
-            callback(null, summary.commit);
-        });
-    });
-}
-
-function createRelease(options, commit, bundlePath, changelog, callback) {
-    if (options.createGithubRelease) {
-        createGithubRelease(commit, options.version, changelog, options.remote, bundlePath, callback);
-    } else {
-        process.nextTick(callback);
+    } finally {
+        fs.unlinkSync(bundlePath);
     }
 }
 
-function createGithubRelease(commit, version, changelog, remote, bundlePath, callback) {
+async function commitAndPush(version, remote) {
+    await git.add(['config.json', 'package.json', 'CHANGELOG.md']);
+    const summary = await git.commit(`Releasing ${version}`);
+
+    console.log(`Pushing Changes to ${remote.name}...`);
+
+    await git.push(remote.name, 'master');
+
+    return summary.commit;
+}
+
+async function createGithubRelease(commit, version, changelog, remote, bundlePath) {
     const github = getGithubClient();
 
     const releaseParams = {
@@ -125,28 +76,22 @@ function createGithubRelease(commit, version, changelog, remote, bundlePath, cal
 
     console.log('Creating Github Release...');
 
-    github.repos.createRelease(releaseParams)
-        .then(release => {
-            const uploadParams = {
-                release_id: release.data.id,
-                owner: remote.owner,
-                repo: remote.repo,
-                data: bundlePath,
-                name: `${themeConfig.getName()}-${version}.zip`,
-            };
+    const release = await github.repos.createRelease(releaseParams);
 
-            console.log('Uploading Bundle File...');
+    const uploadParams = {
+        release_id: release.data.id,
+        owner: remote.owner,
+        repo: remote.repo,
+        data: bundlePath,
+        name: `${themeConfig.getName()}-${version}.zip`,
+    };
 
-            github.repos.uploadReleaseAsset(uploadParams)
-                .then(asset => {
-                    console.log(`Release url: ${release.data.html_url.green}`);
-                    console.log(`Bundle download url: ${asset.data.browser_download_url.green}`);
+    console.log('Uploading Bundle File...');
 
-                    callback();
-                })
-                .catch(callback);
-        })
-        .catch(callback);
+    const asset = await github.repos.uploadReleaseAsset(uploadParams);
+
+    console.log(`Release url: ${release.data.html_url.green}`);
+    console.log(`Bundle download url: ${asset.data.browser_download_url.green}`);
 }
 
 function bumpJsonFileVersion(filePath, version) {
@@ -158,7 +103,7 @@ function bumpJsonFileVersion(filePath, version) {
 
 function parseChangelog(version, date) {
     const filePath = path.join(themePath, 'CHANGELOG.md');
-    var changelog = '';
+    let changelog = '';
 
     try {
         changelog = fs.readFileSync(filePath).toString();
@@ -182,7 +127,7 @@ function parseChangelog(version, date) {
 
 function saveGithubToken(githubToken) {
     const dotStencilPath = path.join(themePath, '.stencil');
-    var data = {};
+    let data = {};
 
     try {
         data = JSON.parse(fs.readFileSync(dotStencilPath));
@@ -196,7 +141,7 @@ function saveGithubToken(githubToken) {
 
 function getGithubToken() {
     const dotStencilPath = path.join(themePath, '.stencil');
-    var data = {};
+    let data = {};
 
     try {
         data = JSON.parse(fs.readFileSync(dotStencilPath));
@@ -207,48 +152,77 @@ function getGithubToken() {
     return data.githubToken;
 }
 
-function bundleTheme(callback) {
+async function bundleTheme() {
     const bundle = new Bundle(themePath, themeConfig, themeConfig.getRawConfig(), {
         dest: os.tmpdir(),
         name: uuid(),
     });
 
-    bundle.initBundle(callback);
+    return await util.promisify(bundle.initBundle.bind(bundle))();
 }
 
-function getGitData(callback) {
-    git.status((err, status) => {
-        if (err) {
-            return callback(err);
-        }
+async function getGitData() {
+    const status = await git.status();
 
-        git.getRemotes(true, (err, response) => {
-            if (err) {
-                return callback(err);
-            }
+    const response = await git.getRemotes(true);
 
-            const remotes = response.map(remote => {
-                const url = remote.refs.push || '';
-                const match = url.match(/github\.com[\/|:](.+?)\/(.+?)[\/|\.]/);
+    const remotes = response.map(remote => {
+        const url = remote.refs.push || '';
+        const match = url.match(/github\.com[\/|:](.+?)\/(.+?)[\/|\.]/);
 
-                return {
-                    name: remote.name,
-                    url,
-                    owner: match ? match[1] : null,
-                    repo: match ? match[2] : null,
-                };
-            });
-
-            const dirty = status.not_added.length > 0 ||
-                status.conflicted.length > 0 ||
-                status.created.length > 0 ||
-                status.deleted.length > 0 ||
-                status.modified.length > 0 ||
-                status.renamed.length > 0;
-
-            callback(null, Object.assign({ dirty }, status, { remotes }));
-        });
+        return {
+            name: remote.name,
+            url,
+            owner: match ? match[1] : null,
+            repo: match ? match[2] : null,
+        };
     });
+
+    const dirty = status.not_added.length > 0 ||
+        status.conflicted.length > 0 ||
+        status.created.length > 0 ||
+        status.deleted.length > 0 ||
+        status.modified.length > 0 ||
+        status.renamed.length > 0;
+
+    return Object.assign({ dirty }, status, { remotes });
+}
+
+/**
+ * @param gitData
+ * @param gitData.remotes
+ * @param gitData.current
+ * @param gitData.dirty
+ * @param gitData.behind
+ * @param gitData.ahead
+ * @returns {boolean}
+ */
+function checkGitData (gitData) {
+    if (gitData.remotes.length === 0) {
+        printError('No git remote repository found');
+        return false;
+    }
+
+    if (gitData.current !== 'master') {
+        printError('Not on master branch, please checkout master branch to proceed');
+        return false;
+    }
+
+    if (gitData.dirty) {
+        printError('git tree is dirty, please commit changes to proceed');
+        return false;
+    }
+
+    if (gitData.behind !== 0) {
+        printError(`Your branch is behind by ${gitData.behind} commits`);
+        return false;
+    }
+
+    if (gitData.ahead !== 0) {
+        printWarning(`your branch is ahead by ${gitData.ahead} commits`);
+    }
+
+    return true;
 }
 
 function printError(message) {

--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -8,7 +8,7 @@ const themePath = process.cwd();
 const git = require('simple-git')(themePath);
 const themeConfig = require('../theme-config').getInstance(themePath);
 const questions = require('./questions');
-const GitHub = require('github');
+const { Octokit } = require('@octokit/rest');
 const Bundle = require('../stencil-bundle');
 
 module.exports = () => {
@@ -128,19 +128,19 @@ function createGithubRelease(commit, version, changelog, remote, bundlePath, cal
     github.repos.createRelease(releaseParams)
         .then(release => {
             const uploadParams = {
-                id: release.id,
+                release_id: release.data.id,
                 owner: remote.owner,
                 repo: remote.repo,
-                filePath: bundlePath,
+                data: bundlePath,
                 name: `${themeConfig.getName()}-${version}.zip`,
             };
 
             console.log('Uploading Bundle File...');
 
-            github.repos.uploadAsset(uploadParams)
+            github.repos.uploadReleaseAsset(uploadParams)
                 .then(asset => {
-                    console.log(`Release url: ${release.html_url.green}`);
-                    console.log(`Bundle download url: ${asset.browser_download_url.green}`);
+                    console.log(`Release url: ${release.data.html_url.green}`);
+                    console.log(`Bundle download url: ${asset.data.browser_download_url.green}`);
 
                     callback();
                 })
@@ -260,14 +260,9 @@ function printWarning(message) {
 }
 
 function getGithubClient() {
-    const github = new GitHub();
-
-    github.authenticate({
-        type: 'oauth',
-        token: getGithubToken(),
+    return new Octokit({
+        auth: getGithubToken(),
     });
-
-    return github;
 }
 
 function isReleaseCandidate(version) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -672,6 +672,127 @@
         }
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-cQ2HGrtyNJ1IBxpTP1U5m/FkMAJvgw7d2j1q3c9P0XUuYilEgF6e4naTpsgm4iVcQeOnccZlw7XHRIUBy0ymcg==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.3.tgz",
+      "integrity": "sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "requires": {
+        "@octokit/types": "^5.2.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
+      "integrity": "sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==",
+      "requires": {
+        "@octokit/types": "^5.1.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^4.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.3.tgz",
+      "integrity": "sha512-GubgemnLvUJlkhouTM2BtX+g/voYT/Mqh0SASGwTnLvSkW1irjt14N911/ABb6m1Hru0TwScOgFgMFggp3igfQ==",
+      "requires": {
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "4.1.2"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
+      "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -712,6 +833,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/node": {
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -760,9 +886,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
     "acorn-globals": {
       "version": "3.1.0",
@@ -796,22 +922,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-        }
-      }
     },
     "ajv": {
       "version": "6.11.0",
@@ -2520,6 +2630,11 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -2618,39 +2733,6 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
           "dev": true
-        },
-        "isemail": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-          "dev": true
-        },
-        "items": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==",
-          "dev": true
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x"
-          }
         }
       }
     },
@@ -3059,14 +3141,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      },
-      "dependencies": {
-        "node-int64": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-          "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-          "dev": true
-        }
       }
     },
     "buffer": {
@@ -3154,12 +3228,20 @@
       }
     },
     "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "callsites": "^0.2.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        }
       }
     },
     "callsite": {
@@ -3571,9 +3653,9 @@
       "dev": true
     },
     "compare-func": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
+      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
@@ -4418,6 +4500,15 @@
         "parse-json": "^4.0.0"
       },
       "dependencies": {
+        "caller-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+          "dev": true,
+          "requires": {
+            "caller-callsite": "^2.0.0"
+          }
+        },
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -4708,6 +4799,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "destroy": {
       "version": "1.0.4",
@@ -5116,9 +5212,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -5896,12 +5992,6 @@
           }
         }
       }
-    },
-    "find-rc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
-      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
-      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -7419,36 +7509,6 @@
         "ini": "^1.3.2"
       }
     },
-    "github": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
-      "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
-      "requires": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "^1.0.0",
-        "mime": "^1.2.11",
-        "netrc": "^0.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-          "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-          "requires": {
-            "debug": "^2.2.0",
-            "stream-consume": "^0.1.0"
-          }
-        }
-      }
-    },
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -7699,6 +7759,27 @@
         "hoek": "2.x.x",
         "items": "1.x.x",
         "joi": "5.x.x || 6.x.x"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "joi": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+          "requires": {
+            "hoek": "2.x.x",
+            "isemail": "1.x.x",
+            "moment": "2.x.x",
+            "topo": "1.x.x"
+          }
+        }
       }
     },
     "good": {
@@ -9399,26 +9480,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "husky": {
@@ -11394,14 +11455,44 @@
       }
     },
     "joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "dev": true,
       "requires": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "topo": "2.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+          "dev": true
+        },
+        "items": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==",
+          "dev": true
+        },
+        "topo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
       }
     },
     "js-base64": {
@@ -11768,9 +11859,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "acorn-jsx": {
@@ -11870,6 +11961,12 @@
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
           }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "doctrine": {
           "version": "2.1.0",
@@ -11988,6 +12085,12 @@
             "object-assign": "^4.0.1"
           }
         },
+        "find-rc": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
+          "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
+          "dev": true
+        },
         "flat-cache": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -12021,15 +12124,16 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.7.3",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
-          "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+          "version": "4.7.6",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+          "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
           "dev": true,
           "requires": {
+            "minimist": "^1.2.5",
             "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
             "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
+            "uglify-js": "^3.1.4",
+            "wordwrap": "^1.0.0"
           }
         },
         "has-flag": {
@@ -12243,6 +12347,12 @@
           "requires": {
             "os-tmpdir": "~1.0.2"
           }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
         },
         "write": {
           "version": "0.2.1",
@@ -13486,6 +13596,11 @@
       "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-gyp": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
@@ -13545,6 +13660,12 @@
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
     },
     "node-notifier": {
       "version": "5.4.3",
@@ -15249,21 +15370,6 @@
         "resolve-from": "^1.0.0"
       },
       "dependencies": {
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-          "dev": true,
-          "requires": {
-            "callsites": "^0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-          "dev": true
-        },
         "resolve-from": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -16625,11 +16731,6 @@
         "duplexer": "~0.1.1"
       }
     },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
-    },
     "stream-exhaust": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -17470,6 +17571,11 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
       }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@bigcommerce/stencil-paper": "^3.0.0-rc.29",
     "@bigcommerce/stencil-styles": "1.2.0",
+    "@octokit/rest": "^18.0.3",
     "accept-language-parser": "^1.0.2",
     "ajv": "^6.11.0",
     "archiver": "^5.0.0",
@@ -47,7 +48,6 @@
     "confidence": "^1.0.0",
     "eslint": "^6.8.0",
     "front-matter": "^1.0.0",
-    "github": "^8.1.0",
     "glob": "^5.0.14",
     "glue": "^2.0.0",
     "good": "^5.1.2",


### PR DESCRIPTION
#### What?

Bumped version of the outdated npm module "github" (which was renamed to "@octokit/rest") to fix security vulnerabilities.
The newer version of the npm module had a lot of braking changes, so I had to update our core as well (the first commit).
Also refactored the related JS file to use async/await instead of callbacks (the second commit).

#### Tickets / Documentation

This PR is a part of [STRF-8574](https://jira.bigcommerce.com/browse/STRF-8511) (since there are going to be a lot of updates they will be split into several PRs).

