### PR TITLE
feat: strf-9245 Warn user if shopper default language file is missing or has missing keys

### DIFF
--- a/lib/lang-helper.js
+++ b/lib/lang-helper.js
@@ -1,0 +1,59 @@
+require('colors');
+const fsUtilsModule = require('./utils/fsUtils');
+
+function flattenObject(object, result = {}, parentKey = '') {
+    return Object.entries(object).reduce((currentLayer, [key, innerValue]) => {
+        const resultKey = parentKey !== '' ? `${parentKey}.${key}` : key;
+        if (typeof innerValue === 'object') {
+            return flattenObject(innerValue, currentLayer, resultKey);
+        }
+        // eslint-disable-next-line no-param-reassign
+        currentLayer[resultKey] = innerValue;
+        return currentLayer;
+    }, result);
+}
+
+class LangHelper {
+    constructor({ fsUtils = fsUtilsModule, logger = console } = {}) {
+        this._fsUtils = fsUtils;
+        this._logger = logger;
+    }
+
+    async checkLangKeysPresence(filesPaths, themeLang) {
+        const themeLangFilename = `${themeLang}.json`;
+        const defaultLangFilePath = filesPaths.find((filePath) =>
+            filePath.includes(themeLangFilename),
+        );
+        const defaultLangFile = await this._fsUtils.parseJsonFile(defaultLangFilePath);
+        const flattenedDefaultLang = flattenObject(defaultLangFile);
+        const alreadyWarnedKey = [];
+
+        for await (const filePath of filesPaths) {
+            if (!filePath.includes(themeLangFilename)) {
+                const langFile = await this._fsUtils.parseJsonFile(filePath);
+                const flattenedLang = flattenObject(langFile);
+                const langKeys = Object.keys(flattenedLang);
+                for (const langKey of langKeys) {
+                    if (!alreadyWarnedKey.includes(langKey)) {
+                        if (!flattenedDefaultLang[langKey]) {
+                            this._logger.log(
+                                `${
+                                    'Warning'.yellow
+                                }: file: ${defaultLangFilePath} doesn't have ${langKey}, which is present in ${filePath}`,
+                            );
+                        } else if (flattenedDefaultLang[langKey].trim().length === 0) {
+                            this._logger.log(
+                                `${
+                                    'Warning'.yellow
+                                }: file: ${defaultLangFilePath} has ${langKey}, but it's empty`,
+                            );
+                        }
+                        alreadyWarnedKey.push(langKey);
+                    }
+                }
+            }
+        }
+    }
+}
+
+module.exports = LangHelper;

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -14,11 +14,15 @@ const fsUtilsModule = require('./utils/fsUtils');
 const stencilPushUtilsModule = require('./stencil-push.utils');
 const cliCommonModule = require('./cliCommon');
 const themeApiClientModule = require('./theme-api-client');
