### PR TITLE
fix:(STRF-8909) theme variation not applied with activate flag

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -311,7 +311,7 @@ utils.getVariations = async (options) => {
         return { ...options, variationId: foundVariation.uuid };
     }
     if (activate) {
-        const indexofVariationToActivate = variations.findIndex(variation => variation.name === activate);
+        const indexofVariationToActivate = variations.findIndex((variation) => variation.name === activate);
         if (indexofVariationToActivate === -1) {
             const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
             throw new Error(

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -311,7 +311,6 @@ utils.getVariations = async (options) => {
         return { ...options, variationId: foundVariation.uuid };
     }
     if (activate) {
-        // Activate the theme variant with the name matches the CLI argument
         const indexofVariationToActivate = variations.findIndex(variation => variation.name == activate);
         if (indexofVariationToActivate === -1) {
             const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -311,7 +311,9 @@ utils.getVariations = async (options) => {
         return { ...options, variationId: foundVariation.uuid };
     }
     if (activate) {
-        const indexofVariationToActivate = variations.findIndex((variation) => variation.name === activate);
+        const indexofVariationToActivate = variations.findIndex(
+            (variation) => variation.name === activate,
+        );
         if (indexofVariationToActivate === -1) {
             const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
             throw new Error(

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -311,7 +311,7 @@ utils.getVariations = async (options) => {
         return { ...options, variationId: foundVariation.uuid };
     }
     if (activate) {
-        const indexofVariationToActivate = variations.findIndex(variation => variation.name == activate);
+        const indexofVariationToActivate = variations.findIndex(variation => variation.name === activate);
         if (indexofVariationToActivate === -1) {
             const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
             throw new Error(

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -311,7 +311,15 @@ utils.getVariations = async (options) => {
         return { ...options, variationId: foundVariation.uuid };
     }
     if (activate) {
-        return { ...options, variationId: variations[0].uuid };
+        // Activate the theme variant with the name matches the CLI argument
+        const indexofVariationToActivate = variations.findIndex(variation => variation.name == activate);
+        if (indexofVariationToActivate === -1) {
+            const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
+            throw new Error(
+                `Invalid theme variation provided!. Available options ${availableOptionsStr}...`,
+            );
+        }
+        return { ...options, variationId: variations[indexofVariationToActivate].uuid };
     }
 
     return { ...options, variations };

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -298,31 +298,25 @@ utils.getVariations = async (options) => {
         storeHash,
     });
 
-    if (!activate && activate !== undefined) {
+    // Activate the default variation
+    if (activate === true) {
+        return { ...options, variationId: variations[0].uuid };
+    }
+    // Activate the specified variation
+    if (activate !== undefined) {
         const foundVariation = variations.find((item) => item.name === activate);
 
         if (!foundVariation || !foundVariation.uuid) {
             const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
             throw new Error(
-                `Invalid theme variation provided!. Available options ${availableOptionsStr}...`,
+                `Invalid theme variation provided! Available options: ${availableOptionsStr}.`,
             );
         }
 
         return { ...options, variationId: foundVariation.uuid };
     }
-    if (activate) {
-        const indexofVariationToActivate = variations.findIndex(
-            (variation) => variation.name === activate,
-        );
-        if (indexofVariationToActivate === -1) {
-            const availableOptionsStr = variations.map((item) => `${item.name}`).join(', ');
-            throw new Error(
-                `Invalid theme variation provided!. Available options ${availableOptionsStr}...`,
-            );
-        }
-        return { ...options, variationId: variations[indexofVariationToActivate].uuid };
-    }
 
+    // Didn't specify a variation explicitly, will ask the user later
     return { ...options, variations };
 };
 


### PR DESCRIPTION
#### What?

The --activate flag should allow for the user to specify the theme variation to apply when pushing a theme, e.g. `stencil push --activate Warm` However, the first theme variation is always applied. The variation parameter form the CLI is ignored. 

#### Tickets / Documentation

STRF-8909

#### Screenshots (if appropriate)

BEFORE: The variation specified in the CLI is ignored. The first variation in the list is always applied.

<img width="1662" alt="Screen Shot 2021-01-13 at 4 19 54 PM" src="https://user-images.githubusercontent.com/5630999/104517347-74196a00-55bb-11eb-8f7a-49da1f61b261.png">


AFTER: The variation specified in the CLI is applied when using the --activate flag

<img width="1676" alt="Screen Shot 2021-01-13 at 4 17 08 PM" src="https://user-images.githubusercontent.com/5630999/104517445-9d39fa80-55bb-11eb-9a6d-093d338d0c04.png">

