### PR TITLE
refactor(stencil-init): improve code style and test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,14 @@
 
 Thanks for showing interest in contributing!
 
-The following is a set of guidelines for contributing to the Stencil CLI. These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to the Stencil CLI. These are just guidelines, not rules.
+Use your best judgment, and feel free to propose changes to this document in a pull request.
 
-By contributing to Stencil CLI, you agree that your contributions will be licensed as listed under the [README.md](https://github.com/bigcommerce/stencil-cli/blob/master/README.md).
+At the moment some parts of the project may be outdated and not follow these recommendations.
+They should be gradually refactored with time.
+
+By contributing to Stencil CLI, you agree that your contributions will be licensed as listed under the 
+[README.md](https://github.com/bigcommerce/stencil-cli/blob/master/README.md).
 
 #### Table of Contents
 
@@ -13,20 +18,35 @@ By contributing to Stencil CLI, you agree that your contributions will be licens
 [How Can I Contribute?](#how-can-i-contribute)
   * [Your First Code Contribution](#your-first-code-contribution)
   * [Pull Requests](#pull-requests)
+  * [Release stencil-cli](#release-stencil-cli)
 
 [Styleguides](#styleguides)
   * [Git Commit Messages](#git-commit-messages)
   * [JavaScript Styleguide](#javascript-styleguide)
+  * [Project best practices](#project-best-practices)
+
+[Implementation details](#implementation-details)
+  * [Project structure](#project-structure)
+
+## How Can I Contribute?
 
 ### Your First Code Contribution
 
-Unsure where to begin contributing to Stencil CLI? Check our [forums](https://forum.bigcommerce.com/s/group/0F91300000029tpCAA) or our [stackoverflow](https://stackoverflow.com/questions/tagged/bigcommerce) tag. 
+Unsure where to begin contributing to Stencil CLI? Check our [forums](https://forum.bigcommerce.com/s/group/0F91300000029tpCAA),
+[Github issues](https://github.com/bigcommerce/stencil-cli/issues), or our
+[stackoverflow](https://stackoverflow.com/questions/tagged/bigcommerce) tag. 
 
 ### Pull Requests
 
 * Fill in [the required template](https://github.com/bigcommerce/stencil-cli/pull/new/master)
 * Include screenshots and animated GIFs in your pull request whenever possible.
 * End files with a newline.
+
+### Release stencil-cli
+In order to release stencil-cli you should first use the `Squash and merge` option on GitHub, This step is important
+for generating the `CHANGELOG.md` file with the PR link attached (if not using `Squash and merge`, the changes will
+be logged only with links to the commits). After the changes are merged to master, pull the latest to your local
+environment, run `gulp release` and follow the prompts.
 
 ## Styleguides
 
@@ -41,3 +61,41 @@ Unsure where to begin contributing to Stencil CLI? Check our [forums](https://fo
 ### JavaScript Styleguide
 
 All JavaScript must adhere to [AirBnB Javascript Styleguide](https://github.com/airbnb/javascript).
+
+Additionally:
+- Prefer async/await to callbacks.
+- Class dependencies with side effects (e.g. "fs" has side effects, "lodash" - hasn't) should be
+explicitly passed to the constructor so that they can be mocked in unit tests.
+
+### Project best practices
+
+**CLI commands:**
+
+Entry point is located at `/bin`. The file with entry point should only read the CLI arguments and
+call a corresponding CLI-command-class with the implementation located at `/lib`. CLI-command-class uses
+dependency injection throughout constructor, the main method runs other methods-tasks. Tasks are aimed to be pure and
+use context (this) only for external dependencies (logger, fs, etc).
+
+Shared logic and tasks should be moved out from the CLI-command-classes to separate service classes.
+
+E.g.: [stencil-init](/bin/stencil-init).
+
+**Local server:**
+
+Hapi server plugins located at `/server/plugins` should have controller logic only. Business logic should be moved out to
+common entities located at `/lib`.
+
+## Implementation details
+
+### Project structure
+
+```
+.
+├── .github                  Templates for github documents
+├── bin                      Entry points for CLI commands
+├── server                   Local server
+├── tasks                    Gulp tasks
+├── test                     Common entities and helpers used for tests
+├── lib                      Source code for all other entities
+└── constants.js             Common constants
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Stencil CLI
 
-[![npm (scoped)](https://img.shields.io/npm/v/@bigcommerce/stencil-cli.svg)](https://www.npmjs.com/package/@bigcommerce/stencil-cli) [![Travis](https://travis-ci.org/bigcommerce/stencil-cli.svg?branch=master)](https://travis-ci.org/bigcommerce/stencil-cli) [![AppVeyor](https://ci.appveyor.com/api/projects/status/jejnlajci3dslwfx?svg=true)](https://ci.appveyor.com/project/BigCommerceEngineering/stencil-cli)
-
+[![npm (scoped)](https://img.shields.io/npm/v/@bigcommerce/stencil-cli.svg)](https://www.npmjs.com/package/@bigcommerce/stencil-cli) 
+[![Travis](https://travis-ci.org/bigcommerce/stencil-cli.svg?branch=master)](https://travis-ci.org/bigcommerce/stencil-cli) 
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/jejnlajci3dslwfx?svg=true)](https://ci.appveyor.com/project/BigCommerceEngineering/stencil-cli)
 
 The BigCommerce server emulator for local theme development.
 
@@ -10,7 +11,8 @@ _Note: Stencil requires the Node.js runtime environment, version 10.x We do not 
 
 Run `npm install -g @bigcommerce/stencil-cli`.
 
-Visit the [installation guide](https://developer.bigcommerce.com/stencil-docs/getting-started/installing-stencil) for more details.
+Visit the [installation guide](https://developer.bigcommerce.com/stencil-docs/getting-started/installing-stencil)
+for more details.
 
 ## Usage
 
@@ -38,23 +40,34 @@ Run `stencil start` to run a local server so you can start developing your theme
 
 Run with `-o` or `--open` to automatically open up a browser.
 
-- While stencil is running, you can type "rs" and then hit enter to auto-reload all browsers. This is similar to Nodemon's rs option.
+- While stencil is running, you can type "rs" and then hit enter to auto-reload all browsers. This is similar to
+Nodemon's rs option.
 
 Run `stencil bundle` to validate your code and create a zip bundle file that can be uploaded to BigCommerce.
 
-Run `stencil release` to tag a new version of your theme, create a [GitHub release](https://help.github.com/articles/about-releases/) in your theme repository, and upload the zip bundle file to the release assets. This is useful for tracking your changes in your Theme, and is the tool we use to create new releases in BigCommerce [Cornerstone](https://github.com/bigcommerce/stencil) theme.
+Run `stencil release` to tag a new version of your theme, create a [GitHub release](https://help.github.com/articles/about-releases/)
+in your theme repository, and upload the zip bundle file to the release assets.
+This is useful for tracking your changesin your Theme, and is the tool we use to create new releases in BigCommerce
+[Cornerstone](https://github.com/bigcommerce/stencil) theme.
 
-## BrowserSync
+## Features
 
-Stencil CLI comes packaged with BrowserSync so you can take advantage of all of those amazing goodies! Have a look at their [web site](http://www.browsersync.io/) for more information.
+### BrowserSync
 
-## Sass compiling
+Stencil CLI comes packaged with BrowserSync so you can take advantage of all of those amazing goodies!
+Have a look at their [web site](http://www.browsersync.io/) for more information.
 
-You can compile Sass (node-sass) scss files in assets/scss into CSS. For example, add an scss file named theme.scss to assets/scss and `{{{stylesheet 'assets/css/theme.css'}}}` to your theme HTML template. Stencil-CLI will compile assets/scss/theme.scss to CSS on the fly.
+### Sass compiling
 
-## Autoprefixer
+You can compile Sass (node-sass) scss files in assets/scss into CSS. For example, add an scss file named theme.scss
+to assets/scss and `{{{stylesheet 'assets/css/theme.css'}}}` to your theme HTML template. Stencil-CLI will compile
+assets/scss/theme.scss to CSS on the fly.
 
-Stencil CLI comes packaged with [Autoprefixer](https://github.com/postcss/autoprefixer). You can set which browsers should be targeted, as well as if it should cascade the generated rules in the theme's config.json file with these options:
+### Autoprefixer
+
+Stencil CLI comes packaged with [Autoprefixer](https://github.com/postcss/autoprefixer). You can set which browsers
+should be targeted, as well as if it should cascade the generated rules in the theme's config.json file with these
+options:
 
 - `autoprefixer_cascade` - Defaults to `true`.
 - `autoprefixer_browsers` - Defaults to `["> 1%", "last 2 versions", "Firefox ESR"]`.
@@ -63,8 +76,10 @@ Stencil CLI comes packaged with [Autoprefixer](https://github.com/postcss/autopr
 
 If you need any help or experience any bugs, please create a GitHub issue in this repository.
 
-## Release stencil-cli
-In order to release stencil-cli you should first use the `Squash and merge` option on GitHub, This step is important for generating the `CHANGELOG.md` file with the pr link attached (if not using `Squash and merge`, the changes will be logged only with links to the commits). After the changes are merged to master, pull the latest to your local environment, run `gulp release` and follow the prompts. NOTE: It is required that all commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) structure.
+## Development
+
+If you would like to improve this project check out the [Contributing Guide](./CONTRIBUTING.md). Also, you can find
+the implementation details there.
 
 ## License
 

--- a/bin/stencil-init
+++ b/bin/stencil-init
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 require('colors');
+const Program = require('commander');
+const _ = require('lodash');
+
 const StencilInit = require('../lib/stencil-init');
 const pkg = require('../package.json');
-const Program = require('commander');
-const dotStencilFilePath = './.stencil';
 const versionCheck = require('../lib/version-check');
 
 Program
@@ -18,4 +19,7 @@ if (!versionCheck()) {
     return;
 }
 
-StencilInit.run(dotStencilFilePath, Program.url, Program.token, Program.port);
+const dotStencilFilePath = './.stencil';
+const cliOptions = _.pick(Program, ['url', 'token', 'port']);
+
+new StencilInit().run(dotStencilFilePath, cliOptions);

--- a/constants.js
+++ b/constants.js
@@ -2,4 +2,14 @@ const path = require('path');
 const packagePath = path.join(process.cwd(), 'package.json');
 const packageInfo = require(packagePath);
 
-module.exports =  { packageInfo };
+const DEFAULT_CUSTOM_LAYOUTS_CONFIG = {
+    'brand': {},
+    'category': {},
+    'page': {},
+    'product': {},
+};
+
+module.exports =  {
+    packageInfo,
+    DEFAULT_CUSTOM_LAYOUTS_CONFIG,
+};

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -1,87 +1,144 @@
 'use strict';
-const Fs = require('fs');
-const Inquirer = require('inquirer');
+const fsModule = require('fs');
+const inquirerModule = require('inquirer');
 
-const jsonLint = require('./json-lint');
+const serverConfigModule = require('../server/config');
+const jsonLintModule = require('./json-lint');
+const { DEFAULT_CUSTOM_LAYOUTS_CONFIG } = require("../constants");
 
-async function performAnswers(stencilConfig, dotStencilFilePath, answers) {
-    const performedStencilConfig = {
-        customLayouts: {
-            'brand': {},
-            'category': {},
-            'page': {},
-            'product': {},
-        },
-        ...stencilConfig,
-        ...answers,
-    };
-
-    Fs.writeFileSync(dotStencilFilePath, JSON.stringify(performedStencilConfig, null, 2));
-}
-
-async function run(dotStencilFilePath, url, token, port) {
-    let stencilConfig = {};
-
-    if (Fs.existsSync(dotStencilFilePath)) {
-        const dotStencilFile = Fs.readFileSync(dotStencilFilePath, { encoding: 'utf-8' });
-        try {
-            stencilConfig = jsonLint.parse(dotStencilFile, dotStencilFilePath);
-        } catch (err) {
-            console.error(
-                'Detected a broken .stencil file: ',
-                err,
-                '\nThe file will be rewritten with your answers',
-            );
-        }
+class StencilInit {
+    /**
+     * @param inquirer
+     * @param jsonLint
+     * @param fs
+     * @param serverConfig
+     * @param logger
+     */
+    constructor ({
+        inquirer = inquirerModule,
+        jsonLint = jsonLintModule,
+        fs = fsModule,
+        serverConfig = serverConfigModule,
+        logger = console,
+    } = {}) {
+        this.inquirer = inquirer;
+        this.jsonLint = jsonLint;
+        this.logger = logger;
+        this.fs = fs;
+        this.serverConfig = serverConfig;
     }
 
-    const questions = [
-        {
-            type: 'input',
-            name: 'normalStoreUrl',
-            message: 'What is the URL of your store\'s home page?',
-            validate: function (val) {
-                if (/^https?:\/\//.test(val)) {
-                    return true;
-                } else {
-                    return 'You must enter a URL';
-                }
-            },
-            default: url || stencilConfig.normalStoreUrl,
-        },
-        {
-            type: 'input',
-            name: 'accessToken',
-            message: 'What is your Stencil OAuth Access Token?',
-            default: token || stencilConfig.accessToken,
-            filter: function(val) {
-                return val.trim();
-            },
-        },
-        {
-            type: 'input',
-            name: 'port',
-            message: 'What port would you like to run the server on?',
-            default: port || stencilConfig.port || 3000,
-            validate: function (val) {
-                if (isNaN(val)) {
-                    return 'You must enter an integer';
-                } else if (val < 1024 || val > 65535) {
-                    return 'The port number must be between 1025 and 65535';
-                } else {
-                    return true;
-                }
-            },
-        },
-    ];
-    const answers = await Inquirer.prompt(questions);
+    /**
+     * @param {string} dotStencilFilePath
+     * @param {object} cliOptions
+     * @param {string} cliOptions.url
+     * @param {string} cliOptions.token
+     * @param {number} cliOptions.port
+     * @returns {Promise<void>}
+     */
+    async run (dotStencilFilePath, cliOptions = {}) {
+        const oldStencilConfig = this.readStencilConfig(dotStencilFilePath);
+        const defaultAnswers = this.getDefaultAnswers(oldStencilConfig, cliOptions);
+        const answers = await this.askQuestions(defaultAnswers);
+        const updatedStencilConfig = this.applyAnswers(oldStencilConfig, answers);
+        this.saveStencilConfig(updatedStencilConfig, dotStencilFilePath);
 
-    await performAnswers(stencilConfig, dotStencilFilePath, answers);
+        this.logger.log('You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan);
+    }
 
-    console.log('You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan);
+    /**
+     * @param {string} dotStencilFilePath
+     * @returns {object}
+     */
+    readStencilConfig (dotStencilFilePath) {
+        if (this.fs.existsSync(dotStencilFilePath)) {
+            const dotStencilFile = this.fs.readFileSync(dotStencilFilePath, { encoding: 'utf-8' });
+            try {
+                // We use jsonLint.parse instead of JSON.parse because jsonLint throws errors with better explanations what is wrong
+                return this.jsonLint.parse(dotStencilFile, dotStencilFilePath);
+            } catch (err) {
+                this.logger.error(
+                    'Detected a broken .stencil file:\n',
+                    err,
+                    '\nThe file will be rewritten with your answers',
+                );
+            }
+        }
+
+        return {};
+    }
+
+    /**
+     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} stencilConfig
+     * @param {{port: (number), url: (string), token: (string)}} cliOptions
+     * @returns {{port: (number), normalStoreUrl: (string), accessToken: (string)}}
+     */
+    getDefaultAnswers (stencilConfig, cliOptions) {
+        return {
+            normalStoreUrl: cliOptions.url || stencilConfig.normalStoreUrl,
+            accessToken: cliOptions.token || stencilConfig.accessToken,
+            port: cliOptions.port || stencilConfig.port || this.serverConfig.get('/server/port'),
+        };
+    }
+
+    /**
+     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} defaultAnswers
+     * @returns {Promise<object>}
+     */
+    async askQuestions (defaultAnswers) {
+        return await this.inquirer.prompt([
+            {
+                type: 'input',
+                name: 'normalStoreUrl',
+                message: 'What is the URL of your store\'s home page?',
+                validate: val => /^https?:\/\//.test(val) || 'You must enter a URL',
+                default: defaultAnswers.normalStoreUrl,
+            },
+            {
+                type: 'input',
+                name: 'accessToken',
+                message: 'What is your Stencil OAuth Access Token?',
+                default: defaultAnswers.accessToken,
+                filter: val => val.trim(),
+            },
+            {
+                type: 'input',
+                name: 'port',
+                message: 'What port would you like to run the server on?',
+                default: defaultAnswers.port,
+                validate: val => {
+                    if (isNaN(val)) {
+                        return 'You must enter an integer';
+                    } else if (val < 1024 || val > 65535) {
+                        return 'The port number must be between 1025 and 65535';
+                    } else {
+                        return true;
+                    }
+                },
+            },
+        ]);
+    }
+
+    /**
+     * @param {object} stencilConfig
+     * @param {object} answers
+     * @returns {object}
+     */
+    applyAnswers (stencilConfig, answers) {
+        return {
+            customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG,
+            ...stencilConfig,
+            ...answers,
+        };
+    }
+
+    /**
+     * @param {object} config
+     * @param {string} path
+     */
+    saveStencilConfig (config, path) {
+        this.fs.writeFileSync(path, JSON.stringify(config, null, 2));
+    }
 }
 
-module.exports = {
-    performAnswers,
-    run,
-};
+module.exports = StencilInit;

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -1,52 +1,343 @@
 'use strict';
 
+const _ = require('lodash');
 const Code = require('code');
 const Sinon = require('sinon');
 const Lab = require('@hapi/lab');
-const Fs = require('fs');
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const Inquirer = require('inquirer');
-const expect = Code.expect;
-const it = lab.it;
+const fs = require('fs');
+const inquirer = require('inquirer');
+
+const jsonLint = require('./json-lint');
+const serverConfig = require('../server/config');
 const StencilInit = require('./stencil-init');
+const { DEFAULT_CUSTOM_LAYOUTS_CONFIG } = require('../constants');
+const { assertNoMutations } = require('../test/assertions/assertNoMutations');
 
-describe('stencil init', () => {
-    let sandbox;
-    let consoleErrorStub;
-    let inquirerPromptStub;
+const { afterEach, beforeEach, describe, it } = exports.lab = Lab.script();
+const { expect }  = Code;
 
-    lab.beforeEach(() => {
-        sandbox = Sinon.createSandbox();
+const getStencilConfig = () => ({
+    customLayouts: {
+        brand: {
+            a: 'aaaa',
+        },
+        category: {},
+        page: {
+            b: 'bbbb',
+        },
+        product: {},
+    },
+    normalStoreUrl: "https://url-from-stencilConfig.mybigcommerce.com",
+    port: 3001,
+    accessToken: "accessToken_from_stencilConfig",
+    githubToken: "githubToken_1234567890",
+});
+const getAnswers = () => ({
+    normalStoreUrl: "https://url-from-answers.mybigcommerce.com",
+    port: 3003,
+    accessToken: "accessToken_from_answers",
+});
+const getCliOptions = () => ({
+    url: "https://url-from-cli-options.mybigcommerce.com",
+    port: 3002,
+    token: "accessToken_from_CLI_options",
+});
 
-        sandbox.stub(console, 'log');
-        consoleErrorStub = sandbox.stub(console, 'error');
+afterEach(() => Sinon.restore());
 
-        inquirerPromptStub = sandbox.stub(Inquirer, 'prompt');
-        inquirerPromptStub.returns({});
+describe('StencilInit integration tests:', () => {
+    describe('run', async () => {
+        it('should perform all the actions, save the result and inform the user about the successful finish', async () => {
+            const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
+            const answers = getAnswers();
+            const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...answers }, null, 2);
+            const fsWriteFileSyncStub = Sinon.stub(fs, "writeFileSync");
+            const inquirerPromptStub = Sinon.stub(inquirer, 'prompt').returns(answers);
+            const consoleErrorStub = Sinon.stub(console, 'error');
+            const consoleLogStub = Sinon.stub(console, 'log');
 
-        sandbox.stub(Fs, 'writeFileSync');
+            // Test with real entities, just some methods stubbed
+            const instance = new StencilInit({
+                inquirer,
+                jsonLint,
+                fs,
+                serverConfig,
+                logger: console,
+            });
+            await instance.run(dotStencilFilePath, getCliOptions());
+
+            expect(fsWriteFileSyncStub.calledOnce).to.be.true();
+            expect(inquirerPromptStub.calledOnce).to.be.true();
+            expect(consoleErrorStub.calledOnce).to.be.false();
+            expect(consoleLogStub.calledOnce).to.be.true();
+
+            expect(fsWriteFileSyncStub.lastCall.args).to.equal([dotStencilFilePath, expectedResult]);
+            expect(consoleLogStub.calledWith('You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan)).to.be.true();
+        });
+    });
+});
+
+describe('StencilInit unit tests:', () => {
+    const serverConfigPort = 3000;
+    const dotStencilFilePath = '/some/test/path/dotStencilFile.json';
+    let consoleStub;
+    let inquirerStub;
+    let jsonLintStub;
+    let fsStub;
+    let serverConfigStub;
+    let getStencilInitInstance;
+
+    beforeEach(() => {
+        consoleStub = {
+            log: Sinon.stub(),
+            error: Sinon.stub(),
+        };
+        inquirerStub = {
+            prompt: Sinon.stub().returns(getAnswers()),
+        };
+        jsonLintStub = {
+            parse: Sinon.stub().returns(getStencilConfig()),
+        };
+        fsStub = {
+            existsSync: Sinon.stub(),
+            readFileSync: Sinon.stub(),
+            writeFileSync: Sinon.stub(),
+        };
+        serverConfigStub = {
+            get: Sinon.stub().callsFake(prop => {
+                return ({
+                    '/server/port': serverConfigPort,
+                })[prop];
+            }),
+        };
+
+        getStencilInitInstance = () => new StencilInit({
+            inquirer: inquirerStub,
+            jsonLint: jsonLintStub,
+            fs: fsStub,
+            serverConfig: serverConfigStub,
+            logger: consoleStub,
+        });
     });
 
-    lab.afterEach(() => {
-        sandbox.restore();
+    describe('constructor', () => {
+        it('should create an instance of StencilInit without options parameters passed', async () => {
+            const instance = new StencilInit();
+
+            expect(instance).to.be.instanceOf(StencilInit);
+        });
+
+        it('should create an instance of StencilInit with options parameters passed', async () => {
+            const instance = getStencilInitInstance();
+
+            expect(instance).to.be.instanceOf(StencilInit);
+        });
     });
 
-    it('Should call prompt on run and not log errors if the .stencil file is valid', async () => {
-        const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
+    describe('readStencilConfig ', async () => {
+        it('should return an empty config if the file doesn\'t exist', async () => {
+            const instance = getStencilInitInstance();
+            fsStub.existsSync.returns(false);
 
-        await StencilInit.run(dotStencilFilePath);
+            const res = instance.readStencilConfig(dotStencilFilePath);
 
-        expect(consoleErrorStub.calledOnce).to.be.false();
-        expect(inquirerPromptStub.calledOnce).to.be.true();
+            expect(fsStub.existsSync.calledOnce).to.be.true();
+            expect(res).to.equal({});
+        });
+
+        it('should read the file and return parsed results if the file exists and it is valid', async () => {
+            const parsedConfig = getStencilConfig();
+            const serializedConfig = JSON.stringify(parsedConfig, null, 2);
+            const instance = getStencilInitInstance();
+            fsStub.existsSync.returns(true);
+            fsStub.readFileSync.returns(serializedConfig);
+            jsonLintStub.parse.returns(parsedConfig);
+
+            const res = instance.readStencilConfig(dotStencilFilePath);
+
+            expect(fsStub.existsSync.calledOnce).to.be.true();
+            expect(fsStub.readFileSync.calledOnce).to.be.true();
+            expect(jsonLintStub.parse.calledOnce).to.be.true();
+            expect(consoleStub.error.calledOnce).to.be.false();
+
+            expect(fsStub.existsSync.calledWith(dotStencilFilePath)).to.be.true();
+            expect(fsStub.readFileSync.calledWith(dotStencilFilePath, { encoding: 'utf-8' })).to.be.true();
+            expect(jsonLintStub.parse.calledWith(serializedConfig, dotStencilFilePath)).to.be.true();
+
+            expect(res).to.equal(parsedConfig);
+        });
+
+        it('should read the file, inform the user that the file is broken and return an empty config', async () => {
+            const serializedConfig = '{ I am broken! }';
+            const thrownError = new Error('invalid file');
+            const instance = getStencilInitInstance();
+            fsStub.existsSync.returns(true);
+            fsStub.readFileSync.returns(serializedConfig);
+            jsonLintStub.parse.throws(thrownError);
+
+            const res = instance.readStencilConfig(dotStencilFilePath);
+
+            expect(fsStub.existsSync.calledOnce).to.be.true();
+            expect(fsStub.readFileSync.calledOnce).to.be.true();
+            expect(jsonLintStub.parse.calledOnce).to.be.true();
+            expect(consoleStub.error.calledOnce).to.be.true();
+
+            expect(fsStub.existsSync.calledWith(dotStencilFilePath)).to.be.true();
+            expect(fsStub.readFileSync.calledWith(dotStencilFilePath, { encoding: 'utf-8' })).to.be.true();
+            expect(jsonLintStub.parse.calledWith(serializedConfig, dotStencilFilePath)).to.be.true();
+
+            expect(res).to.equal({});
+        });
     });
 
-    it('Should inform the user if the .stencil file is broken but continue running', async () => {
-        const dotStencilFilePath = './test/_mocks/malformedSchema.json';
+    describe('getDefaultAnswers', async () => {
+        it('should not mutate the passed objects', async () => {
+            const stencilConfig = getStencilConfig();
+            const cliOptions = getCliOptions();
+            const instance = getStencilInitInstance();
 
-        await StencilInit.run(dotStencilFilePath);
+            await assertNoMutations(
+                [stencilConfig, cliOptions],
+                () => instance.getDefaultAnswers(stencilConfig, cliOptions),
+            );
+        });
 
-        expect(consoleErrorStub.calledOnce).to.be.true();
-        expect(inquirerPromptStub.calledOnce).to.be.true();
+        it('should pick values from cliOptions first if present', async () => {
+            const stencilConfig = getStencilConfig();
+            const cliOptions = getCliOptions();
+            const instance = getStencilInitInstance();
+
+            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
+
+            expect(res.normalStoreUrl).to.equal(cliOptions.url);
+            expect(res.accessToken).to.equal(cliOptions.token);
+            expect(res.port).to.equal(cliOptions.port);
+        });
+
+        it('should pick values from stencilConfig if cliOptions are empty', async () => {
+            const stencilConfig = getStencilConfig();
+            const cliOptions = {};
+            const instance = getStencilInitInstance();
+
+            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
+
+            expect(res.normalStoreUrl).to.equal(stencilConfig.normalStoreUrl);
+            expect(res.accessToken).to.equal(stencilConfig.accessToken);
+            expect(res.port).to.equal(stencilConfig.port);
+        });
+
+        it('should pick values from serverConfig if stencilConfig and cliOptions are empty', async () => {
+            const cliOptions = _.pick(getCliOptions(), ['url']);
+            const stencilConfig = _.pick(getStencilConfig(), ['accessToken']);
+            const instance = getStencilInitInstance();
+
+            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
+
+            expect(res.port).to.equal(serverConfigPort);
+
+            expect(res.normalStoreUrl).to.equal(cliOptions.url);
+            expect(res.accessToken).to.equal(stencilConfig.accessToken);
+        });
+    });
+
+    describe('askQuestions', async () => {
+        it('should call inquirer.prompt with correct arguments', async () => {
+            const defaultAnswers = getAnswers();
+            const instance = getStencilInitInstance();
+
+            await instance.askQuestions(defaultAnswers);
+
+            expect(inquirerStub.prompt.calledOnce).to.be.true();
+            // We compare the serialized results because the objects contain functions which hinders direct comparison
+            expect(JSON.stringify(inquirerStub.prompt.lastCall.args)).to.equal(JSON.stringify([[
+                {
+                    type: 'input',
+                    name: 'normalStoreUrl',
+                    message: 'What is the URL of your store\'s home page?',
+                    validate(val) {
+                        return /^https?:\/\//.test(val)
+                            ? true
+                            : 'You must enter a URL';
+                    },
+                    default: defaultAnswers.normalStoreUrl,
+                },
+                {
+                    type: 'input',
+                    name: 'accessToken',
+                    message: 'What is your Stencil OAuth Access Token?',
+                    default: defaultAnswers.accessToken,
+                    filter: val => val.trim(),
+                },
+                {
+                    type: 'input',
+                    name: 'port',
+                    message: 'What port would you like to run the server on?',
+                    default: defaultAnswers.port,
+                    validate: val => {
+                        if (isNaN(val)) {
+                            return 'You must enter an integer';
+                        } else if (val < 1024 || val > 65535) {
+                            return 'The port number must be between 1025 and 65535';
+                        } else {
+                            return true;
+                        }
+                    },
+                },
+            ]]));
+        });
+    });
+
+    describe('applyAnswers', async () => {
+        it('should not mutate the passed objects', async () => {
+            const stencilConfig = getStencilConfig();
+            const answers = getAnswers();
+            const instance = getStencilInitInstance();
+
+            await assertNoMutations(
+                [stencilConfig, answers],
+                () => instance.applyAnswers(stencilConfig, answers),
+            );
+        });
+
+        it('should correctly merge values from the passed objects', async () => {
+            const stencilConfig = getStencilConfig();
+            const answers = getAnswers();
+            const instance = getStencilInitInstance();
+
+            const res = instance.applyAnswers(stencilConfig, answers);
+
+            expect(res.normalStoreUrl).to.equal(answers.normalStoreUrl);
+            expect(res.accessToken).to.equal(answers.accessToken);
+            expect(res.port).to.equal(answers.port);
+
+            expect(res.githubToken).to.equal(stencilConfig.githubToken);
+            expect(res.customLayouts).to.equal(stencilConfig.customLayouts);
+        });
+
+        it('should add a customLayouts property with default empty values if it\'s absent in stencilConfig', async () => {
+            const stencilConfig = _.omit(getStencilConfig(), 'customLayouts');
+            const answers = getAnswers();
+            const instance = getStencilInitInstance();
+
+            const res = instance.applyAnswers(stencilConfig, answers);
+
+            expect(res.customLayouts).to.equal(DEFAULT_CUSTOM_LAYOUTS_CONFIG);
+            // Make sure that other props aren't overwritten:
+            expect(res.accessToken).to.equal(answers.accessToken);
+            expect(res.githubToken).to.equal(stencilConfig.githubToken);
+        });
+    });
+
+    describe('saveStencilConfig ', async () => {
+        it('should call fs.writeFileSync with the serialized config', async () => {
+            const stencilConfig = getStencilConfig();
+            const serializedConfig = JSON.stringify(stencilConfig, null, 2);
+            const instance = getStencilInitInstance();
+
+            instance.saveStencilConfig(stencilConfig, dotStencilFilePath);
+
+            expect(fsStub.writeFileSync.calledOnce).to.be.true();
+            expect(fsStub.writeFileSync.calledWith(dotStencilFilePath, serializedConfig)).to.be.true();
+        });
     });
 });

--- a/test/assertions/assertNoMutations.js
+++ b/test/assertions/assertNoMutations.js
@@ -1,0 +1,24 @@
+const Code = require('code');
+
+const { expect}  = Code;
+
+
+/** Asserts that all the passed entities weren't mutated after executing the passed procedure
+ *
+ * @param {object[]} entities
+ * @param {Function} procedure
+ * @returns {Promise<void>}
+ */
+async function assertNoMutations (entities, procedure) {
+    const entitiesBefore = entities.map(entity => JSON.stringify(entity));
+
+    await procedure();
+
+    entities.forEach((entity, i) => {
+        expect(entitiesBefore[i]).to.equal(JSON.stringify(entity));
+    });
+}
+
+module.exports = {
+    assertNoMutations,
+};


### PR DESCRIPTION
#### What?

Improved code style and test coverage related to the stencil-init CLI command.

This is kinda an example/template on how other CLI commands implementations can be done.
If our team members like this style - other modules can be gradually rewritten in the same way in the future too.

Considered designs:
1) Similar to [/lib/stencil-push.js](https://github.com/bigcommerce/stencil-cli/blob/master/lib/stencil-push.js): One entry function running all the tasks in async.waterfall([...]), each task returns an updated version of the passed options.
    - _Advantages_:
        - looks more elegant;
        - tasks may be shared between different CLI commands since they are pure functions and don’t depend on context (this);
    - _Disadvantages_:
        - different tasks usually need to work with different variables, which makes polluting the passed options with a lot of fields, some of them keep existing even if they are no longer needed;
        - tasks may accidentally/intentionally mutate the passed options which leads to bugs in other tasks;
        - each task is forced to accept an object with options and then return it even if these options aren't used which is redundant;
2) Current implementation: CLI command implementation is a class with dependency injection throughout constructor, the main method runs other methods-tasks, tasks are tried to be pure and use context (this) only for the injected dependencies (logger, serverConfig, etc). Shared tasks should be later moved out to separate service classes (e.g. SencilConfigManager).
    - _Advantages_:
        - no mess in the passed options;
        - methods-tasks take and return only needed data;
        - less prone to bugs;
    - _Disadvantages_:
        - need to refactor the CLI-command-classes sometimes moving out common tasks to separate service classes 

#### Tickets / Documentation

I partially refactored this module when working on [STRF-8589](https://jira.bigcommerce.com/browse/STRF-8589) and decided to fully rewrite it because I didn't like the style how it was written (procedural paradigm) + it had a low level of test coverage which was hard to increase due to the implementation.
