### PR TITLE
refactor: move API requests from commands to themeApiClient

### DIFF
--- a/bin/stencil-start.js
+++ b/bin/stencil-start.js
@@ -20,4 +20,4 @@ program
     )
     .parse(process.argv);
 
-new StencilStart().run(program.opts(), PACKAGE_INFO.version).catch(printCliResultErrorAndExit);
+new StencilStart().run(program.opts()).catch(printCliResultErrorAndExit);

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -10,9 +10,7 @@ const Bundle = require('./stencil-bundle');
 const themeApiClient = require('./theme-api-client');
 const ThemeConfig = require('./theme-config');
 const StencilConfigManager = require('./StencilConfigManager');
-const NetworkUtils = require('./utils/NetworkUtils');
 
-const networkUtils = new NetworkUtils();
 const themeConfigManager = ThemeConfig.getInstance(THEME_PATH);
 const stencilConfigManager = new StencilConfigManager();
 const utils = {};
@@ -44,19 +42,11 @@ utils.readStencilConfigFile = async (options) => {
 utils.getStoreHash = async (options) => {
     validateOptions(options, ['config.normalStoreUrl']);
 
-    const storeUrlObj = new URL(options.config.normalStoreUrl);
+    const storeHash = await themeApiClient.getStoreHash({
+        storeUrl: options.config.normalStoreUrl,
+    });
 
-    try {
-        const url = `https://${storeUrlObj.host}/admin/oauth/info`;
-        const response = await networkUtils.sendApiRequest({ url });
-        if (!response.data || !response.data.store_hash) {
-            throw new Error('Received empty store_hash value in the server response');
-        }
-        return { ...options, storeHash: response.data.store_hash };
-    } catch (err) {
-        err.name = 'StoreHashReadError';
-        throw err;
-    }
+    return { ...options, storeHash };
 };
 
 utils.getThemes = async (options) => {

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -1,7 +1,6 @@
 require('colors');
 const BrowserSync = require('browser-sync');
 const { promisify } = require('util');
-const fsModule = require('fs');
 const path = require('path');
 
 const Cycles = require('./Cycles');
@@ -13,13 +12,12 @@ const ThemeConfig = require('./theme-config');
 const BuildConfigManager = require('./BuildConfigManager');
 const fsUtilsModule = require('./utils/fsUtils');
 const cliCommonModule = require('./cliCommon');
-const NetworkUtils = require('./utils/NetworkUtils');
+const themeApiClientModule = require('./theme-api-client');
 
 class StencilStart {
     constructor({
         browserSync = BrowserSync.create(),
-        networkUtils = new NetworkUtils(),
-        fs = fsModule,
+        themeApiClient = themeApiClientModule,
         fsUtils = fsUtilsModule,
         cliCommon = cliCommonModule,
         stencilConfigManager = new StencilConfigManager(),
@@ -30,8 +28,7 @@ class StencilStart {
         logger = console,
     } = {}) {
         this._browserSync = browserSync;
-        this._networkUtils = networkUtils;
-        this._fs = fs;
+        this._themeApiClient = themeApiClient;
         this._fsUtils = fsUtils;
         this._cliCommon = cliCommon;
         this._stencilConfigManager = stencilConfigManager;
@@ -42,7 +39,7 @@ class StencilStart {
         this._logger = logger;
     }
 
-    async run(cliOptions, stencilCliVersion) {
+    async run(cliOptions) {
         this.runBasicChecks(cliOptions);
 
         if (cliOptions.variation) {
@@ -53,10 +50,9 @@ class StencilStart {
         // Use initial (before updates) port for BrowserSync
         const browserSyncPort = initialStencilConfig.port;
 
-        const storeInfoFromAPI = await this.runAPICheck(
-            initialStencilConfig.normalStoreUrl,
-            stencilCliVersion,
-        );
+        const storeInfoFromAPI = await this._themeApiClient.checkCliVersion({
+            storeUrl: initialStencilConfig.normalStoreUrl,
+        });
         const updatedStencilConfig = this.updateStencilConfig(
             initialStencilConfig,
             storeInfoFromAPI,
@@ -75,7 +71,7 @@ class StencilStart {
     runBasicChecks(cliOptions) {
         this._cliCommon.checkNodeVersion();
 
-        if (!this._fs.existsSync(this._themeConfigManager.configPath)) {
+        if (!this._fsUtils.existsSync(this._themeConfigManager.configPath)) {
             throw new Error(
                 'You must have a '.red +
                     ' config.json '.cyan +
@@ -87,42 +83,6 @@ class StencilStart {
         if (cliOptions.variation === true) {
             throw new Error('You have to specify a value for -v or --variation'.red);
         }
-    }
-
-    /**
-     *
-     * @param {string} storeUrl
-     * @param {string} currentCliVersion
-     * @returns {Promise<object>}
-     */
-    async runAPICheck(storeUrl, currentCliVersion) {
-        const url = new URL(`/stencil-version-check?v=${currentCliVersion}`, storeUrl).toString();
-        let payload;
-
-        try {
-            const response = await this._networkUtils.sendApiRequest({ url });
-            payload = response.data;
-            if (!payload) {
-                throw new Error('Empty payload in the server response');
-            }
-        } catch (err) {
-            throw new Error(
-                'The BigCommerce Store you are pointing to either does not exist or is not available at this time.'
-                    .red +
-                    '\nError details:\n' +
-                    err.message,
-            );
-        }
-        if (payload.error) {
-            throw new Error(payload.error.red);
-        }
-        if (payload.status !== 'ok') {
-            throw new Error(
-                'Error: You are using an outdated version of stencil-cli, please run '.red +
-                    '$ npm install -g @bigcommerce/stencil-cli'.cyan,
-            );
-        }
-        return payload;
     }
 
     updateStencilConfig(stencilConfig, storeInfoFromAPI) {

--- a/lib/stencil-start.spec.js
+++ b/lib/stencil-start.spec.js
@@ -9,13 +9,11 @@ describe('StencilStart unit tests', () => {
         watch: jest.fn(),
         init: jest.fn(),
     });
-    const getNetworkUtilsStub = () => ({
-        sendApiRequest: jest.fn(),
-    });
-    const getFsStub = () => ({
-        existsSync: jest.fn(),
+    const getThemeApiClientStub = () => ({
+        checkCliVersion: jest.fn(),
     });
     const getFsUtilsStub = () => ({
+        existsSync: jest.fn(),
         parseJsonFile: jest.fn(),
         recursiveReadDir: jest.fn(),
     });
@@ -34,9 +32,8 @@ describe('StencilStart unit tests', () => {
 
     const createStencilStartInstance = ({
         browserSync,
-        fs,
         fsUtils,
-        networkUtils,
+        themeApiClient,
         cliCommon,
         stencilConfigManager,
         themeConfigManager,
@@ -47,9 +44,8 @@ describe('StencilStart unit tests', () => {
     } = {}) => {
         const passedArgs = {
             browserSync: browserSync || getBrowserSyncStub(),
-            fs: fs || getFsStub(),
             fsUtils: fsUtils || getFsUtilsStub(),
-            networkUtils: networkUtils || getNetworkUtilsStub(),
+            themeApiClient: themeApiClient || getThemeApiClientStub(),
             cliCommon: cliCommon || getCliCommonStub(),
             stencilConfigManager: stencilConfigManager || getStencilConfigManagerStub(),
             themeConfigManager: themeConfigManager || getThemeConfigManagerStub(),

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const FormData = require('form-data');
 const NetworkUtils = require('./utils/NetworkUtils');
+const { PACKAGE_INFO } = require('../constants');
 
 const networkUtils = new NetworkUtils();
 
@@ -23,6 +24,42 @@ async function getStoreHash({ storeUrl }) {
         err.name = 'StoreHashReadError';
         throw err;
     }
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.storeUrl
+ * @param {string} [options.currentCliVersion]
+ * @returns {Promise<object>}
+ */
+async function checkCliVersion({ storeUrl, currentCliVersion = PACKAGE_INFO.version }) {
+    const url = new URL(`/stencil-version-check?v=${currentCliVersion}`, storeUrl).toString();
+    let payload;
+
+    try {
+        const response = await networkUtils.sendApiRequest({ url });
+        payload = response.data;
+        if (!payload) {
+            throw new Error('Empty payload in the server response');
+        }
+    } catch (err) {
+        throw new Error(
+            'The BigCommerce Store you are pointing to either does not exist or is not available at this time.'
+                .red +
+                '\nError details:\n' +
+                err.message,
+        );
+    }
+    if (payload.error) {
+        throw new Error(payload.error.red);
+    }
+    if (payload.status !== 'ok') {
+        throw new Error(
+            'Error: You are using an outdated version of stencil-cli, please run '.red +
+                '$ npm install -g @bigcommerce/stencil-cli'.cyan,
+        );
+    }
+    return payload;
 }
 
 /**
@@ -318,6 +355,7 @@ async function downloadTheme({ accessToken, apiHost, storeHash, themeId }) {
 
 module.exports = {
     getStoreHash,
+    checkCliVersion,
     activateThemeByVariationId,
     deleteThemeById,
     getStoreChannels,

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -8,6 +8,25 @@ const networkUtils = new NetworkUtils();
 
 /**
  * @param {object} options
+ * @param {string} options.storeUrl
+ * @returns {Promise<object[]>}
+ */
+async function getStoreHash({ storeUrl }) {
+    try {
+        const url = new URL(`/admin/oauth/info`, storeUrl).toString();
+        const response = await networkUtils.sendApiRequest({ url });
+        if (!response.data || !response.data.store_hash) {
+            throw new Error('Received empty store_hash value in the server response');
+        }
+        return response.data.store_hash;
+    } catch (err) {
+        err.name = 'StoreHashReadError';
+        throw err;
+    }
+}
+
+/**
+ * @param {object} options
  * @param {string} options.variationId
  * @param {string} options.channelId
  * @param {string} options.apiHost
@@ -298,6 +317,7 @@ async function downloadTheme({ accessToken, apiHost, storeHash, themeId }) {
 }
 
 module.exports = {
+    getStoreHash,
     activateThemeByVariationId,
     deleteThemeById,
     getStoreChannels,

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -17,6 +17,7 @@ async function parseJsonFile(filePath) {
 }
 
 module.exports = {
+    ...fs,
     parseJsonFile,
     recursiveReadDir,
 };


### PR DESCRIPTION
#### What?

- Moved getStoreHash request from stencil-push.utils.js to theme-api-client.js
- Move version check request from stencil-start.js to theme-api-client.js