### PR TITLE
STRF-9040 Support dart-sass as primary engine for css compilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "^3.0.0-rc.48",
-        "@bigcommerce/stencil-styles": "1.2.1",
+        "@bigcommerce/stencil-styles": "2.1.0",
         "@hapi/boom": "^8.0.1",
         "@hapi/glue": "^6.2.0",
         "@hapi/h2o2": "^8.3.2",
@@ -83,6 +83,29 @@
       },
       "engines": {
         "node": "^10.17 || ^12"
+      }
+    },
+    "../stencil-styles": {
+      "name": "@bigcommerce/stencil-styles",
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "BSD-4-Clause",
+      "dependencies": {
+        "@bigcommerce/node-sass": "https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+        "autoprefixer": "^6.7.3",
+        "fibers": "^5.0.0",
+        "lodash": "4.17.19",
+        "postcss": "^5.2.14",
+        "sass": "^1.42.0"
+      },
+      "devDependencies": {
+        "@hapi/code": "^8.0.2",
+        "@hapi/lab": "^23.0.0",
+        "eslint": "^7.20.0",
+        "sinon": "^1.14.1"
+      },
+      "engines": {
+        "node": ">10.8.0 <13.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -807,8 +830,7 @@
     },
     "node_modules/@bigcommerce/node-sass": {
       "version": "3.5.0",
-      "resolved": "git+ssh://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
-      "integrity": "sha512-Xc1Y0Qc2NloRsPrm+n+gae63Sop4mqEzupvdm7rjANKdchRInxRQoqXQGVbJhf7UTiXM0oAcs3p+Uvn2s25aDQ==",
+      "resolved": "git+https://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -859,22 +881,6 @@
         "node": "*"
       }
     },
-    "node_modules/@bigcommerce/node-sass/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/@bigcommerce/node-sass/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/@bigcommerce/stencil-paper": {
       "version": "3.0.0-rc.48",
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.48.tgz",
@@ -903,17 +909,19 @@
       }
     },
     "node_modules/@bigcommerce/stencil-styles": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.1.tgz",
-      "integrity": "sha512-O9I2gVIpb5X7uUHBSU/MYVKEycZBP0rj7vzE656we4bprCEa9sfel5diUEvzsO4QqPu+Qofec9b6Z5BNluEQSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-2.1.0.tgz",
+      "integrity": "sha512-qeWf6eybvqpOd8kPlKyNK2ciMwZXvLu1jg6ObZmhX15sKHwSUW9nU6euTKoO3AfZ607rESdqb3sErpRAEDs0wg==",
       "dependencies": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+        "@bigcommerce/node-sass": "git+https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
+        "fibers": "^5.0.0",
         "lodash": "4.17.19",
-        "postcss": "^5.2.14"
+        "postcss": "^5.2.14",
+        "sass": "^1.42.0"
       },
       "engines": {
-        "node": ">= 6.0.0 <13.0.0"
+        "node": ">10.8.0 <13.0.0"
       }
     },
     "node_modules/@bigcommerce/stencil-styles/node_modules/lodash": {
@@ -2240,15 +2248,6 @@
         "@hapi/hoek": "^8.2.4",
         "@hapi/pinpoint": "^1.0.2",
         "@hapi/topo": "^3.1.3"
-      }
-    },
-    "node_modules/@hapi/inert/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "node_modules/@hapi/joi": {
@@ -4307,9 +4306,9 @@
       "dev": true
     },
     "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -5827,9 +5826,9 @@
       }
     },
     "node_modules/caniuse-db": {
-      "version": "1.0.30001112",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001112.tgz",
-      "integrity": "sha512-Xrn3lVEIsvAAUmFVHKKComfyCRM59NfuV3EwCXqs2XLgOxAqYgrfEs0vDk+Dk7KctlAMh6CH/CSd1srJt503ZA=="
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001260.tgz",
+      "integrity": "sha512-De8tLxxSZwDsxSuzKSHWvA4aOkCE0jB9H0QSihH7PJP3rjPSAYZQM4B9dmokQL+X5PQJ+DLS7npOIjCXKX/62w=="
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -6712,9 +6711,9 @@
       }
     },
     "node_modules/config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -8227,15 +8226,6 @@
         "which": "^1.2.8"
       }
     },
