### PR TITLE
feat: (strf-8674) update "async" npm package

### DIFF
--- a/bin/stencil-download.js
+++ b/bin/stencil-download.js
@@ -3,7 +3,6 @@
 require('colors');
 const inquirer = require('inquirer');
 const program = require('../lib/commander');
-const { promisify } = require("util");
 
 const { API_HOST, PACKAGE_INFO, DOT_STENCIL_FILE_PATH } = require('../constants');
 const stencilDownload = require('../lib/stencil-download');
@@ -50,7 +49,7 @@ async function run (opts) {
     console.log(`${'ok'.green} -- ${overwriteType} will be overwritten by change`);
 
     try {
-        await promisify(stencilDownload)(opts);
+        await stencilDownload(opts);
     } catch (err) {
         printCliResultError(err);
         return;

--- a/lib/stencil-download.js
+++ b/lib/stencil-download.js
@@ -6,16 +6,15 @@ let stencilDownloadUtil = require('./stencil-download.utils');
 
 module.exports = stencilDownload;
 
-function stencilDownload(options, callback) {
-    async.waterfall(
-        [
-            async.constant(options),
-            stencilPushUtils.readStencilConfigFile,
-            stencilPushUtils.getStoreHash,
-            stencilPushUtils.getThemes,
-            stencilPullUtils.selectActiveTheme,
-            stencilPullUtils.startThemeDownloadJob,
-            stencilPushUtils.pollForJobCompletion(({download_url: downloadUrl}) => ({downloadUrl})),
-            stencilDownloadUtil.downloadThemeFiles,
-        ], callback);
+function stencilDownload(options) {
+    return async.waterfall([
+        async.constant(options),
+        stencilPushUtils.readStencilConfigFile,
+        stencilPushUtils.getStoreHash,
+        stencilPushUtils.getThemes,
+        stencilPullUtils.selectActiveTheme,
+        stencilPullUtils.startThemeDownloadJob,
+        stencilPushUtils.pollForJobCompletion(({ download_url: downloadUrl }) => ({ downloadUrl })),
+        stencilDownloadUtil.downloadThemeFiles,
+    ]);
 }

--- a/lib/stencil-push.spec.js
+++ b/lib/stencil-push.spec.js
@@ -3,7 +3,7 @@
 const fetchMock = require('node-fetch');
 const { promisify } = require('util');
 
-const StencilPush = require('./stencil-push');
+const stencilPush = require('./stencil-push');
 const utils = require('./stencil-push.utils.js');
 const { MockDB } = require('../test/_mocks/MockDB');
 
@@ -36,17 +36,15 @@ describe('stencil push', () => {
         mockDb.data = {};
     });
 
-    it('should throw an error if dotStencilFilePath is not provided', () => {
-        const throws = () => {
-            StencilPush();
-        };
-
-        expect(throws).toThrow('dotStencilFilePath is required!');
+    it('should throw an error if dotStencilFilePath is not provided', async () => {
+        await expect(
+            promisify(stencilPush)({}),
+        ).rejects.toThrow('dotStencilFilePath is required!');
     });
 
     it('should return an error if dotStencilFilePath does not map to a file', async () => {
         await expect(
-            promisify(StencilPush)({ dotStencilFilePath: 'DNE' }),
+            promisify(stencilPush)({ dotStencilFilePath: 'DNE' }),
         ).rejects.toThrow(/ENOENT/);
     });
 
@@ -54,7 +52,7 @@ describe('stencil push', () => {
         const dotStencilFilePath = `${__dirname}/../test/_mocks/bin/dotStencilFile.json`;
 
         await expect(
-            promisify(StencilPush)({ dotStencilFilePath }),
+            promisify(stencilPush)({ dotStencilFilePath }),
         ).rejects.toThrow('Received empty store_hash value in the server response');
     });
 });

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -90,7 +90,7 @@ utils.generateBundle = (options, callback) => {
     };
 
     if (options.bundleZipPath) {
-        return async.nextTick(callback.bind(null, null, options));
+        return callback(null, options);
     }
 
     if (options.saveBundleName) {
@@ -134,12 +134,12 @@ utils.uploadBundle = async options => {
     }
 };
 
-utils.notifyUserOfThemeLimitReachedIfNecessary = (options, callback) => {
+utils.notifyUserOfThemeLimitReachedIfNecessary = async options => {
     if (options.themeLimitReached && !options.deleteOldest) {
         console.log('warning'.yellow + ` -- You have reached your upload limit.  In order to proceed, you'll need to delete at least one theme.`);
     }
 
-    return async.nextTick(callback.bind(null, null, options));
+    return options;
 };
 
 utils.promptUserToDeleteThemesIfNecessary = async options => {
@@ -198,17 +198,18 @@ utils.deleteThemesIfNecessary = async options => {
     return options;
 };
 
-utils.uploadBundleAgainIfNecessary = (options, callback) => {
+utils.uploadBundleAgainIfNecessary = async options => {
     if (!options.themeLimitReached) {
-        return async.nextTick(callback.bind(null, null, options));
+        return options;
     }
 
-    utils.uploadBundle(options, callback);
+    return utils.uploadBundle(options);
 };
 
-utils.notifyUserOfThemeUploadCompletion = (options, callback) => {
+utils.notifyUserOfThemeUploadCompletion = async options => {
     console.log('ok'.green + ' -- Theme Upload Finished');
-    return async.nextTick(callback.bind(null, null, options));
+
+    return options;
 };
 
 utils.markJobProgressPercentage = percentComplete => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3599,12 +3599,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-done": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "accept-language-parser": "^1.5.0",
     "ajv": "^6.12.4",
     "archiver": "^5.0.0",
-    "async": "^2.4.0",
+    "async": "^3.2.0",
     "browser-sync": "^2.26.12",
     "cheerio": "^0.22.0",
     "colors": "^1.4.0",


### PR DESCRIPTION
#### What?

Updated "async" npm package. Figured out that there were almost no breaking changes for us, [apart form one test](https://github.com/bigcommerce/stencil-cli/compare/master...MaxGenash:STRF-8674_update_async?expand=1#diff-1e2ce63b00bff55f2e0bb165bd286bc5R45). While reviewing all the usages of the library I removed redundant usages of async.nextTick. Also, since in async.js v3 all methods return promise if no callback was passed - I removed promisify in ` bin/stencil-download.js`.

Actually, at the moment maojirty (if not all) of the usages of async.js can be replaced with native means (async/await, Promise.all, for...await..of, etc.), but it will take several days, so I didn’t do it here, but we can do it in a separate ticket.

#### Tickets / Documentation
 
STRF-8674