### PR TITLE
Resolve Schema Translation Error Logging

### DIFF
--- a/lib/bundle-validator.js
+++ b/lib/bundle-validator.js
@@ -175,9 +175,11 @@ function validateSchemaTranslations(callback) {
             errorMessage += '\r\nunused translation key "' + key + '"';
         });
 
-        validator.errors.forEach(error => {
-            errorMessage += '\r\nschemaTranslations' + error.message;
-        });
+        if (validator.errors && validator.errors.length) {
+            validator.errors.forEach(error => {
+                errorMessage += '\r\nschemaTranslations' + error.message;
+            });
+        }
 
         return callback(new Error(errorMessage.red));
     }


### PR DESCRIPTION
#### What?
Properly log out to the console if there is an unused translation key.

Schema Translation errors do not log to the console properly, making it difficult to debug what the actual issue is when you go to bundle a theme. This pull request allows for the correct translation error to log out by addressing a JavaScript error.

#### Tickets / Documentation

[609](https://github.com/bigcommerce/stencil-cli/issues/609)

#### Screenshots (if appropriate)

##### Before Fix
<img width="1092" alt="before fix" src="https://user-images.githubusercontent.com/47044676/90830112-f005d380-e2f5-11ea-901b-18deeee36b40.png">

##### After Fix
<img width="1091" alt="after fix" src="https://user-images.githubusercontent.com/47044676/90830105-ed0ae300-e2f5-11ea-91bf-dea1be337c45.png">
