### PR TITLE
fix: (STRF-9087) set upstream=storefront to support multiple channels in start command

### DIFF
--- a/lib/utils/NetworkUtils.js
+++ b/lib/utils/NetworkUtils.js
@@ -41,6 +41,7 @@ class NetworkUtils {
             ...restOpts,
             headers: {
                 'x-auth-client': 'stencil-cli',
+                'x-bc-upstream': 'storefront',
                 'stencil-cli': this._packageInfo.version,
                 'stencil-version': this._packageInfo.config.stencil_version,
                 ...(restOpts.headers || {}),

--- a/lib/utils/NetworkUtils.spec.js
+++ b/lib/utils/NetworkUtils.spec.js
@@ -33,6 +33,7 @@ describe('NetworkUtils', () => {
                 maxBodyLength: Infinity,
                 headers: {
                     'x-auth-client': 'stencil-cli',
+                    'x-bc-upstream': 'storefront',
                     'stencil-cli': packageInfoMock.version,
                     'stencil-version': packageInfoMock.config.stencil_version,
                 },
@@ -70,6 +71,7 @@ describe('NetworkUtils', () => {
                 headers: {
                     'content-type': extraHeaders['content-type'],
                     'x-auth-client': 'stencil-cli',
+                    'x-bc-upstream': 'storefront',
                     'stencil-cli': packageInfoMock.version,
                     'stencil-version': packageInfoMock.config.stencil_version,
                 },
@@ -110,6 +112,7 @@ describe('NetworkUtils', () => {
                     'content-type': extraHeaders['content-type'],
                     'x-auth-client': extraHeaders['x-auth-client'],
                     'stencil-cli': extraHeaders['stencil-cli'],
+                    'x-bc-upstream': 'storefront',
                     'stencil-version': packageInfoMock.config.stencil_version,
                 },
             });
@@ -144,6 +147,7 @@ describe('NetworkUtils', () => {
                 headers: {
                     'x-auth-token': accessToken,
                     'x-auth-client': 'stencil-cli',
+                    'x-bc-upstream': 'storefront',
                     'stencil-cli': packageInfoMock.version,
                     'stencil-version': packageInfoMock.config.stencil_version,
                 },


### PR DESCRIPTION
#### What?

Added `'x-bc-upstream': 'storefront'` header to support multiple channels in the `start` command because all the CLI requests are handled by Stapler by default and it doesn’t know about channels. 

After this PR `stencil start` command will display a channel whose URL was specified as `normalStoreUrl` in `stencil.config.json`. Previously it always displayed the default channel of the store.

#### Tickets / Documentation

[STRF-9087](https://jira.bigcommerce.com/browse/STRF-9087)
