### PR TITLE
feat: remove old unused field staplerUrl from local server

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -53,7 +53,10 @@ class StencilStart {
         // Use initial (before updates) port for BrowserSync
         const browserSyncPort = initialStencilConfig.port;
 
-        const storeInfoFromAPI = await this.runAPICheck(initialStencilConfig, stencilCliVersion);
+        const storeInfoFromAPI = await this.runAPICheck(
+            initialStencilConfig.normalStoreUrl,
+            stencilCliVersion,
+        );
         const updatedStencilConfig = this.updateStencilConfig(
             initialStencilConfig,
             storeInfoFromAPI,
@@ -88,24 +91,16 @@ class StencilStart {
 
     /**
      *
-     * @param {object} stencilConfig
+     * @param {string} storeUrl
      * @param {string} currentCliVersion
      * @returns {Promise<object>}
      */
-    async runAPICheck(stencilConfig, currentCliVersion) {
-        const staplerUrl = stencilConfig.staplerUrl
-            ? stencilConfig.staplerUrl
-            : stencilConfig.normalStoreUrl;
-        const url = new URL(`/stencil-version-check?v=${currentCliVersion}`, staplerUrl).toString();
+    async runAPICheck(storeUrl, currentCliVersion) {
+        const url = new URL(`/stencil-version-check?v=${currentCliVersion}`, storeUrl).toString();
         let payload;
 
-        const headers = {};
-        if (stencilConfig.staplerUrl) {
-            headers['stencil-store-url'] = stencilConfig.normalStoreUrl;
-        }
-
         try {
-            const response = await this._networkUtils.sendApiRequest({ url, headers });
+            const response = await this._networkUtils.sendApiRequest({ url });
             payload = response.data;
             if (!payload) {
                 throw new Error('Empty payload in the server response');
@@ -274,10 +269,6 @@ class StencilStart {
         information += `${secretsFileName} location: ${secretsPath.cyan}\n`;
         information += `config.json location: ${this._themeConfigManager.configPath.cyan}\n`;
         information += `Store URL: ${stencilConfig.normalStoreUrl.cyan}\n`;
-
-        if (stencilConfig.staplerUrl) {
-            information += `Stapler URL: ${stencilConfig.staplerUrl.cyan}\n`;
-        }
 
         information += `SSL Store URL: ${stencilConfig.storeUrl.cyan}\n`;
         information += `Node Version: ${process.version.cyan}\n`;

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,6 @@ function buildManifest(srcManifest, options) {
         parsedNormalUrl.protocol + '//' + parsedNormalUrl.host;
     pluginsByName['./plugins/router/router.module'].apiKey = options.dotStencilFile.apiKey;
     pluginsByName['./plugins/router/router.module'].port = options.dotStencilFile.port;
-    pluginsByName['./plugins/router/router.module'].staplerUrl = options.dotStencilFile.staplerUrl;
     pluginsByName['./plugins/renderer/renderer.module'].useCache = options.useCache;
     pluginsByName['./plugins/renderer/renderer.module'].username = options.dotStencilFile.username;
     pluginsByName['./plugins/renderer/renderer.module'].token = options.dotStencilFile.token;

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -61,20 +61,18 @@ internals.sha1sum = (input) => {
  * @param request
  */
 internals.getResponse = async (request) => {
-    const staplerUrlObject = request.app.staplerUrl
-        ? new URL(request.app.staplerUrl)
-        : new URL(request.app.storeUrl);
+    const storeUrlObj = new URL(request.app.storeUrl);
 
     const httpOpts = {
         url: Object.assign(new URL(request.url.toString()), {
-            port: staplerUrlObject.port,
-            host: staplerUrlObject.host,
-            protocol: staplerUrlObject.protocol,
+            port: storeUrlObj.port,
+            host: storeUrlObj.host,
+            protocol: storeUrlObj.protocol,
         }).toString(),
         headers: internals.buildReqHeaders({
             request,
             stencilOptions: { get_template_file: true, get_data_only: true },
-            extraHeaders: { host: staplerUrlObject.host },
+            extraHeaders: { host: storeUrlObj.host },
         }),
         accessToken: internals.options.accessToken,
         data: request.payload,
@@ -88,7 +86,7 @@ internals.getResponse = async (request) => {
 
     const responseArgs = {
         httpOpts,
-        staplerUrlObject,
+        storeUrlObj,
     };
 
     // check request signature and use cache, if available
@@ -148,7 +146,7 @@ internals.getResponse = async (request) => {
  * @returns {*}
  */
 internals.parseResponse = async (bcAppData, request, response, responseArgs) => {
-    const { httpOpts, staplerUrlObject } = responseArgs;
+    const { httpOpts, storeUrlObj } = responseArgs;
 
     if (typeof bcAppData !== 'object' || !('pencil_response' in bcAppData)) {
         delete response.headers['x-frame-options'];
@@ -169,7 +167,7 @@ internals.parseResponse = async (bcAppData, request, response, responseArgs) => 
         request,
         stencilOptions: { get_data_only: true },
         stencilConfig: internals.getResourceConfig(bcAppData, request, configuration),
-        extraHeaders: { host: staplerUrlObject.host },
+        extraHeaders: { host: storeUrlObj.host },
     });
     httpOpts.responseType = 'json'; // In the second request we always expect json
 
@@ -385,10 +383,6 @@ internals.buildReqHeaders = ({
 
     if (!request.headers['stencil-config'] && stencilConfig) {
         headers['stencil-config'] = JSON.stringify(stencilConfig);
-    }
-    // Development
-    if (request.app.staplerUrl) {
-        headers['stencil-store-url'] = request.app.storeUrl;
     }
 
     return { ...request.headers, ...headers, ...extraHeaders };

--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -5,7 +5,6 @@ const internals = {
     options: {
         storeUrl: '',
         apiKey: '',
-        staplerUrl: '',
         port: '',
     },
     paths: {
@@ -27,7 +26,6 @@ function register(server, options) {
         request.app.storeUrl = internals.options.storeUrl;
         request.app.normalStoreUrl = internals.options.normalStoreUrl;
         request.app.apiKey = internals.options.apiKey;
-        request.app.staplerUrl = internals.options.staplerUrl;
         request.app.themeConfig = ThemeConfig.getInstance();
 
         return h.continue;


### PR DESCRIPTION
#### What?

Removed old unused field staplerUrl from the local server. Probably It was used to test local Stapler before cloud-dev-vm appeared. 