### PR TITLE
fix: replaced set-cookie header attributes in storefront api response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,6 +1175,16 @@
           "requires": {
             "@hapi/hoek": "8.x.x"
           }
+        },
+        "@hapi/wreck": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+          "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+          "requires": {
+            "@hapi/boom": "7.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x"
+          }
         }
       }
     },
@@ -1421,6 +1431,16 @@
           "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
           "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
           "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
+        "@hapi/wreck": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+          "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+          "requires": {
+            "@hapi/boom": "7.x.x",
+            "@hapi/bourne": "1.x.x",
             "@hapi/hoek": "8.x.x"
           }
         }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@hapi/h2o2": "^8.3.2",
     "@hapi/hapi": "^18.4.1",
     "@hapi/inert": "^5.2.2",
+    "@hapi/wreck": "15.x.x",
     "@octokit/rest": "^18.0.6",
     "ajv": "^6.12.5",
     "archiver": "^5.0.2",


### PR DESCRIPTION
fixes issue #792, and possibly #667


#### What?

Responses from the storefront API are returning `set-cookie` headers with attributes, such as "Same-Site=none" and "Secure" that are preventing cookies from being set when developing locally using `stencil start`

These changes aim to filter the response header from the proxy request and remove the unwanted attributes.

#### Tickets / Documentation

https://github.com/bigcommerce/stencil-cli/issues/792
https://github.com/bigcommerce/stencil-cli/issues/667

#### Screenshots (if appropriate)

cc @bigcommerce/storefront-team

Edited, for grammar.