### PR TITLE
fix: (MERC-8038) Added check to ensure we are not looping over undefined object

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -237,9 +237,12 @@ internals.parseResponse = async (bcAppData, request, response, responseArgs) => 
     }
 
     const formattedRegions = {};
-    regionResponse.renderedRegions.forEach((region) => {
-        formattedRegions[region.name] = region.html;
-    });
+
+    if (typeof regionResponse.renderedRegions !== 'undefined') {
+        regionResponse.renderedRegions.forEach((region) => {
+            formattedRegions[region.name] = region.html;
+        });
+    }
 
     return internals.getPencilResponse(
         response2.data,


### PR DESCRIPTION
#### What?
A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.

#### Tickets / Documentation
[MERC-8038](https://jira.bigcommerce.com/browse/MERC-8038)

When we are looking at pages that are not supported by the GraphQL renderedRegions field we were getting back an `undefined` value. This was not accounted for when we were looping over the result. This PR fixes that issue. 
