### PR TITLE
STRF-9011: fix spoiling changelog.md after stencil release command

### DIFF
--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -84,7 +84,7 @@ async function parseChangelog(version, date) {
     let changelog = '';
 
     try {
-        changelog = await fs.promises.readFile(filePath).toString();
+        changelog = await fs.promises.readFile(filePath, 'utf8');
     } catch (e) {
         // no CHANGELOG file
         return null;


### PR DESCRIPTION
#### What?

Fixed a typo in the code causing a broken changelog after `stencil release` command.

#### Tickets / Documentation

STRF-9011