-    "node_modules/cross-spawn-async/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "node_modules/css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -8506,6 +8496,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -8730,9 +8731,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.526",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.526.tgz",
-      "integrity": "sha512-HiroW5ZbGwgT8kCnoEO8qnGjoTPzJxduvV/Vv/wH63eo2N6Zj3xT5fmmaSPAPUM05iN9/5fIEkIg3owTtV6QZg=="
+      "version": "1.3.848",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.848.tgz",
+      "integrity": "sha512-wchRyBcdcmibioggdO7CbMT5QQ4lXlN/g7Mkpf1K2zINidnqij6EVu94UIZ+h5nB2S9XD4bykqFv9LonAWLFyw=="
     },
     "node_modules/emittery": {
       "version": "0.7.1",
@@ -10383,6 +10384,18 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fibers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
+      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -11136,34 +11149,30 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -11171,17 +11180,15 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -11189,75 +11196,66 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -11267,27 +11265,24 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -11301,10 +11296,9 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11322,17 +11316,15 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -11342,20 +11334,18 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11363,27 +11353,24 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -11393,17 +11380,15 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -11413,17 +11398,15 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -11431,20 +11414,18 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -11454,17 +11435,15 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -11479,10 +11458,9 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -11501,10 +11479,9 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -11515,27 +11492,24 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -11543,10 +11517,9 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -11556,60 +11529,54 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -11617,27 +11584,24 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11650,17 +11614,15 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11673,10 +11635,9 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11686,65 +11647,57 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -11756,10 +11709,9 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -11769,20 +11721,18 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -11798,34 +11748,30 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fstream": {
       "version": "1.0.12",
@@ -11839,22 +11785,6 @@
       },
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/fstream/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/function-bind": {
@@ -12842,19 +12772,6 @@
         "node",
         "rhino"
       ]
-    },
-    "node_modules/globule/node_modules/minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/glogg": {
       "version": "1.0.2",
@@ -19309,9 +19226,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -19900,6 +19821,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -19962,6 +19901,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/modify-values": {
@@ -20208,52 +20158,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -20332,9 +20236,9 @@
       }
     },
     "node_modules/nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dependencies": {
         "abbrev": "1"
       },
@@ -20455,33 +20359,6 @@
         "safe-buffer": "^5.1.1",
         "semver": "2 || 3 || 4",
         "uid-number": "0.0.5"
-      }
-    },
-    "node_modules/npmconf/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/npmconf/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/npmconf/node_modules/nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
       }
     },
     "node_modules/npmconf/node_modules/once": {
@@ -22723,36 +22600,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -23217,6 +23064,20 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/sass": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/sass-graph": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.6.tgz",
@@ -23249,40 +23110,10 @@
         "wrap-ansi": "^2.0.0"
       }
     },
-    "node_modules/sass-graph/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sass-graph/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sass-graph/node_modules/yargs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
-      "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
+      "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
       "dependencies": {
         "camelcase": "^3.0.0",
         "cliui": "^3.2.0",
@@ -23296,16 +23127,153 @@
         "string-width": "^1.0.2",
         "which-module": "^1.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "5.0.0-security.0"
+        "yargs-parser": "^5.0.1"
       }
     },
-    "node_modules/sass-graph/node_modules/yargs-parser": {
-      "version": "5.0.0-security.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
-      "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
+    "node_modules/sass/node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dependencies": {
-        "camelcase": "^3.0.0",
-        "object.assign": "^4.1.0"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sass/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass/node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sass/node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/sass/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sass/node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass/node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sass/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/sass/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/sass/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/saxes": {
@@ -25737,18 +25705,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/write/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ws": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -25817,19 +25773,18 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "dev": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
       "dependencies": {
-        "camelcase": "^3.0.0"
+        "camelcase": "^3.0.0",
+        "object.assign": "^4.1.0"
       }
     },
     "node_modules/yargs-parser/node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26495,8 +26450,8 @@
       }
     },
     "@bigcommerce/node-sass": {
-      "version": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
-      "from": "@bigcommerce/node-sass@git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+      "version": "git+https://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+      "from": "@bigcommerce/node-sass@git+https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -26532,19 +26487,6 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
         }
       }
     },
@@ -26573,14 +26515,16 @@
       }
     },
     "@bigcommerce/stencil-styles": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.1.tgz",
-      "integrity": "sha512-O9I2gVIpb5X7uUHBSU/MYVKEycZBP0rj7vzE656we4bprCEa9sfel5diUEvzsO4QqPu+Qofec9b6Z5BNluEQSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-2.1.0.tgz",
+      "integrity": "sha512-qeWf6eybvqpOd8kPlKyNK2ciMwZXvLu1jg6ObZmhX15sKHwSUW9nU6euTKoO3AfZ607rESdqb3sErpRAEDs0wg==",
       "requires": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+        "@bigcommerce/node-sass": "git+https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
+        "fibers": "^5.0.0",
         "lodash": "4.17.19",
-        "postcss": "^5.2.14"
+        "postcss": "^5.2.14",
+        "sass": "^1.42.0"
       },
       "dependencies": {
         "lodash": {
@@ -27679,15 +27623,6 @@
             "@hapi/hoek": "^8.2.4",
             "@hapi/pinpoint": "^1.0.2",
             "@hapi/topo": "^3.1.3"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
           }
         }
       }
