### PR TITLE
fix: (strf-8705) fix broken headers and cookies in local server

### DIFF
--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -3,13 +3,15 @@ const uuidRegExp = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-([0-9a-f]{12
 /**
  * Strip domain from the cookies header string
  *
- * @param {string} cookies
- * @returns {string}
+ * @param {string[]} cookies
+ * @returns {string[]}
  */
 function stripDomainFromCookies(cookies) {
-    return cookies
-        .replace(/(?:;\s)?domain=(?:.+?)(;|$)/gi, '$1')
-        .replace(new RegExp('; SameSite=none', 'gi'), '');
+    return cookies.map((val) =>
+        val
+            .replace(/(?:;\s)?domain=(?:.+?)(;|$)/gi, '$1')
+            .replace(new RegExp('; SameSite=none', 'gi'), ''),
+    );
 }
 
 /**
@@ -30,7 +32,7 @@ function normalizeRedirectUrl(request, redirectUrl) {
     }
 
     if (stripHost) {
-        return redirectUrlObj.path;
+        return redirectUrlObj.pathname + redirectUrlObj.search + redirectUrlObj.hash;
     }
     return redirectUrl;
 }

--- a/server/plugins/renderer/renderer.module.spec.js
+++ b/server/plugins/renderer/renderer.module.spec.js
@@ -2,11 +2,30 @@ const fetchMock = require('node-fetch');
 const path = require('path');
 
 const Server = require('../../index');
+const ThemeConfig = require('../../../lib/theme-config');
+const { PACKAGE_INFO } = require('../../../constants');
+
+const themeConfigManager = ThemeConfig.getInstance(
+    path.join(process.cwd(), 'test/_mocks/themes/valid'),
+);
 
 // eslint-disable-next-line node/no-unpublished-require,global-require
 jest.mock('node-fetch', () => require('fetch-mock-jest').sandbox());
 
 describe('Renderer Plugin', () => {
+    const storeUrl = 'https://store-abc123.mybigcommerce.com';
+    const normalStoreUrl = 'http://s123456789.mybigcommerce.com';
+    const serverOptions = {
+        dotStencilFile: {
+            storeUrl,
+            normalStoreUrl,
+            port: 4000,
+            username: 'testUser',
+            token: '6832b1c755bb9de13aa8990216a69a7623043fd7',
+        },
+        useCache: false,
+        themePath: themeConfigManager.themePath,
+    };
     let server;
 
     beforeAll(async () => {
@@ -14,19 +33,7 @@ describe('Renderer Plugin', () => {
         jest.spyOn(console, 'log').mockImplementation(jest.fn());
         jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
-        const options = {
-            dotStencilFile: {
-                storeUrl: 'https://store-abc123.mybigcommerce.com',
-                normalStoreUrl: 'http://s123456789.mybigcommerce.com',
-                port: 4000,
-                username: 'testUser',
-                token: '6832b1c755bb9de13aa8990216a69a7623043fd7',
-            },
-            useCache: false,
-            themePath: path.join(process.cwd(), 'test/_mocks/themes/valid'),
-        };
-
-        server = await Server.create(options);
+        server = await Server.create(serverOptions);
 
         // Don't log errors during the test
         server.ext('onPostHandler', (request, h) => {
@@ -46,64 +53,214 @@ describe('Renderer Plugin', () => {
         await server.stop();
     });
 
-    it('should handle fatal errors in the BCApp request', async () => {
-        const options = {
+    it('should handle fatal errors in the storefront server response', async () => {
+        const browserRequest = {
             method: 'GET',
             url: '/test',
         };
         fetchMock.mock('*', { throws: new Error('failure') });
 
-        const response = await server.inject(options);
+        const localServerResponse = await server.inject(browserRequest);
 
-        expect(response.statusCode).toEqual(500);
+        expect(localServerResponse.statusCode).toEqual(500);
     });
 
-    it('should handle responses of a 500 in the BCApp request', async () => {
-        const options = {
+    it('should handle status 500 in the storefront server response', async () => {
+        const browserRequest = {
             method: 'GET',
             url: '/',
         };
         fetchMock.mock('*', 500);
 
-        const response = await server.inject(options);
+        const localServerResponse = await server.inject(browserRequest);
 
-        expect(response.statusCode).toEqual(500);
+        expect(localServerResponse.statusCode).toEqual(500);
     });
 
-    it('should handle redirects in the BCApp request', async () => {
-        const options = {
-            method: 'GET',
-            url: '/',
-        };
-        const redirectResponse = {
-            status: 301,
+    describe('when the storefront server response is Redirect', () => {
+        const browserRequest = {
+            method: 'post',
+            url: '/login.php?action=check_login',
+            payload: 'login_email=user%40gmail.com&login_pass=12345678&authenticity_token=abcdefg',
             headers: {
-                location: 'http://www.example.com/',
+                'content-type': 'application/x-www-form-urlencoded',
             },
         };
-        fetchMock.mock('*', redirectResponse);
 
-        const response = await server.inject(options);
+        const redirectLocationPath = '/account.php?action=order_status#first';
+        const storefrontResponseHeaders = new fetchMock.Headers({
+            location: `${normalStoreUrl}${redirectLocationPath}`,
+        });
+        // Fetch.Headers have implementation problem that it joins headers with that same name,
+        //  so we have to set an array directly to the raw value
+        storefrontResponseHeaders.raw()['set-cookie'] = [
+            'SHOP_SESSION_TOKEN=aaaaaaaaaaaaaa; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly; SameSite=none',
+            'fornax_anonymousId=bbbbbbbbbbbbbb; expires=Wed, 05-Oct-2022 17:40:04 GMT; path=/; Secure; SameSite=none',
+            'RECENTLY_VIEWED_PRODUCTS=cccccccc; expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/; Secure; SameSite=none',
+            'SHOP_TOKEN=dddddddddddddddddddddd; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly; SameSite=none',
+        ];
+        let localServerResponse;
 
-        expect(response.statusCode).toEqual(301);
-        expect(response.headers.location).toEqual(redirectResponse.headers.location);
+        beforeEach(async () => {
+            fetchMock.mock('*', {
+                status: 301,
+                headers: storefrontResponseHeaders,
+            });
+
+            localServerResponse = await server.inject(browserRequest);
+        });
+
+        it('should send a request to the storefront server with correct url', async () => {
+            expect(fetchMock.lastUrl()).toEqual(`${storeUrl}${browserRequest.url}`);
+        });
+
+        it('should pass request method from the browser request to the storefront server request', async () => {
+            expect(fetchMock.lastOptions().method).toEqual(browserRequest.method);
+        });
+
+        it('should pass body from the browser request to the storefront server request', async () => {
+            expect(fetchMock.lastOptions().body).toEqual(browserRequest.payload);
+        });
+
+        it('should send a request to the storefront server with correct headers', async () => {
+            expect(fetchMock.lastOptions().headers).toMatchObject({
+                'content-type': 'application/x-www-form-urlencoded',
+                host: new URL(storeUrl).host,
+                'stencil-cli': PACKAGE_INFO.version,
+                'stencil-options': '{"get_template_file":true,"get_data_only":true}',
+                'stencil-version': PACKAGE_INFO.config.stencil_version,
+                'accept-encoding': 'identity',
+            });
+        });
+
+        it('should avoid automatic handling of redirects by fetch library', async () => {
+            expect(fetchMock.lastOptions().redirect).toEqual('manual');
+        });
+
+        it('should return a correct status code', async () => {
+            expect(localServerResponse.statusCode).toEqual(301);
+        });
+
+        it("should return a location header value equal to the URL's path if the URL's host equal to the storeURL", async () => {
+            expect(localServerResponse.headers.location).toEqual(redirectLocationPath);
+        });
+
+        it('should return an array of set-cookie headers with removed "Secure" and "SameSite" settings', async () => {
+            expect(localServerResponse.headers['set-cookie']).toEqual([
+                'SHOP_SESSION_TOKEN=aaaaaaaaaaaaaa; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; HttpOnly',
+                'fornax_anonymousId=bbbbbbbbbbbbbb; expires=Wed, 05-Oct-2022 17:40:04 GMT; path=/',
+                'RECENTLY_VIEWED_PRODUCTS=cccccccc; expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/',
+                'SHOP_TOKEN=dddddddddddddddddddddd; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; HttpOnly',
+            ]);
+        });
     });
 
-    it('should handle unauthorized in the Stapler Request', async () => {
-        const options = {
+    it('should handle Unauthorized in the storefront server response', async () => {
+        const browserRequest = {
             method: 'GET',
             url: '/',
         };
-        const unauthorizedResponse = {
+        const storefrontServerResponse = {
             status: 401,
             headers: {
-                location: 'http://www.example.com/',
+                'content-type': 'text/html',
             },
         };
-        fetchMock.mock('*', unauthorizedResponse);
+        fetchMock.mock('*', storefrontServerResponse);
 
-        const response = await server.inject(options);
+        const localServerResponse = await server.inject(browserRequest);
 
-        expect(response.statusCode).toEqual(401);
+        expect(localServerResponse.statusCode).toEqual(401);
+    });
+
+    describe('when the storefront server response is Success and content-type is not JSON', () => {
+        const browserRequest = {
+            method: 'get',
+            url: '/checkout.php',
+            headers: {
+                cookie: 'bcactive=yes; lastVisitedCategory=23; STORE_VISITOR=1',
+            },
+        };
+
+        const storefrontResponseHeaders = new fetchMock.Headers({
+            'content-type': 'text/html; charset=utf-8',
+        });
+        // Fetch.Headers have implementation problem that it joins headers with that same name,
+        //  so we have to set an array directly to the raw value
+        storefrontResponseHeaders.raw()['set-cookie'] = [
+            'SHOP_SESSION_TOKEN=aaaaaaaaaaaaaa; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly; SameSite=none',
+            'fornax_anonymousId=bbbbbbbbbbbbbb; expires=Wed, 05-Oct-2022 17:40:04 GMT; path=/; Secure; SameSite=none',
+            'RECENTLY_VIEWED_PRODUCTS=cccccccc; expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/; Secure; SameSite=none',
+            'SHOP_TOKEN=dddddddddddddddddddddd; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly; SameSite=none',
+        ];
+        const storefrontServerResponse = {
+            status: 200,
+            headers: storefrontResponseHeaders,
+            body:
+                '<!DOCTYPE html>' +
+                '<html>' +
+                '<head>' +
+                '<title>Checkout</title>' +
+                '<body>' +
+                'Checkout page body' +
+                '</body>' +
+                '</html>',
+        };
+        let localServerResponse;
+
+        beforeEach(async () => {
+            fetchMock.mock('*', storefrontServerResponse);
+
+            localServerResponse = await server.inject(browserRequest);
+        });
+
+        it('should send a request to the storefront server with correct url', async () => {
+            expect(fetchMock.lastUrl()).toEqual(`${storeUrl}${browserRequest.url}`);
+        });
+
+        it('should pass request method from browser request to the storefront server request', async () => {
+            expect(fetchMock.lastOptions().method).toEqual(browserRequest.method);
+        });
+
+        it('should send a request to the storefront server with correct headers', async () => {
+            expect(fetchMock.lastOptions().headers).toMatchObject({
+                cookie: browserRequest.headers.cookie,
+                host: new URL(storeUrl).host,
+                'stencil-cli': PACKAGE_INFO.version,
+                'stencil-options': '{"get_template_file":true,"get_data_only":true}',
+                'stencil-version': PACKAGE_INFO.config.stencil_version,
+                'accept-encoding': 'identity',
+            });
+        });
+
+        it('should return a correct status code', async () => {
+            expect(localServerResponse.statusCode).toEqual(200);
+        });
+
+        it('should return correct headers', async () => {
+            expect(localServerResponse.headers).toMatchObject({
+                'content-type': storefrontServerResponse.headers.get('content-type'),
+                'set-cookie': [
+                    'SHOP_SESSION_TOKEN=aaaaaaaaaaaaaa; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly',
+                    'fornax_anonymousId=bbbbbbbbbbbbbb; expires=Wed, 05-Oct-2022 17:40:04 GMT; path=/; Secure',
+                    'RECENTLY_VIEWED_PRODUCTS=cccccccc; expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/; Secure',
+                    'SHOP_TOKEN=dddddddddddddddddddddd; expires=Mon, 12-Oct-2020 17:40:04 GMT; path=/; Secure; HttpOnly',
+                ],
+            });
+        });
+
+        it('should return a correct response body', async () => {
+            expect(localServerResponse.payload).toEqual(
+                '<!DOCTYPE html>' +
+                    '<html>' +
+                    '<head>' +
+                    '<title>Checkout</title>' +
+                    '<link href="/stencil/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000001/css/checkout.css" type="text/css" rel="stylesheet"></head>' +
+                    '<body>' +
+                    'Checkout page body' +
+                    '</body>' +
+                    '</html>',
+            );
+        });
     });
 });

--- a/server/plugins/renderer/responses/pencil-response.js
+++ b/server/plugins/renderer/responses/pencil-response.js
@@ -95,7 +95,21 @@ const makeDecorator = (request, context) => (content) => {
     return updatedContent;
 };
 
-class PencilResponce {
+class PencilResponse {
+    /**
+     * @param {Object} data
+     * @param data.template_file
+     * @param data.templates
+     * @param data.remote
+     * @param data.remote_data
+     * @param data.context
+     * @param data.translations
+     * @param data.method
+     * @param data.acceptLanguage
+     * @param {{[string]: string[]}} data.headers
+     * @param data.statusCode
+     * @param assembler
+     */
     constructor(data, assembler) {
         this.data = data;
         this.assembler = assembler;
@@ -153,4 +167,4 @@ class PencilResponce {
     }
 }
 
-module.exports = PencilResponce;
+module.exports = PencilResponse;

--- a/server/plugins/renderer/responses/raw-response.js
+++ b/server/plugins/renderer/responses/raw-response.js
@@ -9,7 +9,7 @@ const internals = {
 class RawResponse {
     /**
      * @param {buffer} data
-     * @param {object} headers
+     * @param {{[string]: string[]}} headers
      * @param {string} statusCode
      * @returns {object} response
      */
@@ -42,9 +42,18 @@ class RawResponse {
 
         const response = h.response(payload).code(this.statusCode);
 
-        for (const [name, value] of Object.entries(this.headers)) {
-            if (!['transfer-encoding', 'content-length'].includes(name)) {
-                response.header(name, value);
+        for (const [name, values] of Object.entries(this.headers)) {
+            switch (name) {
+                case 'transfer-encoding':
+                case 'content-length':
+                    break;
+                case 'set-cookie':
+                    // Cookies should be an array
+                    response.header('set-cookie', values);
+                    break;
+                default:
+                    // Other headers should be strings
+                    response.header(name, values.toString());
             }
         }
 

--- a/server/plugins/renderer/responses/redirect-response.js
+++ b/server/plugins/renderer/responses/redirect-response.js
@@ -1,7 +1,7 @@
 class RedirectResponse {
     /**
      * @param {string} location
-     * @param {Object} headers
+     * @param {{[string]: string[]}} headers
      * @param {number} statusCode
      */
     constructor(location, headers, statusCode) {
@@ -13,18 +13,24 @@ class RedirectResponse {
     respond(request, h) {
         const response = h.redirect(this.location).code(this.statusCode);
 
-        for (const [name, value] of Object.entries(this.headers)) {
+        for (const [name, values] of Object.entries(this.headers)) {
             switch (name) {
                 case 'transfer-encoding':
                     break;
                 case 'set-cookie':
+                    // Cookies should be an array
                     response.header(
                         'set-cookie',
-                        value.replace(/; Secure$/, '').replace(/; domain=(.+)$/, ''),
+                        values.map((val) =>
+                            val
+                                .replace(/; Secure/gi, '')
+                                .replace(/(?:;\s)?domain=(?:.+?)(;|$)/gi, ''),
+                        ),
                     );
                     break;
                 default:
-                    response.header(name, value);
+                    // Other headers should be strings
+                    response.header(name, values.toString());
             }
         }
 


### PR DESCRIPTION
#### What?

Fixed bugs in the local server:
1. Local server always returned empty headers because of the typo [in the code](https://github.com/bigcommerce/stencil-cli/compare/master...MaxGenash:STRF-8705_Bug_local_server_is_broken_after_updating_packages?expand=1#diff-596ce37f7ed6dc6ea50288ac9903be41L393) (should be `_.fromPairs(...response.headers.entries())` instead of `_.fromPairs(response.headers.entries())`).
2. Response headers 'set-cookies' were joined into a single string because of [a problem in node-fetch implementation](https://github.com/node-fetch/node-fetch/issues/251) which resulted in parsing the cookies by the browser incorrectly. To avoid it I started using response.headers.raw() which returns an internal raw map of headers.
3. Figured out that fetch handles redirects automatically by default in contrast with the previous library (wreck), which resulted in skipping processing of the redirect response headers and incorrect ultimate response. Hopefully, there is an option to [process the redirects manually](https://github.com/bigcommerce/stencil-cli/compare/master...MaxGenash:STRF-8705_Bug_local_server_is_broken_after_updating_packages?expand=1#diff-596ce37f7ed6dc6ea50288ac9903be41R81).
4. After we start using the WHATWG URL instead of the deprecated Node's "url" library we got a [typo of using the absent "path" property ](https://github.com/bigcommerce/stencil-cli/compare/master...MaxGenash:STRF-8705_Bug_local_server_is_broken_after_updating_packages?expand=1#diff-4645f2b850a88f2c4bfcf2908ff2fac5L33) in the redirect location header URL.

Covered these bugs with tests.

#### Tickets / Documentation

STRF-8705