### PR TITLE
feat: bump paper to rc30, release 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,11 +704,11 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.29.tgz",
-      "integrity": "sha512-0udUgzAIbzDvr1vg4d6WvY+FUcYKArqsKuEDIeo+eEer44gPnHDRfL84jidNhMDUNSJJ+yP5YjSFm4zj8P8rYQ==",
+      "version": "3.0.0-rc.30",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.30.tgz",
+      "integrity": "sha512-9JZMciMQu9G9Op+C5DAMBNEe3ua7MOkHITP47EuG2Mz9T42h5wBuxE6oSpbjMRP5CXFmdBZHVYPmTl7fNGrHmg==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "4.3.2",
+        "@bigcommerce/stencil-paper-handlebars": "4.4.0",
         "accept-language-parser": "~1.4.1",
         "lodash": "~3.10.1",
         "messageformat": "~0.2.2"
@@ -727,9 +727,9 @@
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.3.2.tgz",
-      "integrity": "sha512-Ja9nF0FHbH6I0Nwm8q6T87Xu2pX8YcQbms1Pn4jH9p512qS9w5+V0tgf4+DjrN2svTOLSSq7hUaphfgQL9zDGg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.4.0.tgz",
+      "integrity": "sha512-HOl/NdrPKS/uZYXx1lYMOdx9D9NvW9HTxVdvfJFn8sPLbHp9odmjwVcKN0gvBYMGE3BRKpu/LgS1zNCIoapxtQ==",
       "requires": {
         "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#v4.0.14",
         "handlebars": "3.0.7",
@@ -15396,9 +15396,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-cli",
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^3.0.0-rc.29",
+    "@bigcommerce/stencil-paper": "^3.0.0-rc.30",
     "@bigcommerce/stencil-styles": "1.2.1",
     "@hapi/boom": "^8.0.1",
     "@hapi/glue": "^6.2.0",


### PR DESCRIPTION
#### What?

Bump paper to rc30 to pull in more helpers

New helpers: https://github.com/bigcommerce/paper-handlebars/releases/tag/v4.4.0