### PR TITLE
feat: Add overwrite option to download command

### DIFF
--- a/bin/stencil-download.js
+++ b/bin/stencil-download.js
@@ -34,16 +34,16 @@ const options = {
 async function run(opts) {
     const overwriteType = opts.file ? opts.file : 'files';
 
-    const answers =
-        opts.overwrite ||
-        (await inquirer.prompt([
-            {
-                message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
-                name: 'overwrite',
-                type: 'checkbox',
-                choices: ['Yes', 'No'],
-            },
-        ]));
+    const answers = opts.overwrite
+        ? [opts.overwrite]
+        : await inquirer.prompt([
+              {
+                  message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
+                  name: 'overwrite',
+                  type: 'checkbox',
+                  choices: ['Yes', 'No'],
+              },
+          ]);
 
     if (!answers.overwrite.includes('Yes')) {
         console.log(`Request cancelled by user ${'No'.red}`);

--- a/bin/stencil-download.js
+++ b/bin/stencil-download.js
@@ -15,7 +15,7 @@ program
     .option('-f, --file [filename]', 'specify the filename to download only')
     .option('-e, --exclude [exclude]', 'specify a directory to exclude from download')
     .option('-c, --channel_id [channelId]', 'specify the channel ID of the storefront', parseInt)
-    .option('-o, --overwrite [overwrite]', 'specify whether to overwrite local with remote files')
+    .option('-o, --overwrite', 'overwrite local with remote files')
     .parse(process.argv);
 
 checkNodeVersion();
@@ -34,18 +34,23 @@ const options = {
 async function run(opts) {
     const overwriteType = opts.file ? opts.file : 'files';
 
-    const answers = opts.overwrite
-        ? [opts.overwrite]
-        : await inquirer.prompt([
-              {
-                  message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
-                  name: 'overwrite',
-                  type: 'checkbox',
-                  choices: ['Yes', 'No'],
-              },
-          ]);
+    const promptAnswers = await inquirer.prompt([
+        {
+            message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
+            name: 'overwrite',
+            type: 'confirm',
+            when() {
+                return !opts.overwrite;
+            },
+        },
+    ]);
 
-    if (!answers.overwrite.includes('Yes')) {
+    const answers = {
+        ...opts,
+        ...promptAnswers,
+    };
+
+    if (!answers.overwrite) {
         console.log(`Request cancelled by user ${'No'.red}`);
         return;
     }

--- a/bin/stencil-download.js
+++ b/bin/stencil-download.js
@@ -15,6 +15,7 @@ program
     .option('-f, --file [filename]', 'specify the filename to download only')
     .option('-e, --exclude [exclude]', 'specify a directory to exclude from download')
     .option('-c, --channel_id [channelId]', 'specify the channel ID of the storefront', parseInt)
+    .option('-o, --overwrite [overwrite]', 'specify whether to overwrite local with remote files')
     .parse(process.argv);
 
 checkNodeVersion();
@@ -25,6 +26,7 @@ const options = {
     exclude: ['parsed', 'manifest.json', ...extraExclude],
     apiHost: cliOptions.host,
     channelId: cliOptions.channel_id,
+    overwrite: cliOptions.overwrite,
     applyTheme: true, // fix to be compatible with stencil-push.utils
     file: cliOptions.file,
 };
@@ -32,14 +34,16 @@ const options = {
 async function run(opts) {
     const overwriteType = opts.file ? opts.file : 'files';
 
-    const answers = await inquirer.prompt([
-        {
-            message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
-            name: 'overwrite',
-            type: 'checkbox',
-            choices: ['Yes', 'No'],
-        },
-    ]);
+    const answers =
+        opts.overwrite ||
+        (await inquirer.prompt([
+            {
+                message: `${'Warning'.yellow} -- overwrite local with remote ${overwriteType}?`,
+                name: 'overwrite',
+                type: 'checkbox',
+                choices: ['Yes', 'No'],
+            },
+        ]));
 
     if (!answers.overwrite.includes('Yes')) {
         console.log(`Request cancelled by user ${'No'.red}`);


### PR DESCRIPTION
#### What?
I want the ability to run `stencil download` without being prompted about whether to overwrite local files. The goal is to easier be able to run download in my CI pipeline.

This is a conceptual pull requests thus far, I have not verified whether the functionality works exactly as intended. This particular command seemed to be untested, so I did not venture to add any tests.

If you have preferences for how this functionality could work different, please let me know or feel free to make changes.