### PR TITLE
fix: strf-9356 Replace ssh to https on node-sass dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26495,7 +26495,7 @@
       }
     },
     "@bigcommerce/node-sass": {
-      "version": "git+ssh://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+      "version": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
       "from": "@bigcommerce/node-sass@git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
       "requires": {
         "async-foreach": "^0.1.3",


### PR DESCRIPTION
#### What?

Github Release is [failing](https://github.com/bigcommerce/stencil-cli/runs/3634671397?check_suite_focus=true) because NPM 7 has a bug with installing dependencies using [SSH](https://github.com/npm/cli/issues/2610) 