+const storeSettingsApiClientModule = require('./store-settings-api-client');
+const LangHelper = require('./lang-helper');
 
 class StencilStart {
     constructor({
         browserSync = BrowserSync.create(),
         themeApiClient = themeApiClientModule,
+        storeSettingsApiClient = storeSettingsApiClientModule,
+        langHelper = new LangHelper(),
         fsUtils = fsUtilsModule,
         cliCommon = cliCommonModule,
         stencilConfigManager = new StencilConfigManager(),
@@ -31,6 +35,8 @@ class StencilStart {
     } = {}) {
         this._browserSync = browserSync;
         this._themeApiClient = themeApiClient;
+        this._storeSettingsApiClient = storeSettingsApiClient;
+        this._langHelper = langHelper;
         this._fsUtils = fsUtils;
         this._cliCommon = cliCommon;
         this._stencilConfigManager = stencilConfigManager;
@@ -72,11 +78,11 @@ class StencilStart {
     async getChannelUrl(stencilConfig, cliOptions) {
         const { accessToken } = stencilConfig;
         const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
-        const storeHash = await this._themeApiClient.getStoreHash({
+        this.storeHash = await this._themeApiClient.getStoreHash({
             storeUrl: stencilConfig.normalStoreUrl,
         });
         const channels = await this._themeApiClient.getStoreChannels({
-            storeHash,
+            storeHash: this.storeHash,
             accessToken,
             apiHost,
         });
@@ -89,6 +95,16 @@ class StencilStart {
             (channel) => channel.channel_id === parseInt(channelId, 10),
         );
         return foundChannel ? foundChannel.url : null;
+    }
+
+    async getDefaultShopperLanguage(cliOptions, stencilConfig) {
+        const { accessToken } = stencilConfig;
+        const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
+        return this._storeSettingsApiClient.getDefaultShopperLanguage({
+            storeHash: this.storeHash,
+            accessToken,
+            apiHost,
+        });
     }
 
     /**
@@ -140,6 +156,10 @@ class StencilStart {
         const DEFAULT_WATCH_IGNORED = ['/assets/scss', '/assets/css'];
         const { themePath, configPath } = this._themeConfigManager;
         const { watchOptions } = this._buildConfigManager;
+        const defaultShopperLanguage = await this.getDefaultShopperLanguage(
+            cliOptions,
+            stencilConfig,
+        );
 
         // Watch sccs directory and automatically reload all css files if a file changes
         const stylesPath = path.join(themePath, 'assets/scss');
@@ -174,6 +194,17 @@ class StencilStart {
             try {
                 const results = await this.assembleTemplates(templatesPath);
                 new this._CyclesDetector(results).detect();
+            } catch (e) {
+                this._logger.error(e);
+            }
+        });
+
+        const langsPath = path.join(themePath, 'lang');
+        this._browserSync.watch(langsPath, async (event) => {
+            try {
+                if (event === 'change') {
+                    await this.checkLangFiles(langsPath, defaultShopperLanguage);
+                }
             } catch (e) {
                 this._logger.error(e);
             }
@@ -215,6 +246,8 @@ class StencilStart {
         if (this._buildConfigManager.development) {
             this._buildConfigManager.initWorker().development(this._browserSync);
         }
+
+        await this.checkLangFiles(langsPath, defaultShopperLanguage);
     }
 
     /**
@@ -234,6 +267,23 @@ class StencilStart {
                 promisify(this._templateAssembler.assemble)(templatesPath, templateName),
             ),
         );
+    }
+
+    async checkLangFiles(langsPath, defaultShopperLanguage) {
+        const filesPaths = await this._fsUtils.recursiveReadDir(langsPath);
+        const isDefaultLanguagePresent = filesPaths.some((file) =>
+            file.includes(defaultShopperLanguage),
+        );
+
+        if (!isDefaultLanguagePresent) {
+            this._logger.log(
+                `${
+                    'Warning'.yellow
+                }: "missing language file for default shopper language: ${defaultShopperLanguage}"`,
+            );
+        }
+
+        await this._langHelper.checkLangKeysPresence(filesPaths, defaultShopperLanguage);
     }
 
     /**

--- a/lib/store-settings-api-client.js
+++ b/lib/store-settings-api-client.js
@@ -1,0 +1,26 @@
+require('colors');
+const NetworkUtils = require('./utils/NetworkUtils');
+
+const networkUtils = new NetworkUtils();
+
+async function getDefaultShopperLanguage({ apiHost, storeHash, accessToken }) {
+    try {
+        const response = await networkUtils.sendApiRequest({
+            url: `${apiHost}/stores/${storeHash}/v3/settings/store/locale`,
+            accessToken,
+        });
+        if (!response.data.data || !response.data.data.default_shopper_language) {
+            throw new Error(
+                'Received empty default_shopper_language value in the server response'.red,
+            );
+        }
+        return response.data.data.default_shopper_language;
+    } catch (err) {
+        err.name = 'DefaultShopperLanguageError';
+        throw err;
+    }
+}
+
+module.exports = {
+    getDefaultShopperLanguage,
+};


### PR DESCRIPTION
#### What?
As a Stencil CLI user,
When I run `stencil start` for a particular store,
I will receive a warning if the store's default shopper language does not have a language file within the theme.

#### Tickets / Documentation

-   [STRF-9245](https://jira.bigcommerce.com/browse/STRF-9245)

#### Screenshots (if appropriate)
<img width="1787" alt="Screenshot 2021-12-02 at 17 24 40" src="https://user-images.githubusercontent.com/68893868/144463116-8841aebb-da5a-4a5e-9582-08d046bad205.png">


cc @bigcommerce/storefront-team
