### PR TITLE
Typo fix at StencilConfigManager.js

### DIFF
--- a/lib/StencilConfigManager.js
+++ b/lib/StencilConfigManager.js
@@ -126,7 +126,7 @@ class StencilConfigManager {
         this._logger.log(
             `The deprecated ${this.oldConfigFileName.cyan} file was successfully replaced.\n` +
                 `Make sure to add ${this.secretsFileName.cyan} to .gitignore.\n` +
-                `${this.configFileName.cyan} can by tracked by git if you wish.\n`,
+                `${this.configFileName.cyan} can be tracked by git if you wish.\n`,
         );
     }
 }


### PR DESCRIPTION
#### What?

There is a typo at an error message displayed to user in the CLI. This pull request fixes it.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

N/A