### PR TITLE
fix: strf-8574, remove redundant dependency "hoek"

### DIFF
--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -3,24 +3,21 @@ const Fs = require('fs');
 const { promisify } = require("util");
 const Path = require('path');
 const Inquirer = require('inquirer');
-const hoek = require('hoek');
 
 const jsonLint = require('./json-lint');
 const themePath = process.cwd();
 
 async function performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotStencilFilePath, answers) {
-    // Check for custom layout configurations
-    // If already set, do nothing otherwise write the empty configurations
-    if (!stencilConfig || stencilConfig && !stencilConfig.customLayouts) {
-        answers.customLayouts = {
+    const performedStencilConfig = {
+        customLayouts: {
             'brand': {},
             'category': {},
             'page': {},
             'product': {},
-        };
-    }
-
-    const performedStencilConfig = stencilConfig ? hoek.applyToDefaults(stencilConfig, answers) : answers;
+        },
+        ...stencilConfig,
+        ...answers,
+    };
 
     Fs.writeFileSync(dotStencilFilePath, JSON.stringify(performedStencilConfig, null, 2));
 
@@ -44,7 +41,7 @@ async function performAnswers(JspmAssembler, ThemeConfig, stencilConfig, dotSten
 }
 
 async function run(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, port) {
-    let stencilConfig;
+    let stencilConfig = {};
 
     if (Fs.existsSync(dotStencilFilePath)) {
         const dotStencilFile = Fs.readFileSync(dotStencilFilePath, { encoding: 'utf-8' });
@@ -71,13 +68,13 @@ async function run(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, p
                     return 'You must enter a URL';
                 }
             },
-            default: url || stencilConfig && stencilConfig.normalStoreUrl || undefined,
+            default: url || stencilConfig.normalStoreUrl,
         },
         {
             type: 'input',
             name: 'accessToken',
             message: 'What is your Stencil OAuth Access Token?',
-            default: token || stencilConfig && stencilConfig.accessToken,
+            default: token || stencilConfig.accessToken,
             filter: function(val) {
                 return val.trim();
             },
@@ -86,7 +83,7 @@ async function run(JspmAssembler, ThemeConfig, dotStencilFilePath, url, token, p
             type: 'input',
             name: 'port',
             message: 'What port would you like to run the server on?',
-            default: port || stencilConfig && stencilConfig.port || 3000,
+            default: port || stencilConfig.port || 3000,
             validate: function (val) {
                 if (isNaN(val)) {
                     return 'You must enter an integer';

--- a/lib/theme-config.js
+++ b/lib/theme-config.js
@@ -1,12 +1,11 @@
-var _ = require('lodash');
-var Fs = require('fs');
-var Hoek = require('hoek');
-var Path = require('path');
-var Glob = require('glob');
-var Async = require('async');
-var jsonLint = require('./json-lint');
+const _ = require('lodash');
+const Fs = require('fs');
+const Path = require('path');
+const Glob = require('glob');
+const Async = require('async');
+const jsonLint = require('./json-lint');
 
-var themeConfigInstance;
+let themeConfigInstance;
 
 module.exports.getInstance = getInstance;
 
@@ -54,10 +53,10 @@ function ThemeConfig(themePath) {
  * @returns {object}
  */
 ThemeConfig.prototype.getConfig = function () {
-    var config = this.getRawConfig();
-    var variation = getVariation(config, this.variationIndex);
+    const config = this.getRawConfig();
+    const variation = getVariation(config, this.variationIndex);
 
-    this.globalSettings = Hoek.clone(config.settings);
+    this.globalSettings = _.cloneDeep(config.settings);
 
     if (!this.currentVariationSettings) {
         this.currentVariationSettings = variation.settings;
@@ -69,8 +68,8 @@ ThemeConfig.prototype.getConfig = function () {
     config.autoprefixer_browsers = config.autoprefixer_browsers || ['> 1%', 'last 2 versions', 'Firefox ESR'];
 
     // Merge in the variation settings and images objects
-    config.settings = Hoek.applyToDefaults(config.settings || {}, this.currentVariationSettings);
-    config.images = Hoek.applyToDefaults(config.images || {}, variation.images);
+    config.settings = _.defaultsDeep(this.currentVariationSettings, config.settings || {});
+    config.images = _.defaultsDeep(variation.images, config.images || {});
     config.variationName = variation.name;
 
     return config;
@@ -84,8 +83,8 @@ ThemeConfig.prototype.getConfig = function () {
  * @returns {ThemeConfig}
  */
 ThemeConfig.prototype.updateConfig = function (newSettings, saveToFile) {
-    var rawConfig;
-    var variation;
+    let rawConfig;
+    let variation;
 
     // Remove all variation settings that match theme's settings
     this.currentVariationSettings = _.omit(newSettings, function (value, key) {
@@ -166,8 +165,8 @@ ThemeConfig.prototype.getVariation = function (variationIndex) {
  * @returns {ThemeConfig}
  */
 ThemeConfig.prototype.setVariationByName = function (variationName) {
-    var config = this.getRawConfig();
-    var variationIndex = 0;
+    const config = this.getRawConfig();
+    let variationIndex = 0;
 
     if (variationName) {
         variationIndex = _.findIndex(config.variations, function (variation) {
@@ -234,7 +233,7 @@ ThemeConfig.prototype.getVariationName = function () {
  * @return {Number}
  */
 ThemeConfig.prototype.getVariationCount = function () {
-    var variations = this.getConfig().variations;
+    const variations = this.getConfig().variations;
 
     if (!_.isArray(variations)) {
         return 0;
@@ -305,8 +304,8 @@ ThemeConfig.prototype.schemaTranslationsExists = function () {
  * @param {Function} callback
  */
 ThemeConfig.prototype.getSchema = function (callback) {
-    var themeSchemaContent;
-    var themeSchema;
+    let themeSchemaContent;
+    let themeSchema;
 
     try {
         themeSchemaContent = Fs.readFileSync(this.schemaPath, {encoding: 'utf-8'});
@@ -332,7 +331,7 @@ ThemeConfig.prototype.getSchema = function (callback) {
         }
 
         Async.map(files, fetchThemeSettings, function (err, themeSettings) {
-            var forceReloadIds = {};
+            let forceReloadIds = {};
 
             if (err) {
                 return callback(err);
@@ -361,11 +360,11 @@ ThemeConfig.prototype.getSchema = function (callback) {
  * @param  {Function} callback
  */
 function fetchThemeSettings(path, callback) {
-    var themeSettingsRegexPattern = /\Wtheme_settings\.(.+?)\W/g;
-    var themeSettings = {};
+    const themeSettingsRegexPattern = /\Wtheme_settings\.(.+?)\W/g;
+    const themeSettings = {};
 
     Fs.readFile(path, 'utf8', function (err, content) {
-        var match;
+        let match;
 
         if (err) {
             return callback(err);
@@ -377,7 +376,7 @@ function fetchThemeSettings(path, callback) {
 
         return callback(null, themeSettings);
     });
-};
+}
 
 /**
  * Get Schema Translations
@@ -385,8 +384,8 @@ function fetchThemeSettings(path, callback) {
  * @param {Function} callback
  */
 ThemeConfig.prototype.getSchemaTranslations = function(callback) {
-    var schemaTranslationsContent;
-    var schemaTranslations;
+    let schemaTranslationsContent;
+    let schemaTranslations;
 
     try {
         schemaTranslationsContent = Fs.readFileSync(this.schemaTranslationsPath, {encoding: 'utf-8'});
@@ -444,7 +443,7 @@ ThemeConfig.prototype.getRawSchemaTranslations = function() {
  * @returns {object}
  */
 function getVariation(config, variationIndex) {
-    var variation;
+    let variation;
 
     if (! _.isArray(config.variations) || config.variations.length === 0) {
         throw new Error(

--- a/lib/theme-config.spec.js
+++ b/lib/theme-config.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Code = require('code');
-const Hoek = require('hoek');
+const _ = require('lodash');
 const Lab = require('@hapi/lab');
 const Sinon = require('sinon');
 const Path = require('path');
@@ -122,7 +122,7 @@ describe('ThemeConfig', () => {
         lab.beforeEach(async () => {
             themeConfig = ThemeConfig.getInstance();
             config = themeConfig.getConfig();
-            originalSettings = Hoek.clone(config.settings);
+            originalSettings = _.cloneDeep(config.settings);
             newSettings = {
                 color: '#000000',
                 font: 'Sans Something',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "good-console": "^4.1.0",
     "graceful-fs": "^4.1.11",
     "hapi": "^8.4.0",
-    "hoek": "^2.12.0",
     "image-size": "^0.4.0",
     "inquirer": "^7.3.3",
     "jsonlint": "^1.6.2",

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Glue = require('glue');
-const Hoek = require('hoek');
 const Url = require('url');
 const manifest = require('./manifest');
 const logo = require('./lib/show-logo');
@@ -12,8 +11,6 @@ module.exports = (options, callback) => {
     const config = manifest.get('/');
     const parsedSecureUrl = Url.parse(options.dotStencilFile.storeUrl); //The url to a secure page (prompted as login page)
     const parsedNormalUrl = Url.parse(options.dotStencilFile.normalStoreUrl); //The host url of the homepage;
-
-    callback = Hoek.nextTick(callback);
 
     config.connections[0].port = options.dotStencilFile.port;
     config.plugins['./plugins/router/router.module'].storeUrl = parsedSecureUrl.protocol + '//' + parsedSecureUrl.host;
@@ -38,6 +35,5 @@ module.exports = (options, callback) => {
             console.log(logo);
             return callback(null, server);
         });
-
     });
 };

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -5,7 +5,6 @@ const Boom = require('@hapi/boom');
 const Cache = require('memory-cache');
 const Crypto = require('crypto');
 const Frontmatter = require('front-matter');
-const Hoek = require('hoek');
 const Path = require('path');
 const LangAssembler = require('../../../lib/lang-assembler');
 const Pkg = require('../../../package.json');
@@ -21,7 +20,7 @@ const internals = {
 };
 
 module.exports.register = function (server, options, next) {
-    internals.options = Hoek.applyToDefaults(internals.options, options);
+    internals.options = _.defaultsDeep(options, internals.options);
 
     server.expose('implementation', internals.implementation);
 
@@ -440,7 +439,7 @@ internals.getHeaders = function (request, options, config) {
     headers = {
         'stencil-cli': Pkg.version,
         'stencil-version': Pkg.config.stencil_version,
-        'stencil-options': JSON.stringify(Hoek.applyToDefaults(options, currentOptions)),
+        'stencil-options': JSON.stringify(_.defaultsDeep(currentOptions, options)),
         'accept-encoding': 'identity',
     };
 
@@ -454,7 +453,7 @@ internals.getHeaders = function (request, options, config) {
         headers['stencil-store-url'] = request.app.storeUrl;
     }
 
-    return Hoek.applyToDefaults(request.headers, headers);
+    return { ...request.headers, ...headers };
 };
 
 /**

--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -1,4 +1,4 @@
-const Hoek = require('hoek');
+const _ = require('lodash');
 const ThemeConfig = require('../../../lib/theme-config');
 const internals = {
     options: {
@@ -20,7 +20,7 @@ const internals = {
 };
 
 module.exports.register = function(server, options, next) {
-    internals.options = Hoek.applyToDefaults(internals.options, options);
+    internals.options = _.defaultsDeep(options, internals.options);
 
     server.ext('onRequest', function(request, reply) {
         request.app.storeUrl = internals.options.storeUrl;

--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -1,7 +1,7 @@
+const _ = require('lodash');
 const Boom = require('@hapi/boom');
 const CssAssembler = require('../../../lib/css-assembler');
 const Utils = require('../../lib/utils');
-const Hoek = require('hoek');
 const Path = require('path');
 const StencilStyles = require('@bigcommerce/stencil-styles');
 const internals = {
@@ -9,7 +9,7 @@ const internals = {
 };
 
 module.exports.register = function (server, options, next) {
-    internals.options = Hoek.applyToDefaults(internals.options, options);
+    internals.options = _.defaultsDeep(options, internals.options);
 
     server.expose('cssHandler', internals.cssHandler);
     server.expose('assetHandler', internals.assetHandler);


### PR DESCRIPTION
#### What?

Replaced usages of npm module "hoek" with "lodash" to avoid supporting 2 similar libraries.
Did it since "hoek" had security vulnerabilities and required updating the library to newer major versions anyway.

#### Tickets / Documentation

This PR is a part of STRF-8574 (since there are going to be a lot of updates they will be split into several PRs).
