### PR TITLE
docs(release): release 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.5.2 (2021-09-17)
+
+-   fix: strf-9356 Support npm 7 for stencil cli ([d67747d5384](https://github.com/bigcommerce/stencil-cli/commit/d67747d5384))
+
 ### 3.5.1 (2021-09-15)
 
 -   fix: strf-9345: Fallback to API_HOST constant in the absense of a provided one ([d138536c8](https://github.com/bigcommerce/stencil-cli/commit/d138536c8))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "^3.0.0-rc.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
#### What?

-   fix: strf-9356 Support npm 7 for stencil cli ([d67747d5384](https://github.com/bigcommerce/stencil-cli/commit/d67747d5384))
