### PR TITLE
feat(other): merc-7834 validate theme variation translations

### DIFF
--- a/lib/schemas/privateThemeConfig.json
+++ b/lib/schemas/privateThemeConfig.json
@@ -155,6 +155,29 @@
                 },
                 "uniqueItems": true,
                 "minItems": 0
+              },
+              "translations": {
+                "type": "object",
+                "properties": {
+                  "i18n.description": {
+                    "type": "object",
+                    "properties": {
+                      "default": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "patternProperties": {
+                      "[a-z]{2}(-[a-zA-Z0-9]{2,})?$": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["default"]
+                  }
+                },
+                "additionalProperties": false
               }
             },
             "required": ["description"]

--- a/lib/schemas/themeConfig.json
+++ b/lib/schemas/themeConfig.json
@@ -191,6 +191,29 @@
                 },
                 "uniqueItems": true,
                 "minItems": 0
+              },
+              "translations": {
+                "type": "object",
+                "properties": {
+                  "i18n.description": {
+                    "type": "object",
+                    "properties": {
+                      "default": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "patternProperties": {
+                      "[a-z]{2}(-[a-zA-Z0-9]{2,})?$": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["default"]
+                  }
+                },
+                "additionalProperties": false
               }
             },
             "required": [


### PR DESCRIPTION
#### What?
feat(other): merc-7834 validate theme variation translations. This will be used to translate the variation config (more specifically variation description). 

#### Tickets / Documentation
[MERC-7834](https://jira.bigcommerce.com/browse/MERC-7834)

Order of release for all PRs:
- [x] [(1) Theme Registry translations to variations table migration](https://github.com/bigcommerce/theme-registry/pull/1175)
- [x] [(2) Theme Registry PR to expose translations](https://github.com/bigcommerce/theme-registry/pull/1178)
- [x] [(3) BC App](https://github.com/bigcommerce/bigcommerce/pull/41372)
- [x] [(4) Ng Marketplace PR to update frontend](https://github.com/bigcommerce-labs/ng-marketplace/pull/536)
- [ ] (5) This PR - Allow merchants to bundle with new translations object
