### PR TITLE
fix: added missed linting step to GitHub actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set a consistent line-ending styles across different OS to avoid problems with linters
+* text eol=lf

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -41,5 +41,8 @@ jobs:
             - name: Install Dependencies
               run: npm i
 
+            - name: Lint the code
+              run: npm run lint
+
             - name: Run tests
               run: npm test

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -45,4 +45,4 @@ jobs:
               run: npm run lint
 
             - name: Run tests
-              run: npm test
+              run: npm run test-with-coverage


### PR DESCRIPTION
#### What?

in https://github.com/bigcommerce/stencil-cli/pull/648 we moved from Travis+Appveyour to Github actions, but missed the linting step in the new CI/CD config, so I added it back here.

**Upd**: also added .gitattributes to fix problems with prettier on Windows https://stackoverflow.com/a/55998281/9193658 .

And updated the testing step to check test coverage