### PR TITLE
fix: (strf-8734) fix a typo in renderer.module -> getTemplatePath()

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -325,11 +325,7 @@ internals.getTemplatePath = (requestPath, data) => {
         });
 
         if (templatePath) {
-            templatePath = requestPath.join(
-                'pages/custom',
-                pageType,
-                templatePath.replace(/\.html$/, ''),
-            );
+            templatePath = path.join('pages/custom', pageType, templatePath.replace(/\.html$/, ''));
         }
     }
 


### PR DESCRIPTION
#### What?

Fixed a typo in the code of getTemplatePath method of renderer.module.js.

Reason: there were similar names of the function argument (path) and module-level variable (Path) which got mixed-up after refactoring.

#### Tickets / Documentation

Ticket: STRF-8734
Issue: https://github.com/bigcommerce/stencil-cli/issues/654
