### PR TITLE
Strf-8740: Bugfix: stencil start yields "...templates are missing..." on themes files updates

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -1,5 +1,4 @@
 const upath = require('upath');
-const Readdir = require('recursive-readdir');
 const Archiver = require('archiver');
 const async = require('async');
 const crypto = require('crypto');
@@ -12,6 +11,7 @@ const Cycles = require('./Cycles');
 const cssAssembler = require('./css-assembler');
 const langAssembler = require('./lang-assembler');
 const templateAssembler = require('./template-assembler');
+const { recursiveReadDir } = require('./utils/fsUtils');
 const { fetchRegions } = require('./regions');
 
 const MEGABYTE = 1024 * 1024;
@@ -149,7 +149,7 @@ class Bundle {
     assembleTemplatesTask(callback) {
         console.log('Template Parsing Started...');
 
-        Readdir(this.templatesPath, ['!*.html'], (readdirError, files) => {
+        recursiveReadDir(this.templatesPath, ['!*.html'], (readdirError, files) => {
             if (readdirError) {
                 return callback(readdirError);
             }
@@ -228,7 +228,7 @@ class Bundle {
     generateManifest(taskResults, callback) {
         console.log('Generating Manifest Started...');
 
-        Readdir(this.templatesPath, ['!*.html'], (err, filePaths) => {
+        recursiveReadDir(this.templatesPath, ['!*.html'], (err, filePaths) => {
             if (err) {
                 return callback(err);
             }

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -1,7 +1,6 @@
 require('colors');
 const browserSyncInstance = require('browser-sync').create();
-const recursiveRead = require('recursive-readdir');
-const async = require('async');
+const { promisify } = require('util');
 const fetchModule = require('node-fetch');
 const fsModule = require('fs');
 const path = require('path');
@@ -29,6 +28,7 @@ class StencilStart {
         buildConfigManger = buildConfigManagerInstance,
         templateAssembler = templateAssemblerModule,
         CyclesDetector = Cycles,
+        logger = console,
     } = {}) {
         this.browserSync = browserSync;
         this.fetch = fetch;
@@ -39,6 +39,7 @@ class StencilStart {
         this.buildConfigManger = buildConfigManger;
         this.templateAssembler = templateAssembler;
         this.CyclesDetector = CyclesDetector;
+        this.logger = logger;
     }
 
     async run(cliOptions, dotStencilFilePath, stencilCliVersion) {
@@ -70,7 +71,7 @@ class StencilStart {
 
         await this.startLocalServer(cliOptions, updatedStencilConfig);
 
-        console.log(this.getStartUpInfo(updatedStencilConfig, dotStencilFilePath));
+        this.logger.log(this.getStartUpInfo(updatedStencilConfig, dotStencilFilePath));
 
         await this.startBrowserSync(cliOptions, updatedStencilConfig, browserSyncPort);
     }
@@ -186,7 +187,7 @@ class StencilStart {
         const storefrontConfigPath = path.join(themePath, '.config/storefront.json');
         this.browserSync.watch(storefrontConfigPath, (event, file) => {
             if (event === 'change') {
-                console.log('storefront.json changed');
+                this.logger.log('storefront.json changed');
                 this.browserSync.emitter.emit('storefront_config_file:changed', {
                     event,
                     path: file,
@@ -197,19 +198,13 @@ class StencilStart {
         });
 
         const templatesPath = path.join(themePath, 'templates');
-        this.browserSync.watch(templatesPath, { ignoreInitial: true }, () => {
-            this.assembleTemplates(templatesPath, (err, results) => {
-                if (err) {
-                    console.error(err);
-                    return;
-                }
-
-                try {
-                    new this.CyclesDetector(results).detect();
-                } catch (e) {
-                    console.error(e);
-                }
-            });
+        this.browserSync.watch(templatesPath, { ignoreInitial: true }, async () => {
+            try {
+                const results = await this.assembleTemplates(templatesPath);
+                new this.CyclesDetector(results).detect();
+            } catch (e) {
+                this.logger.error(e);
+            }
         });
 
         // tunnel value should be true/false or a string with name
@@ -256,26 +251,21 @@ class StencilStart {
 
     /**
      * Assembles all the needed templates and resolves their partials.
+     *
      * @param {string} templatesPath
-     * @param {function} callback
+     * @returns {object[]}
      */
-    assembleTemplates(templatesPath, callback) {
-        recursiveRead(templatesPath, ['!*.html'], (err, files) => {
-            const templateNames = files.map((file) =>
-                file.replace(templatesPath + path.sep, '').replace('.html', ''),
-            );
+    async assembleTemplates(templatesPath) {
+        const filesPaths = await this.fsUtils.recursiveReadDir(templatesPath, ['!*.html']);
+        const templateNames = filesPaths.map((file) =>
+            file.replace(templatesPath + path.sep, '').replace('.html', ''),
+        );
 
-            async.map(
-                templateNames,
-                this.templateAssembler.assemble.bind(null, templatesPath),
-                (err2, results) => {
-                    if (err2) {
-                        callback(err2);
-                    }
-                    callback(null, results);
-                },
-            );
-        });
+        return Promise.all(
+            templateNames.map(async (templateName) =>
+                promisify(this.templateAssembler.assemble)(templatesPath, templateName),
+            ),
+        );
     }
 
     /**

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -262,7 +262,7 @@ class StencilStart {
     assembleTemplates(templatesPath, callback) {
         recursiveRead(templatesPath, ['!*.html'], (err, files) => {
             const templateNames = files.map((file) =>
-                file.replace(templatesPath + templatesPath.sep, '').replace('.html', ''),
+                file.replace(templatesPath + path.sep, '').replace('.html', ''),
             );
 
             async.map(

--- a/lib/stencil-start.spec.js
+++ b/lib/stencil-start.spec.js
@@ -1,0 +1,123 @@
+const fetchMockModule = require('fetch-mock-jest');
+const path = require('path');
+
+const StencilStart = require('./stencil-start');
+
+afterAll(() => jest.restoreAllMocks());
+
+describe('StencilStart unit tests', () => {
+    const getBrowserSyncStub = () => ({
+        watch: jest.fn(),
+        init: jest.fn(),
+    });
+    const getFetchStub = () => fetchMockModule.sandbox();
+    const getFsStub = () => ({
+        existsSync: jest.fn(),
+    });
+    const getFsUtilsStub = () => ({
+        parseJsonFile: jest.fn(),
+        recursiveReadDir: jest.fn(),
+    });
+    const getCliCommonStub = () => ({
+        checkNodeVersion: jest.fn(),
+    });
+    const getThemeConfigManagerStub = () => ({});
+    const getBuildConfigMangerStub = () => ({});
+    const getTemplateAssemblerStub = () => ({});
+    const getCyclesDetectorConstructorStub = () => jest.fn();
+    const getLoggerStub = () => ({
+        log: jest.fn(),
+        error: jest.fn(),
+    });
+
+    const createStencilStartInstance = ({
+        browserSync,
+        fetch,
+        fs,
+        fsUtils,
+        cliCommon,
+        themeConfigManager,
+        buildConfigManger,
+        templateAssembler,
+        CyclesDetector,
+        logger,
+    } = {}) => {
+        const passedArgs = {
+            browserSync: browserSync || getBrowserSyncStub(),
+            fetch: fetch || getFetchStub(),
+            fs: fs || getFsStub(),
+            fsUtils: fsUtils || getFsUtilsStub(),
+            cliCommon: cliCommon || getCliCommonStub(),
+            themeConfigManager: themeConfigManager || getThemeConfigManagerStub(),
+            buildConfigManger: buildConfigManger || getBuildConfigMangerStub(),
+            templateAssembler: templateAssembler || getTemplateAssemblerStub(),
+            CyclesDetector: CyclesDetector || getCyclesDetectorConstructorStub(),
+            logger: logger || getLoggerStub(),
+        };
+        const instance = new StencilStart(passedArgs);
+
+        return {
+            passedArgs,
+            instance,
+        };
+    };
+
+    describe('constructor', () => {
+        it('should create an instance of StencilStart without options parameters passed', async () => {
+            const instance = new StencilStart();
+
+            expect(instance).toBeInstanceOf(StencilStart);
+        });
+
+        it('should create an instance of StencilStart with all options parameters passed', async () => {
+            const { instance } = createStencilStartInstance();
+
+            expect(instance).toBeInstanceOf(StencilStart);
+        });
+    });
+
+    describe('assembleTemplates method', () => {
+        it('should obtain names of all templates in the passed templatesPath and return results of call templateAssembler.assemble for each template name', async () => {
+            const templatesPath = '/some/absolute/templates/path';
+            const templateNamesMock = ['layout/base', 'pages/page1'];
+            const filesPathsMock = [
+                templatesPath + path.sep + templateNamesMock[0] + '.html',
+                templatesPath + path.sep + templateNamesMock[1] + '.html',
+            ];
+            const templateAssemblerResults = [
+                {
+                    [templateNamesMock[0]]: 'html file content 1',
+                },
+                {
+                    [templateNamesMock[0]]: 'html file content 1',
+                    [templateNamesMock[1]]: 'html file content 2',
+                },
+            ];
+            const fsUtilsStub = {
+                recursiveReadDir: jest.fn().mockResolvedValue(filesPathsMock),
+            };
+            const templateAssemblerStub = {
+                assemble: jest
+                    .fn()
+                    .mockImplementationOnce((p, n, cb) => cb(null, templateAssemblerResults[0]))
+                    .mockImplementationOnce((p, n, cb) => cb(null, templateAssemblerResults[1])),
+            };
+
+            const { instance } = createStencilStartInstance({
+                fsUtils: fsUtilsStub,
+                templateAssembler: templateAssemblerStub,
+            });
+            const result = await instance.assembleTemplates(templatesPath);
+
+            expect(fsUtilsStub.recursiveReadDir).toHaveBeenCalledTimes(1);
+            expect(fsUtilsStub.recursiveReadDir).toHaveBeenCalledWith(templatesPath, ['!*.html']);
+
+            expect(templateAssemblerStub.assemble.mock.calls).toEqual([
+                [templatesPath, templateNamesMock[0], expect.any(Function)],
+                [templatesPath, templateNamesMock[1], expect.any(Function)],
+            ]);
+
+            expect(result).toStrictEqual(templateAssemblerResults);
+        });
+    });
+});

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -3,6 +3,7 @@
  */
 
 const fs = require('fs');
+const recursiveReadDir = require('recursive-readdir');
 const jsonLint = require('../json-lint');
 
 /**
@@ -17,4 +18,5 @@ async function parseJsonFile(filePath) {
 
 module.exports = {
     parseJsonFile,
+    recursiveReadDir,
 };


### PR DESCRIPTION
#### What?

- Fixed a typo in the code of StencilStart.assembleTemplates(), which caused the bug. Reason: there were similar names of the function argument (path->templatesPath) and module-level variable (Path->path) which got mixed-up after refactoring several PRs ago.
- Covered StencilStart.assembleTemplates() with tests to avoid such bugs in the future.
- Refactored StencilStart.assembleTemplates() and related code to get rid of callbacks and make the testing easier.

#### Tickets / Documentation

Ticket: STRF-8740
Issue: https://github.com/bigcommerce/stencil-cli/issues/656
