### PR TITLE
fix(stencil-push): (STRF-8913) increase maxBodyLength in NetworkUtils.sendApiRequest

### DIFF
--- a/lib/utils/NetworkUtils.js
+++ b/lib/utils/NetworkUtils.js
@@ -35,6 +35,8 @@ class NetworkUtils {
     async sendApiRequest(options) {
         const { accessToken, ...restOpts } = options;
         const reqConfig = {
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
             httpsAgent: this._httpsAgent,
             ...restOpts,
             headers: {

--- a/lib/utils/NetworkUtils.spec.js
+++ b/lib/utils/NetworkUtils.spec.js
@@ -28,6 +28,8 @@ describe('NetworkUtils', () => {
             expect(axiosMock).toHaveBeenCalledWith({
                 url,
                 httpsAgent: httpsAgentMock,
+                maxContentLength: Infinity,
+                maxBodyLength: Infinity,
                 headers: {
                     'x-auth-client': 'stencil-cli',
                     'stencil-cli': packageInfoMock.version,
@@ -62,6 +64,8 @@ describe('NetworkUtils', () => {
             expect(axiosMock).toHaveBeenCalledWith({
                 url,
                 httpsAgent: httpsAgentMock,
+                maxContentLength: Infinity,
+                maxBodyLength: Infinity,
                 headers: {
                     'content-type': extraHeaders['content-type'],
                     'x-auth-client': 'stencil-cli',
@@ -99,6 +103,8 @@ describe('NetworkUtils', () => {
             expect(axiosMock).toHaveBeenCalledWith({
                 url,
                 httpsAgent: httpsAgentMock,
+                maxContentLength: Infinity,
+                maxBodyLength: Infinity,
                 headers: {
                     'content-type': extraHeaders['content-type'],
                     'x-auth-client': extraHeaders['x-auth-client'],
@@ -132,6 +138,8 @@ describe('NetworkUtils', () => {
             expect(axiosMock).toHaveBeenCalledWith({
                 url,
                 httpsAgent: httpsAgentMock,
+                maxContentLength: Infinity,
+                maxBodyLength: Infinity,
                 headers: {
                     'x-auth-token': accessToken,
                     'x-auth-client': 'stencil-cli',


### PR DESCRIPTION
#### What?

Noticed that after moving to Axios we got a bug that sometimes `stencil push` command fails with a message "not ok – ThemeUploadError: Request body larger than maxBodyLength limit".

To fix the bug I just increased maxBodyLength and maxContentLength to Infinite values.

#### Tickets / Documentation

STRF-8913
