### PR TITLE
fix: STRF-8574, bump version of "inquirer" package to fix security issues + update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,13 @@
 {
   "parserOptions": {
-    "ecmaVersion": 8,
     "sourceType": "module",
     "ecmaFeatures": {
       "impliedStrict": true
     }
   },
   "env": {
-    "es6": true,
+    "es2020": true,
     "node": true
-  },
-  "globals": {
-    "Set": true
   },
   "rules": {
     "curly": 2,

--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 require('colors');
-var stencilInit = require('../lib/stencil-init');
-var pkg = require('../package.json');
-var Program = require('commander');
-var JspmAssembler = require('../lib/jspm-assembler');
-var ThemeConfig = require('../lib/theme-config');
-var dotStencilFilePath = './.stencil';
-var versionCheck = require('../lib/version-check');
+const StencilInit = require('../lib/stencil-init');
+const pkg = require('../package.json');
+const Program = require('commander');
+const JspmAssembler = require('../lib/jspm-assembler');
+const ThemeConfig = require('../lib/theme-config');
+const dotStencilFilePath = './.stencil';
+const versionCheck = require('../lib/version-check');
 
 Program
     .version(pkg.version)
@@ -20,4 +20,4 @@ if (!versionCheck()) {
     return;
 }
 
-stencilInit(JspmAssembler, ThemeConfig, dotStencilFilePath, Program.url, Program.token, Program.port);
+StencilInit.run(JspmAssembler, ThemeConfig, dotStencilFilePath, Program.url, Program.token, Program.port);

--- a/lib/release/questions.js
+++ b/lib/release/questions.js
@@ -8,7 +8,7 @@ const dateFormatOptions = {
     day: '2-digit',
 };
 
-function askQuestions(themeConfig, githubToken, remotes, callback) {
+async function askQuestions(themeConfig, githubToken, remotes) {
     const remoteChoices = remotes.map(remote => {
         return { value: remote,  name: `${remote.name}: ${remote.url}` };
     });
@@ -18,35 +18,37 @@ function askQuestions(themeConfig, githubToken, remotes, callback) {
     const nextPatchVersion = semver.inc(currentVersion, 'patch');
     const nextMinorVersion = semver.inc(currentVersion, 'minor');
     const nextMajorVersion = semver.inc(currentVersion, 'major');
-    const nextReleaseCandidate = currentVersion.includes('-rc.') ?
-      semver.inc(currentVersion, 'prerelease', 'rc') :
-      semver.inc(currentVersion, 'minor') + '-rc.1';
+    const nextReleaseCandidate = currentVersion.includes('-rc.')
+        ? semver.inc(currentVersion, 'prerelease', 'rc')
+        : semver.inc(currentVersion, 'minor') + '-rc.1';
 
     const questions = [
         {
             name: 'version',
             type: 'list',
             message: 'What type of release would you like to do? ' + 'Current version: '.cyan + currentVersion,
-            choices: [{
-                name: 'Release Candidate:  '.yellow + nextReleaseCandidate.yellow + '   Internal release for testing.',
-                value: nextReleaseCandidate,
-            },
-            {
-                name: 'Patch:  '.yellow + nextPatchVersion.yellow + '   Backwards-compatible bug fixes.',
-                value: nextPatchVersion,
-            },
-            {
-                name: 'Minor:  '.yellow + nextMinorVersion.yellow + '   Feature release or significant update.',
-                value: nextMinorVersion,
-            },
-            {
-                name: 'Major:  '.yellow + nextMajorVersion.yellow + '   Major change.',
-                value: nextMajorVersion,
-            },
-            {
-                name: 'Custom: ?.?.?'.yellow + '   Specify version...',
-                value: 'custom',
-            }],
+            choices: [
+                {
+                    name: 'Release Candidate:  '.yellow + nextReleaseCandidate.yellow + '   Internal release for testing.',
+                    value: nextReleaseCandidate,
+                },
+                {
+                    name: 'Patch:  '.yellow + nextPatchVersion.yellow + '   Backwards-compatible bug fixes.',
+                    value: nextPatchVersion,
+                },
+                {
+                    name: 'Minor:  '.yellow + nextMinorVersion.yellow + '   Feature release or significant update.',
+                    value: nextMinorVersion,
+                },
+                {
+                    name: 'Major:  '.yellow + nextMajorVersion.yellow + '   Major change.',
+                    value: nextMajorVersion,
+                },
+                {
+                    name: 'Custom: ?.?.?'.yellow + '   Specify version...',
+                    value: 'custom',
+                },
+            ],
         },
         {
             name: 'version',
@@ -86,15 +88,15 @@ function askQuestions(themeConfig, githubToken, remotes, callback) {
         },
     ];
 
-    inquirer.prompt(questions, answers => {
-        if (!answers.proceed) {
-            return callback(new Error('Operation cancelled'));
-        }
+    const answers = await inquirer.prompt(questions);
 
-        answers.date = new Date().toLocaleString('en-US', dateFormatOptions).split('/').join('-');
+    if (!answers.proceed) {
+        throw new Error('Operation cancelled');
+    }
 
-        callback(null, answers);
-    });
+    answers.date = new Date().toLocaleString('en-US', dateFormatOptions).split('/').join('-');
+
+    return answers;
 }
 
 module.exports = askQuestions;

--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -20,7 +20,7 @@ module.exports = async () => {
     }
 
     try {
-        const answers = await util.promisify(askQuestions)(themeConfig, getGithubToken(), gitData.remotes);
+        const answers = await askQuestions(themeConfig, getGithubToken(), gitData.remotes);
 
         saveGithubToken(answers.githubToken);
 
@@ -28,7 +28,7 @@ module.exports = async () => {
 
         console.log('done'.green);
     } catch (err) {
-        return printError(err.message);
+        return printError(err.message || err);
     }
 };
 

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -1,18 +1,17 @@
 'use strict';
-var Fs = require('fs');
-var jsonLint = require('./json-lint');
-var Path = require('path');
-var Inquirer = require('inquirer');
-var themePath = process.cwd();
-var hoek = require('hoek');
-var configuration;
-var internals = {};
+const Fs = require('fs');
+const { promisify } = require("util");
+const Path = require('path');
+const Inquirer = require('inquirer');
+const hoek = require('hoek');
 
-internals.parseAnswers = function(JspmAssembler, ThemeConfig, dotStencilFile, dotStencilFilePath, answers) {
+const jsonLint = require('./json-lint');
+const themePath = process.cwd();
 
+async function performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotStencilFilePath, answers) {
     // Check for custom layout configurations
     // If already set, do nothing otherwise write the empty configurations
-    if (!dotStencilFile || dotStencilFile && !dotStencilFile.customLayouts) {
+    if (!stencilConfig || stencilConfig && !stencilConfig.customLayouts) {
         answers.customLayouts = {
             'brand': {},
             'category': {},
@@ -21,56 +20,45 @@ internals.parseAnswers = function(JspmAssembler, ThemeConfig, dotStencilFile, do
         };
     }
 
-    var defaults = dotStencilFile ? hoek.applyToDefaults(dotStencilFile, answers) : answers;
+    const performedStencilConfig = stencilConfig ? hoek.applyToDefaults(stencilConfig, answers) : answers;
 
-    Fs.writeFile(dotStencilFilePath, JSON.stringify(defaults, null, 2), function (err) {
-        var ready = 'You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan,
-            bundleTask;
+    Fs.writeFileSync(dotStencilFilePath, JSON.stringify(performedStencilConfig, null, 2));
+    const ready = 'You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan;
 
-        if (err) {
-            throw err;
+    // bundle dev dependencies
+    const themeConfig = ThemeConfig.getInstance(themePath).getConfig();
+    if (themeConfig.jspm) {
+        if (!Fs.existsSync(Path.join(themePath, themeConfig.jspm.jspm_packages_path))) {
+            console.log('Error: The path you specified for your "jspm_packages" folder does not exist.'.red);
+            return console.log(
+                'Please check your '.red +
+                'jspm.jspm_packages_path'.cyan +
+                ' setting in your theme\'s '.red +
+                'config.json'.cyan +
+                ' file to make sure it\'s correct.'.red,
+            );
         }
 
-        // bundle dev dependencies
-        configuration = ThemeConfig.getInstance(themePath).getConfig();
-        if (configuration.jspm) {
-            if (!Fs.existsSync(Path.join(themePath, configuration.jspm.jspm_packages_path))) {
-                console.log('Error: The path you specified for your "jspm_packages" folder does not exist.'.red);
-                return console.log(
-                    'Please check your '.red +
-                    'jspm.jspm_packages_path'.cyan +
-                    ' setting in your theme\'s '.red +
-                    'config.json'.cyan +
-                    ' file to make sure it\'s correct.'.red,
-                );
-            }
+        const bundleTask = promisify(JspmAssembler.assemble.bind(JspmAssembler));
+        await bundleTask(themeConfig.jspm, themePath);
+    }
 
-            bundleTask = JspmAssembler.assemble(configuration.jspm, themePath);
+    console.log(ready);
+}
 
-            bundleTask(function () {
-                console.log(ready);
-            });
-
-        } else {
-            console.log(ready);
-        }
-    });
-};
-
-internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
-    var dotStencilFile;
-    var questions;
+async function implementation(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
+    let stencilConfig;
 
     if (Fs.existsSync(dotStencilFilePath)) {
-        dotStencilFile = Fs.readFileSync(dotStencilFilePath, {encoding: 'utf-8'});
+        const dotStencilFile = Fs.readFileSync(dotStencilFilePath, { encoding: 'utf-8' });
         try {
-            dotStencilFile = jsonLint.parse(dotStencilFile, dotStencilFilePath);
+            stencilConfig = jsonLint.parse(dotStencilFile, dotStencilFilePath);
         } catch (e) {
             return console.error(e.fileName, e.stack);
         }
     }
 
-    questions = [
+    const questions = [
         {
             type: 'input',
             name: 'normalStoreUrl',
@@ -82,13 +70,13 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
                     return 'You must enter a URL';
                 }
             },
-            default: url || dotStencilFile && dotStencilFile.normalStoreUrl || undefined,
+            default: url || stencilConfig && stencilConfig.normalStoreUrl || undefined,
         },
         {
             type: 'input',
             name: 'accessToken',
             message: 'What is your Stencil OAuth Access Token?',
-            default: token || dotStencilFile && dotStencilFile.accessToken,
+            default: token || stencilConfig && stencilConfig.accessToken,
             filter: function(val) {
                 return val.trim();
             },
@@ -97,7 +85,7 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             type: 'input',
             name: 'port',
             message: 'What port would you like to run the server on?',
-            default: port || dotStencilFile && dotStencilFile.port || 3000,
+            default: port || stencilConfig && stencilConfig.port || 3000,
             validate: function (val) {
                 if (isNaN(val)) {
                     return 'You must enter an integer';
@@ -109,10 +97,9 @@ internals.implementation = function(JspmAssembler, ThemeConfig, dotStencilFilePa
             },
         },
     ];
+    const answers = await Inquirer.prompt(questions);
 
-    Inquirer.prompt(questions, function(answers) {
-        internals.parseAnswers(JspmAssembler, ThemeConfig, dotStencilFile, dotStencilFilePath, answers);
-    });
-};
+    await performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotStencilFilePath, answers);
+}
 
-module.exports = internals.implementation;
+module.exports = implementation;

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -23,7 +23,6 @@ async function performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotSten
     const performedStencilConfig = stencilConfig ? hoek.applyToDefaults(stencilConfig, answers) : answers;
 
     Fs.writeFileSync(dotStencilFilePath, JSON.stringify(performedStencilConfig, null, 2));
-    const ready = 'You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan;
 
     // bundle dev dependencies
     const themeConfig = ThemeConfig.getInstance(themePath).getConfig();
@@ -42,19 +41,21 @@ async function performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotSten
         const bundleTask = promisify(JspmAssembler.assemble.bind(JspmAssembler));
         await bundleTask(themeConfig.jspm, themePath);
     }
-
-    console.log(ready);
 }
 
-async function implementation(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
+async function run(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
     let stencilConfig;
 
     if (Fs.existsSync(dotStencilFilePath)) {
         const dotStencilFile = Fs.readFileSync(dotStencilFilePath, { encoding: 'utf-8' });
         try {
             stencilConfig = jsonLint.parse(dotStencilFile, dotStencilFilePath);
-        } catch (e) {
-            return console.error(e.fileName, e.stack);
+        } catch (err) {
+            console.error(
+                'Detected a broken .stencil file: ',
+                err,
+                '\nThe file will be rewritten with your answers',
+            );
         }
     }
 
@@ -100,6 +101,11 @@ async function implementation(JspmAssembler, ThemeConfig, dotStencilFilePath, ur
     const answers = await Inquirer.prompt(questions);
 
     await performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotStencilFilePath, answers);
+
+    console.log('You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan);
 }
 
-module.exports = implementation;
+module.exports = {
+    performAnswers,
+    run,
+};

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -149,9 +149,9 @@ utils.notifyUserOfThemeLimitReachedIfNecessary = (options, callback) => {
     return async.nextTick(callback.bind(null, null, options));
 };
 
-utils.promptUserToDeleteThemesIfNecessary = (options, callback) => {
+utils.promptUserToDeleteThemesIfNecessary = async options => {
     if (!options.themeLimitReached) {
-        return async.nextTick(callback.bind(null, null, options));
+        return options;
     }
 
     if (options.deleteOldest) {
@@ -159,7 +159,8 @@ utils.promptUserToDeleteThemesIfNecessary = (options, callback) => {
             .filter(theme => theme.is_private && !theme.is_active)
             .map(theme => ({ uuid: theme.uuid, updated_at: new Date(theme.updated_at).valueOf() }))
             .reduce((prev, current) => prev.updated_at < current.updated_at ? prev : current);
-        return callback(null, Object.assign({}, options, { themeIdsToDelete: [oldestTheme.uuid] }));
+
+        return { ...options, themeIdsToDelete: [oldestTheme.uuid] };
     }
 
     const questions = [{
@@ -179,10 +180,9 @@ utils.promptUserToDeleteThemesIfNecessary = (options, callback) => {
             }
         },
     }];
+    const answers = await Inquirer.prompt(questions);
 
-    Inquirer.prompt(questions, answers => {
-        callback(null, Object.assign({}, options, answers));
-    });
+    return {...options, ...answers};
 };
 
 utils.deleteThemesIfNecessary = (options, callback) => {
@@ -271,21 +271,20 @@ utils.checkIfJobIsComplete = resultFilter => (options, callback) => {
     });
 };
 
-utils.promptUserWhetherToApplyTheme = (options, callback) => {
+utils.promptUserWhetherToApplyTheme = async options => {
     if (options.activate) {
-        callback(null, Object.assign({}, options, { applyTheme: true }));
-    } else {
-        const questions = [{
-            type: 'confirm',
-            name: 'applyTheme',
-            message: `Would you like to apply your theme to your store at ${options.config.normalStoreUrl}?`,
-            default: false,
-        }];
-
-        Inquirer.prompt(questions, answers => {
-            callback(null, Object.assign({}, options, { applyTheme: answers.applyTheme }));
-        });
+        return {...options, applyTheme: true };
     }
+
+    const questions = [{
+        type: 'confirm',
+        name: 'applyTheme',
+        message: `Would you like to apply your theme to your store at ${options.config.normalStoreUrl}?`,
+        default: false,
+    }];
+    const answers = await Inquirer.prompt(questions);
+
+    return { ...options, ...answers };
 };
 
 utils.getVariations = (options, callback) => {
@@ -317,25 +316,20 @@ utils.getVariations = (options, callback) => {
     });
 };
 
-utils.promptUserForVariation = (options, callback) => {
-    if (!options.applyTheme) {
-        return async.nextTick(callback.bind(null, null, options));
+utils.promptUserForVariation = async options => {
+    if (!options.applyTheme || options.variationId) {
+        return options;
     }
 
-    if (options.variationId) {
-        callback(null, options);
-    } else {
-        const questions = [{
-            type: 'list',
-            name: 'variationId',
-            message: 'Which variation would you like to apply?',
-            choices: options.variations.map(variation => ({ name: variation.name, value: variation.uuid })),
-        }];
+    const questions = [{
+        type: 'list',
+        name: 'variationId',
+        message: 'Which variation would you like to apply?',
+        choices: options.variations.map(variation => ({ name: variation.name, value: variation.uuid })),
+    }];
+    const answers = await Inquirer.prompt(questions);
 
-        Inquirer.prompt(questions, answers => {
-            callback(null, Object.assign({}, options, answers));
-        });
-    }
+    return { ...options, ...answers };
 };
 
 utils.requestToApplyVariationWithRetrys = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12938,48 +12938,119 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-      "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "requires": {
-        "ansi-regex": "^1.1.1",
-        "chalk": "^1.0.0",
-        "cli-width": "^1.0.1",
-        "figures": "^1.3.5",
-        "lodash": "^3.3.1",
-        "readline2": "^0.1.1",
-        "rx": "^2.4.3",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
-        "cli-width": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
         },
-        "rx": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY="
+        "cli-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        },
+        "run-async": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+          "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+        },
+        "rxjs": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -18621,35 +18692,6 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
-          }
-        }
-      }
-    },
-    "readline2": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-      "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-      "requires": {
-        "mute-stream": "0.0.4",
-        "strip-ansi": "^2.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
-        },
-        "mute-stream": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
-        },
-        "strip-ansi": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-          "requires": {
-            "ansi-regex": "^1.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "npm run lint && npm run run-tests",
-    "run-tests": "lab bin/ server/ lib/ tasks/ -t 80 -l -e 'development' -P spec",
+    "run-tests": "lab bin/ server/ lib/ tasks/ -t 80 -l -e 'development' -P spec --verbose",
     "test-cov-html": "lab bin/ server/ lib/ -r html -o coverage.html -P spec"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "hapi": "^8.4.0",
     "hoek": "^2.12.0",
     "image-size": "^0.4.0",
-    "inquirer": "^0.8.2",
+    "inquirer": "^7.3.3",
     "jsonlint": "^1.6.2",
     "jsonschema": "^1.0.2",
     "jspm": "^0.16.55",


### PR DESCRIPTION
#### What?

Bumped version of the outdated npm module "inquirer" to fix security vulnerabilities.
The newer version of the npm module lost the support of callbacks, so I had to update the corresponding parts of our code to use async/await instead of callbacks (the second commit).

Also, updated .eslinrc to allow newer JS syntax, esp. _Object spread operator_ which is supported by NodeJS v10 (the first commit).

#### Tickets / Documentation

This PR is a part of STRF-8574 (since there are going to be a lot of updates they will be split into several PRs).

