### PR TITLE
STRF-6905: stencil release did not update version number in package lock

### DIFF
--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -21,7 +21,7 @@ async function saveGithubToken(githubToken) {
 
     data.githubToken = githubToken;
 
-    await this.stencilConfigManager.save(data);
+    await stencilConfigManager.save(data);
 }
 
 async function getGithubToken() {

--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -188,7 +188,7 @@ function checkGitData(gitData) {
 }
 
 async function commitAndPush(version, remote) {
-    await git.add(['config.json', 'package.json', 'CHANGELOG.md']);
+    await git.add(['config.json', 'package.json', 'package-lock.json', 'CHANGELOG.md']);
     const summary = await git.commit(`Releasing ${version}`);
 
     console.log(`Pushing Changes to ${remote.name}...`);
@@ -204,6 +204,7 @@ async function doRelease(options) {
 
     await bumpJsonFileVersion(themeConfigManager.configPath, options.version);
     await bumpJsonFileVersion(path.join(THEME_PATH, 'package.json'), options.version);
+    await bumpJsonFileVersion(path.join(THEME_PATH, 'package-lock.json'), options.version);
 
     const bundlePath = await bundleTheme();
 

--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -56,16 +56,16 @@ async function createGithubRelease(commit, version, changelog, remote, bundlePat
     const release = await github.repos.createRelease(releaseParams);
     const themeName = await themeConfigManager.getName();
 
+    console.log('Uploading Bundle File...');
+
+    const zipFile = await fs.promises.readFile(bundlePath);
     const uploadParams = {
         release_id: release.data.id,
         owner: remote.owner,
         repo: remote.repo,
-        data: bundlePath,
+        data: zipFile,
         name: `${themeName}-${version}.zip`,
     };
-
-    console.log('Uploading Bundle File...');
-
     const asset = await github.repos.uploadReleaseAsset(uploadParams);
 
     console.log(`Release url: ${release.data.html_url.green}`);


### PR DESCRIPTION
#### What?

- Added missing updating of version in package-lock.json.
- Fixed typo in the code 
- Fixed uploading broken bundle archive (it uploaded just a string with pathname instead of the archive itself) to Github

#### Tickets / Documentation

STRF-6905
