### PR TITLE
docs(release): release 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.6.5 (2021-11-22)
+
+-   fix: strf-4307 Frontmatter/yaml validation and trailing symbols checks ([798](https://github.com/bigcommerce/stencil-cli/pull/798))
+
 ### 3.6.4 (2021-11-5)
 
 -   fix: strf-9474 Removed "git+" prefix from package-lock ([794](https://github.com/bigcommerce/stencil-cli/pull/794))

--- a/lib/bundle-validator.js
+++ b/lib/bundle-validator.js
@@ -391,11 +391,6 @@ class BundleValidator {
                 try {
                     const result = yamlValidator.loadAll(yaml);
                     this.validateTrailingSymbols(result[0]);
-                    if (filePath.includes('home.html')) {
-                        console.log(filePath);
-                        console.log(yaml);
-                        console.log(result[0].products.new.limit);
-                    }
                 } catch (e) {
                     throw new Error(
                         `Error: ${e.message}, while parsing frontmatter at "${filePath}".`.red,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
#### What?

-   fix: strf-4307 Frontmatter/yaml validation and trailing symbols checks ([798](https://github.com/bigcommerce/stencil-cli/pull/798))


cc @bigcommerce/storefront-team
