### PR TITLE
feat: strf-9345 Infer apiHost from storeUrl

### DIFF
--- a/bin/stencil-download.js
+++ b/bin/stencil-download.js
@@ -4,14 +4,14 @@ require('colors');
 const inquirer = require('inquirer');
 const program = require('../lib/commander');
 
-const { API_HOST, PACKAGE_INFO } = require('../constants');
+const { PACKAGE_INFO } = require('../constants');
 const stencilDownload = require('../lib/stencil-download');
 const { checkNodeVersion } = require('../lib/cliCommon');
 const { printCliResultErrorAndExit } = require('../lib/cliCommon');
 
 program
     .version(PACKAGE_INFO.version)
-    .option('-h, --host [hostname]', 'specify the api host', API_HOST)
+    .option('-h, --host [hostname]', 'specify the api host')
     .option('-f, --file [filename]', 'specify the filename to download only')
     .option('-e, --exclude [exclude]', 'specify a directory to exclude from download')
     .option('-c, --channel_id [channelId]', 'specify the channel ID of the storefront', parseInt)
@@ -23,7 +23,7 @@ const cliOptions = program.opts();
 const extraExclude = cliOptions.exclude ? [cliOptions.exclude] : [];
 const options = {
     exclude: ['parsed', 'manifest.json', ...extraExclude],
-    apiHost: cliOptions.host || API_HOST,
+    apiHost: cliOptions.host,
     channelId: cliOptions.channel_id,
     applyTheme: true, // fix to be compatible with stencil-push.utils
     file: cliOptions.file,

--- a/bin/stencil-pull.js
+++ b/bin/stencil-pull.js
@@ -2,7 +2,7 @@
 
 require('colors');
 
-const { PACKAGE_INFO, API_HOST } = require('../constants');
+const { PACKAGE_INFO } = require('../constants');
 const program = require('../lib/commander');
 const stencilPull = require('../lib/stencil-pull');
 const { checkNodeVersion } = require('../lib/cliCommon');
@@ -11,7 +11,7 @@ const { printCliResultErrorAndExit } = require('../lib/cliCommon');
 program
     .version(PACKAGE_INFO.version)
     .option('-s, --saved', 'get the saved configuration instead of the active one')
-    .option('-h, --host [hostname]', 'specify the api host', API_HOST)
+    .option('-h, --host [hostname]', 'specify the api host')
     .option(
         '-f, --filename [filename]',
         'specify the filename to save the config as',
@@ -27,8 +27,9 @@ program
 checkNodeVersion();
 
 const cliOptions = program.opts();
+
 const options = {
-    apiHost: cliOptions.host || API_HOST,
+    apiHost: cliOptions.host,
     saveConfigName: cliOptions.filename,
     channelId: cliOptions.channel_id,
     saved: cliOptions.saved || false,

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 require('colors');
-const { PACKAGE_INFO, API_HOST } = require('../constants');
+const { PACKAGE_INFO } = require('../constants');
 const program = require('../lib/commander');
 const stencilPush = require('../lib/stencil-push');
 const { checkNodeVersion } = require('../lib/cliCommon');
@@ -25,7 +25,7 @@ checkNodeVersion();
 
 const cliOptions = program.opts();
 const options = {
-    apiHost: cliOptions.host || API_HOST,
+    apiHost: cliOptions.host,
     channelId: cliOptions.channel_id,
     bundleZipPath: cliOptions.file,
     activate: cliOptions.activate,

--- a/bin/stencil-start.js
+++ b/bin/stencil-start.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 require('colors');
-const { PACKAGE_INFO, API_HOST } = require('../constants');
+const { PACKAGE_INFO } = require('../constants');
 const program = require('../lib/commander');
 const StencilStart = require('../lib/stencil-start');
 const { printCliResultErrorAndExit } = require('../lib/cliCommon');
@@ -28,7 +28,7 @@ const options = {
     open: cliOptions.open,
     variation: cliOptions.variation,
     channelId: cliOptions.channelId,
-    apiHost: cliOptions.host || API_HOST,
+    apiHost: cliOptions.host,
     tunnel: cliOptions.tunnel,
     cache: cliOptions.cache,
 };

--- a/constants.js
+++ b/constants.js
@@ -15,11 +15,17 @@ const DEFAULT_CUSTOM_LAYOUTS_CONFIG = {
 
 /// /////////////////////////////////////////   Other   //////////////////////////////////////// ///
 
+const DEV_API_HOST = 'https://api.service.bcdev';
+const INTG_API_HOST = 'https://api.integration.zone';
+const STG_API_HOST = 'https://api.staging.zone';
 const API_HOST = 'https://api.bigcommerce.com';
 
 module.exports = {
     PACKAGE_INFO,
     THEME_PATH,
     DEFAULT_CUSTOM_LAYOUTS_CONFIG,
+    DEV_API_HOST,
+    INTG_API_HOST,
+    STG_API_HOST,
     API_HOST,
 };

--- a/lib/stencil-download.utils.js
+++ b/lib/stencil-download.utils.js
@@ -37,10 +37,11 @@ utils.downloadThemeFiles = async (options) => {
 utils.startThemeDownloadJob = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         activeTheme,
         storeHash,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     const { jobId } = await themeApiClient.downloadTheme({
         accessToken,

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -4,7 +4,13 @@ const inquirerModule = require('inquirer');
 
 const serverConfigModule = require('../server/config');
 const StencilConfigManager = require('./StencilConfigManager');
-const { DEFAULT_CUSTOM_LAYOUTS_CONFIG } = require('../constants');
+const {
+    DEFAULT_CUSTOM_LAYOUTS_CONFIG,
+    API_HOST,
+    INTG_API_HOST,
+    STG_API_HOST,
+    DEV_API_HOST,
+} = require('../constants');
 
 class StencilInit {
     /**
@@ -133,6 +139,22 @@ class StencilInit {
         return questions.length ? this._inquirer.prompt(questions) : {};
     }
 
+    apiHostFromStoreUrl(storeUrl) {
+        if (storeUrl !== undefined) {
+            if (storeUrl.includes('service.bcdev')) {
+                return DEV_API_HOST;
+            }
+            if (storeUrl.includes('my-integration.zone')) {
+                return INTG_API_HOST;
+            }
+            if (storeUrl.includes('my-staging.zone')) {
+                return STG_API_HOST;
+            }
+        }
+
+        return API_HOST;
+    }
+
     /**
      * @param {object} stencilConfig
      * @param {object} answers
@@ -140,8 +162,12 @@ class StencilInit {
      * @returns {object}
      */
     applyAnswers(stencilConfig, answers, cliOptions) {
+        const storeUrl =
+            answers.normalStoreUrl || cliOptions.normalStoreUrl || stencilConfig.normalStoreUrl;
+
         return {
             customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG,
+            apiHost: this.apiHostFromStoreUrl(storeUrl),
             ...stencilConfig,
             ...cliOptions,
             ...answers,

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -3,7 +3,7 @@ const inquirerModule = require('inquirer');
 
 const StencilInit = require('./stencil-init');
 const StencilConfigManager = require('./StencilConfigManager');
-const { DEFAULT_CUSTOM_LAYOUTS_CONFIG } = require('../constants');
+const { DEFAULT_CUSTOM_LAYOUTS_CONFIG, API_HOST } = require('../constants');
 const { assertNoMutations } = require('../test/assertions/assertNoMutations');
 
 const getStencilConfig = () => ({
@@ -21,6 +21,7 @@ const getStencilConfig = () => ({
     port: 3001,
     accessToken: 'accessToken_from_stencilConfig',
     githubToken: 'githubToken_1234567890',
+    apiHost: API_HOST,
 });
 const getAnswers = () => ({
     normalStoreUrl: 'https://url-from-answers.mybigcommerce.com',
@@ -73,6 +74,7 @@ describe('StencilInit integration tests', () => {
             const expectedResult = {
                 customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG,
                 ...answers,
+                apiHost: API_HOST,
             };
             const stencilConfigManager = new StencilConfigManager({
                 themePath: './test/_mocks/themes/valid/',
@@ -110,6 +112,7 @@ describe('StencilInit integration tests', () => {
             const expectedResult = {
                 customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG,
                 ...cliOptions,
+                apiHost: API_HOST,
             };
             const stencilConfigManager = new StencilConfigManager({
                 themePath: './test/_mocks/themes/valid/',
@@ -362,6 +365,37 @@ describe('StencilInit unit tests', () => {
             // Make sure that other props aren't overwritten:
             expect(res.accessToken).toEqual(answers.accessToken);
             expect(res.githubToken).toEqual(stencilConfig.githubToken);
+        });
+    });
+
+    describe('apiHostFromStoreUrl', () => {
+        it('should return the integration api host for integration stores', async () => {
+            const storeUrl = 'https://store-url.my-integration.zone';
+            const expected = 'https://api.integration.zone';
+
+            const { instance } = createStencilInitInstance();
+            const res = instance.apiHostFromStoreUrl(storeUrl);
+
+            expect(res).toEqual(expected);
+        });
+
+        it('should return the staging api host for staging stores', async () => {
+            const storeUrl = 'https://store-url.my-staging.zone';
+            const expected = 'https://api.staging.zone';
+
+            const { instance } = createStencilInitInstance();
+            const res = instance.apiHostFromStoreUrl(storeUrl);
+
+            expect(res).toEqual(expected);
+        });
+
+        it('should return the API_HOST constant for all ohter stores', async () => {
+            const storeUrl = 'https://store-url.mystore.com';
+
+            const { instance } = createStencilInitInstance();
+            const res = instance.apiHostFromStoreUrl(storeUrl);
+
+            expect(res).toEqual(API_HOST);
         });
     });
 });

--- a/lib/stencil-pull.utils.js
+++ b/lib/stencil-pull.utils.js
@@ -8,10 +8,11 @@ const utils = {};
 utils.getChannelActiveTheme = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         channelId,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     const activeTheme = await themeApiClient.getChannelActiveTheme({
         accessToken,
@@ -28,11 +29,12 @@ utils.getChannelActiveTheme = async (options) => {
 utils.getThemeConfiguration = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         activeTheme,
         saved,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     const themeId = activeTheme.active_theme_uuid;
 

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -52,9 +52,10 @@ utils.getStoreHash = async (options) => {
 utils.getThemes = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     const themes = await themeApiClient.getThemes({ accessToken, apiHost, storeHash });
 
@@ -84,10 +85,11 @@ utils.generateBundle = async (options) => {
 utils.uploadBundle = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         bundleZipPath,
         storeHash,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     try {
         const result = await themeApiClient.postTheme({
@@ -162,11 +164,12 @@ utils.promptUserToDeleteThemesIfNecessary = async (options) => {
 utils.deleteThemesIfNecessary = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         themeLimitReached,
         themeIdsToDelete,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     if (!themeLimitReached) {
         return options;
@@ -229,11 +232,12 @@ utils.pollForJobCompletion = (resultFilter) => {
 utils.checkIfJobIsComplete = (resultFilter) => async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         bundleZipPath,
         jobId,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     const result = await themeApiClient.getJob({
         accessToken,
@@ -271,10 +275,11 @@ utils.getChannels = async (options) => {
     const {
         config: { accessToken },
         channelId,
-        apiHost,
         storeHash,
         applyTheme,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     if (!applyTheme || channelId) {
         return options;
@@ -292,12 +297,13 @@ utils.getChannels = async (options) => {
 utils.getVariations = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         themeId,
         applyTheme,
         activate,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     if (!applyTheme) {
         return options;
@@ -406,11 +412,12 @@ utils.requestToApplyVariationWithRetrys = () => {
 utils.requestToApplyVariation = async (options) => {
     const {
         config: { accessToken },
-        apiHost,
         storeHash,
         variationId,
         channelId,
     } = options;
+
+    const apiHost = options.apiHost || options.config.apiHost;
 
     if (options.applyTheme) {
         await themeApiClient.activateThemeByVariationId({

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -71,7 +71,7 @@ class StencilStart {
 
     async getChannelUrl(stencilConfig, cliOptions) {
         const { accessToken } = stencilConfig;
-        const { apiHost } = cliOptions;
+        const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
         const storeHash = await this._themeApiClient.getStoreHash({
             storeUrl: stencilConfig.normalStoreUrl,
         });


### PR DESCRIPTION
[STRF-9345](https://jira.bigcommerce.com/browse/STRF-9345)

#### What?

Attempt to infer the apiHost from the storeUrl for integration/staging stores, falling back to API_HOST constant otherwise.

apiHost is now saved in the stencil config and loaded from there instead of just the API_HOST


@jairo-bc 