### PR TITLE
fix: strf-9312 Rename github workflow on relaese action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Paper Handlebars Library
+name: Stencil CLI
 on:
     release:
         types: [created]


### PR DESCRIPTION
#### What?

Renamed github workflow on release action

