### PR TITLE
MERC-7873 Support multiple character language code for schema translations

### DIFF
--- a/lib/schemas/schemaTranslations.json
+++ b/lib/schemas/schemaTranslations.json
@@ -13,7 +13,24 @@
         }
       },
       "patternProperties": {
-        "^[a-z]{2}$": {
+        "[a-z]{2}(-[a-zA-Z0-9]{2,})?$": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["default"]
+    },
+    "^i18n.Bigcommerce.": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "patternProperties": {
+        "[a-z]{2}(-[a-zA-Z0-9]{2,})?$": {
           "type": "string",
           "minLength": 1
         }


### PR DESCRIPTION
Jira: [MERC-7873](https://jira.bigcommerce.com/browse/MERC-7873)

- [x] [Should merge theme-registry first](https://github.com/bigcommerce/theme-registry/pull/1176)

## What? Why?
MERC-7873 Support multiple character language code for schema translations. With the roll out of `TRANS-830.new.language.set`, there are a few languageCodes that are returning as multiple characters, we need to allow the schema validation to accept these new conditions.

This also adds in reserved name space of `i18n.Bigcommerce.` this will be used to translate things not related to the schema settings. 

What the patternProperty checks for:

(1) `^[a-z]{2}` First two letters start with lowercase letter
(2) `(-[a-zA-Z0-9]{2,})` optional `-` + at least 2 length alphanumeric string (could be longer than 2 alphanumerics) 

## Additional Deploy Steps?
None

## How was it tested?
(1) Create dummy `schema_translations.json` (example below)
(2) Upsert locally or can use api 
(3) Expect schema_translations to successfully post.


Cases to test

2 characters (must be lowercase letters, 2 characters in length and no symbols allowed)
```
{
  "i18n.FontFamily": {
    "default": "Font family",
    "fr": "Famille de polices",
    "en": "Font family (english)",
    "uk": "字体系列",
    "zh": "adskljflkasdjflkajflkajdslk;a"
  }
}
```

Multiple characters (can allow for uppercase letters, multiple characters in length, and allows `-`)
```
{
  "i18n.FontFamily": {
    "default": "Font family",
    "fr-FR": "Famille de polices",
    "en": "Font family (english)",
    "zh-ch": "字体系列",
    "es-416": "testing123"
  }
}
```

ping @bigcommerce/merc-team
