### PR TITLE
fix: strf-9474 Removed "git+" prefix from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -537,8 +537,8 @@
       }
     },
     "@bigcommerce/node-sass": {
-      "version": "git+https://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
-      "from": "git+https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+      "version": "https://git@github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+      "from": "https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -598,7 +598,7 @@
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-2.1.0.tgz",
       "integrity": "sha512-qeWf6eybvqpOd8kPlKyNK2ciMwZXvLu1jg6ObZmhX15sKHwSUW9nU6euTKoO3AfZ607rESdqb3sErpRAEDs0wg==",
       "requires": {
-        "@bigcommerce/node-sass": "git+https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+        "@bigcommerce/node-sass": "https://git@github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
         "fibers": "^5.0.0",
         "lodash": "4.17.19",


### PR DESCRIPTION
#### What?

Removed "git+" protocol from node-sass dependencies in package-lock.json

https://github.blog/2021-09-01-improving-git-protocol-security-github/

#### Tickets / Documentation

-   [STRF-9474](https://jira.bigcommerce.com/browse/STRF-9474)


cc @bigcommerce/storefront-team