@@ -29362,9 +29297,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -30529,9 +30464,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001112",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001112.tgz",
-      "integrity": "sha512-Xrn3lVEIsvAAUmFVHKKComfyCRM59NfuV3EwCXqs2XLgOxAqYgrfEs0vDk+Dk7KctlAMh6CH/CSd1srJt503ZA=="
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001260.tgz",
+      "integrity": "sha512-De8tLxxSZwDsxSuzKSHWvA4aOkCE0jB9H0QSihH7PJP3rjPSAYZQM4B9dmokQL+X5PQJ+DLS7npOIjCXKX/62w=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -31239,9 +31174,9 @@
       }
     },
     "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -32393,17 +32328,6 @@
       "requires": {
         "lru-cache": "^4.0.0",
         "which": "^1.2.8"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        }
       }
     },
     "css-select": {
@@ -32623,6 +32547,11 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -32817,9 +32746,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.526",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.526.tgz",
-      "integrity": "sha512-HiroW5ZbGwgT8kCnoEO8qnGjoTPzJxduvV/Vv/wH63eo2N6Zj3xT5fmmaSPAPUM05iN9/5fIEkIg3owTtV6QZg=="
+      "version": "1.3.848",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.848.tgz",
+      "integrity": "sha512-wchRyBcdcmibioggdO7CbMT5QQ4lXlN/g7Mkpf1K2zINidnqij6EVu94UIZ+h5nB2S9XD4bykqFv9LonAWLFyw=="
     },
     "emittery": {
       "version": "0.7.1",
@@ -34122,6 +34051,14 @@
         "pend": "~1.2.0"
       }
     },
+    "fibers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
+      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -34726,26 +34663,22 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -34754,14 +34687,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -34770,38 +34701,32 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -34809,26 +34734,22 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -34836,14 +34757,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -34858,8 +34777,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -34872,14 +34790,12 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -34887,8 +34803,7 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -34896,8 +34811,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -34906,20 +34820,17 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -34927,14 +34838,12 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -34942,14 +34851,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -34958,8 +34865,7 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -34967,8 +34873,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -34976,14 +34881,12 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -34993,8 +34896,7 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -35011,8 +34913,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -35021,8 +34922,7 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -35030,14 +34930,12 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -35046,8 +34944,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -35058,20 +34955,17 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "wrappy": "1"
           }
@@ -35079,20 +34973,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -35101,20 +34992,17 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -35125,16 +35013,14 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "extraneous": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -35148,8 +35034,7 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -35157,44 +35042,37 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -35202,8 +35080,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -35213,8 +35090,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -35222,14 +35098,12 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -35243,14 +35117,12 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -35258,14 +35130,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         }
       }
     },
@@ -35278,21 +35148,6 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "function-bind": {
@@ -36048,15 +35903,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
         }
       }
     },
@@ -41043,9 +40889,13 @@
       }
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -41524,6 +41374,22 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        }
+      }
+    },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -41575,6 +41441,14 @@
             "is-plain-object": "^2.0.4"
           }
         }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
       }
     },
     "modify-values": {
@@ -41772,40 +41646,6 @@
         "which": "1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -41870,9 +41710,9 @@
       }
     },
     "nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
         "abbrev": "1"
       }
@@ -41968,27 +41808,6 @@
         "uid-number": "0.0.5"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "requires": {
-            "abbrev": "1"
-          }
-        },
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
@@ -43735,29 +43554,6 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
     "rsvp": {
@@ -44146,6 +43942,117 @@
         }
       }
     },
+    "sass": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "readdirp": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "sass-graph": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.6.tgz",
@@ -44172,31 +44079,10 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
         "yargs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
-          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
+          "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
           "requires": {
             "camelcase": "^3.0.0",
             "cliui": "^3.2.0",
@@ -44210,16 +44096,7 @@
             "string-width": "^1.0.2",
             "which-module": "^1.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "5.0.0-security.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "5.0.0-security.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
-          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "object.assign": "^4.1.0"
+            "yargs-parser": "^5.0.1"
           }
         }
       }
@@ -46213,17 +46090,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "write-file-atomic": {
@@ -46297,19 +46163,18 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "dev": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "^3.0.0",
+        "object.assign": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "@bigcommerce/stencil-paper": "^3.0.0-rc.48",
-    "@bigcommerce/stencil-styles": "1.2.1",
+    "@bigcommerce/stencil-styles": "2.1.0",
     "@hapi/boom": "^8.0.1",
     "@hapi/glue": "^6.2.0",
     "@hapi/h2o2": "^8.3.2",

--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -84,17 +84,15 @@ internals.cssHandler = async (request, h) => {
             browsers: configuration.autoprefixer_browsers,
         },
     };
-    const stencilStyles = new StencilStyles();
+    const stencilStyles = new StencilStyles(console);
 
-    let css;
     try {
-        css = await promisify(stencilStyles.compileCss.bind(stencilStyles))('scss', params);
+        const css = await stencilStyles.compileCss('scss', params);
+        return h.response(css).type('text/css');
     } catch (err) {
         console.error(err);
         throw Boom.badData(err);
     }
-
-    return h.response(css).type('text/css');
 };
 
 /**


### PR DESCRIPTION
#### What?

Upgrade stencil styles to 2.1.0, that has dart sass as primary engine for css compilation

#### Tickets / Documentation

[STRF-9040](https://jira.bigcommerce.com/browse/STRF-9040)


