### PR TITLE
Updated stencil push and pull commands to support multiple channels

### DIFF
--- a/bin/stencil-pull.js
+++ b/bin/stencil-pull.js
@@ -30,8 +30,9 @@ const cliOptions = program.opts();
 const options = {
     apiHost: cliOptions.host || API_HOST,
     saveConfigName: cliOptions.filename,
-    channelId: cliOptions.channel_id || 1,
+    channelId: cliOptions.channel_id,
     saved: cliOptions.saved || false,
+    applyTheme: true, // fix to be compatible with stencil-push.utils
 };
 
 stencilPull(options, (err) => {

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -9,11 +9,16 @@ const { printCliResultErrorAndExit } = require('../lib/cliCommon');
 
 program
     .version(PACKAGE_INFO.version)
-    .option('--host [hostname]', 'specify the api host', API_HOST)
+    .option('--host [hostname]', 'specify the api host')
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
     .option('-s, --save [filename]', 'specify the filename to save the bundle as')
     .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
     .option('-d, --delete', 'delete oldest private theme if upload limit reached')
+    .option(
+        '-c, --channel_id [channelId]',
+        'specify the channel ID of the storefront to push the theme to',
+        parseInt,
+    )
     .parse(process.argv);
 
 checkNodeVersion();
@@ -21,6 +26,7 @@ checkNodeVersion();
 const cliOptions = program.opts();
 const options = {
     apiHost: cliOptions.host || API_HOST,
+    channelId: cliOptions.channel_id,
     bundleZipPath: cliOptions.file,
     activate: cliOptions.activate,
     saveBundleName: cliOptions.save,

--- a/lib/stencil-pull.js
+++ b/lib/stencil-pull.js
@@ -8,6 +8,8 @@ function stencilPull(options = {}, callback) {
             async.constant(options),
             stencilPushUtils.readStencilConfigFile,
             stencilPushUtils.getStoreHash,
+            stencilPushUtils.getChannels,
+            stencilPushUtils.promptUserForChannel,
             stencilPullUtils.getChannelActiveTheme,
             stencilPullUtils.getThemeConfiguration,
             stencilPullUtils.mergeThemeConfiguration,

--- a/lib/stencil-push.js
+++ b/lib/stencil-push.js
@@ -17,6 +17,8 @@ function stencilPush(options = {}, callback) {
             utils.notifyUserOfThemeUploadCompletion,
             utils.pollForJobCompletion((data) => ({ themeId: data.theme_id })),
             utils.promptUserWhetherToApplyTheme,
+            utils.getChannels,
+            utils.promptUserForChannel,
             utils.getVariations,
             utils.promptUserForVariation,
             utils.requestToApplyVariationWithRetrys(),

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -268,13 +268,34 @@ utils.promptUserWhetherToApplyTheme = async (options) => {
         {
             type: 'confirm',
             name: 'applyTheme',
-            message: `Would you like to apply your theme to your store at ${options.config.normalStoreUrl}?`,
+            message: `Would you like to apply your theme to your store?`,
             default: false,
         },
     ];
     const answers = await Inquirer.prompt(questions);
 
     return { ...options, ...answers };
+};
+
+utils.getChannels = async (options) => {
+    const {
+        config: { accessToken },
+        apiHost,
+        storeHash,
+        applyTheme,
+    } = options;
+
+    if (!applyTheme) {
+        return options;
+    }
+
+    const channels = await themeApiClient.getStoreChannels({
+        accessToken,
+        apiHost,
+        storeHash,
+    });
+
+    return { ...options, channels };
 };
 
 utils.getVariations = async (options) => {
@@ -318,6 +339,29 @@ utils.getVariations = async (options) => {
 
     // Didn't specify a variation explicitly, will ask the user later
     return { ...options, variations };
+};
+
+utils.promptUserForChannel = async (options) => {
+    const { applyTheme, channelId, channels } = options;
+
+    if (!applyTheme || channelId || channels.length < 2) {
+        return options;
+    }
+
+    const questions = [
+        {
+            type: 'list',
+            name: 'channelId',
+            message: 'Which channel would you like to apply the theme to?',
+            choices: channels.map((channel) => ({
+                name: channel.name,
+                value: channel.id,
+            })),
+        },
+    ];
+    const answers = await Inquirer.prompt(questions);
+
+    return { ...options, channelId: answers.channelId };
 };
 
 utils.promptUserForVariation = async (options) => {
@@ -365,6 +409,7 @@ utils.requestToApplyVariation = async (options) => {
         apiHost,
         storeHash,
         variationId,
+        channelId,
     } = options;
 
     if (options.applyTheme) {
@@ -373,6 +418,7 @@ utils.requestToApplyVariation = async (options) => {
             apiHost,
             storeHash,
             variationId,
+            channelId,
         });
     }
 

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -280,12 +280,13 @@ utils.promptUserWhetherToApplyTheme = async (options) => {
 utils.getChannels = async (options) => {
     const {
         config: { accessToken },
+        channelId,
         apiHost,
         storeHash,
         applyTheme,
     } = options;
 
-    if (!applyTheme) {
+    if (!applyTheme || channelId) {
         return options;
     }
 
@@ -344,15 +345,19 @@ utils.getVariations = async (options) => {
 utils.promptUserForChannel = async (options) => {
     const { applyTheme, channelId, channels } = options;
 
-    if (!applyTheme || channelId || channels.length < 2) {
+    if (!applyTheme || channelId) {
         return options;
+    }
+
+    if (channels.length < 2) {
+        return { ...options, channelId: channels[0].id };
     }
 
     const questions = [
         {
             type: 'list',
             name: 'channelId',
-            message: 'Which channel would you like to apply the theme to?',
+            message: 'Which channel would you like to use?',
             choices: channels.map((channel) => ({
                 name: channel.name,
                 value: channel.id,

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -350,7 +350,7 @@ utils.promptUserForChannel = async (options) => {
     }
 
     if (channels.length < 2) {
-        return { ...options, channelId: channels[0].id };
+        return { ...options, channelId: channels[0].channel_id };
     }
 
     const questions = [
@@ -359,8 +359,8 @@ utils.promptUserForChannel = async (options) => {
             name: 'channelId',
             message: 'Which channel would you like to use?',
             choices: channels.map((channel) => ({
-                name: channel.name,
-                value: channel.id,
+                name: channel.url,
+                value: channel.channel_id,
             })),
         },
     ];

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -9,12 +9,19 @@ const networkUtils = new NetworkUtils();
 /**
  * @param {object} options
  * @param {string} options.variationId
+ * @param {string} options.channelId
  * @param {string} options.apiHost
  * @param {string} options.storeHash
  * @param {string} options.accessToken
  * @returns {Promise<any>}
  */
-async function activateThemeByVariationId({ variationId, apiHost, storeHash, accessToken }) {
+async function activateThemeByVariationId({
+    variationId,
+    channelId,
+    apiHost,
+    storeHash,
+    accessToken,
+}) {
     try {
         return await networkUtils.sendApiRequest({
             url: `${apiHost}/stores/${storeHash}/v3/themes/actions/activate`,
@@ -25,6 +32,7 @@ async function activateThemeByVariationId({ variationId, apiHost, storeHash, acc
             accessToken,
             data: {
                 variation_id: variationId,
+                channel_id: channelId,
                 which: 'original',
             },
         });
@@ -129,6 +137,24 @@ async function getChannelActiveTheme({ accessToken, apiHost, storeHash, channelI
         throw new Error(
             `Could not fetch active theme details for channel ${channelId}: ${err.message}`,
         );
+    }
+}
+/**
+ * @param {object} options
+ * @param {string} options.accessToken
+ * @param {string} options.apiHost
+ * @param {string} options.storeHash
+ * @returns {Promise<object[]>}
+ */
+async function getStoreChannels({ accessToken, apiHost, storeHash }) {
+    try {
+        const response = await networkUtils.sendApiRequest({
+            url: `${apiHost}/stores/${storeHash}/v3/channels?platform=bigcommerce&type=storefront&available=true`,
+            accessToken,
+        });
+        return response.data.data;
+    } catch (err) {
+        throw new Error(`Could not fetch a list of the store channels: ${err.message}`);
     }
 }
 
@@ -273,6 +299,7 @@ async function downloadTheme({ accessToken, apiHost, storeHash, themeId }) {
 module.exports = {
     activateThemeByVariationId,
     deleteThemeById,
+    getStoreChannels,
     getChannelActiveTheme,
     getJob,
     getVariationsByThemeId,

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -139,17 +139,18 @@ async function getChannelActiveTheme({ accessToken, apiHost, storeHash, channelI
         );
     }
 }
+
 /**
  * @param {object} options
  * @param {string} options.accessToken
  * @param {string} options.apiHost
  * @param {string} options.storeHash
- * @returns {Promise<object[]>}
+ * @returns {Promise<[{channel_id, url}]>}
  */
 async function getStoreChannels({ accessToken, apiHost, storeHash }) {
     try {
         const response = await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/channels?platform=bigcommerce&type=storefront&available=true`,
+            url: `${apiHost}/stores/${storeHash}/v3/sites`,
             accessToken,
         });
         return response.data.data;


### PR DESCRIPTION
#### What?

Updated stencil push and pull commands to support multiple channels.

#### Tickets / Documentation

- feat: [STRF-7651](https://jira.bigcommerce.com/browse/STRF-7651) update push command
- feat: [STRF-8282](https://jira.bigcommerce.com/browse/STRF-8282) - update pull command

#### Screenshots (if appropriate)

`stencil push`

- When there is only 1 channel (skips channel selection):
<img width="461" alt="push when only 1 channel" src="https://user-images.githubusercontent.com/12990348/110997656-664b4f80-8386-11eb-86dd-394a8e5868c3.png">

- When we specify channel_id in arguments (skips channel selection):
<img width="831" alt="push with specified channel_id" src="https://user-images.githubusercontent.com/12990348/110997685-6f3c2100-8386-11eb-96af-cfdfa4854099.png">

- When there are several channels available:
<img width="664" alt="stencil push choice" src="https://user-images.githubusercontent.com/12990348/111304934-0642fa80-865f-11eb-906c-b266ee31f4a6.png">
<img width="664" alt="push final" src="https://user-images.githubusercontent.com/12990348/111304943-0a6f1800-865f-11eb-8b86-4010195921f9.png">


`stencil pull`

- When there is only 1 channel (skips channel selection):
<img width="489" alt="pull when only 1 channel" src="https://user-images.githubusercontent.com/12990348/110997873-ae6a7200-8386-11eb-8e7f-417c885e2ecd.png">

- When we specify channel_id in arguments (skips channel selection):
<img width="1379" alt="pull with specified channel_id" src="https://user-images.githubusercontent.com/12990348/110997884-b2968f80-8386-11eb-9de4-3684830a540d.png">

- When there are several channels available:
<img width="664" alt="pull choice" src="https://user-images.githubusercontent.com/12990348/111304968-11962600-865f-11eb-84f3-ec36c3a173b3.png">
<img width="664" alt="pull final" src="https://user-images.githubusercontent.com/12990348/111304982-14911680-865f-11eb-87e6-9675ae84aabe.png">




