### PR TITLE
feat: strf-9345: Log api host

### DIFF
--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -140,19 +140,26 @@ class StencilInit {
     }
 
     apiHostFromStoreUrl(storeUrl) {
+        let host = null;
         if (storeUrl !== undefined) {
             if (storeUrl.includes('service.bcdev')) {
-                return DEV_API_HOST;
+                host = DEV_API_HOST;
             }
             if (storeUrl.includes('my-integration.zone')) {
-                return INTG_API_HOST;
+                host = INTG_API_HOST;
             }
             if (storeUrl.includes('my-staging.zone')) {
-                return STG_API_HOST;
+                host = STG_API_HOST;
             }
         }
 
-        return API_HOST;
+        if (host === null) {
+            host = API_HOST;
+        }
+
+        console.log('Set API host to: ' + host);
+
+        return host;
     }
 
     /**

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -98,7 +98,7 @@ describe('StencilInit integration tests', () => {
 
             expect(inquirerPromptStub).toHaveBeenCalledTimes(1);
             expect(consoleErrorStub).toHaveBeenCalledTimes(0);
-            expect(consoleLogStub).toHaveBeenCalledTimes(1);
+            expect(consoleLogStub).toHaveBeenCalledTimes(2);
             expect(saveStencilConfigStub).toHaveBeenCalledTimes(1);
 
             expect(saveStencilConfigStub).toHaveBeenCalledWith(expectedResult);
@@ -134,7 +134,7 @@ describe('StencilInit integration tests', () => {
 
             expect(inquirerPromptStub).toHaveBeenCalledTimes(0);
             expect(consoleErrorStub).toHaveBeenCalledTimes(0);
-            expect(consoleLogStub).toHaveBeenCalledTimes(1);
+            expect(consoleLogStub).toHaveBeenCalledTimes(2);
             expect(saveStencilConfigStub).toHaveBeenCalledTimes(1);
 
             expect(saveStencilConfigStub).toHaveBeenCalledWith(expectedResult);


### PR DESCRIPTION
#### What?

Continued from STRF-9345, this should log out the host that we've inferred and set


@jairo-bc @zvuki @bookernath 
