### PR TITLE
fix: strf-9535 Add fallback for shopper language default

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -68,11 +68,26 @@ class StencilStart {
             storeInfoFromAPI,
         );
 
+        this._storeSettingsLocale = await this.getStoreSettingsLocale(
+            cliOptions,
+            updatedStencilConfig,
+        );
+
         await this.startLocalServer(cliOptions, updatedStencilConfig);
 
         this._logger.log(this.getStartUpInfo(updatedStencilConfig));
 
         await this.startBrowserSync(cliOptions, updatedStencilConfig, browserSyncPort);
+    }
+
+    async getStoreSettingsLocale(cliOptions, stencilConfig) {
+        const { accessToken } = stencilConfig;
+        const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
+        return this._storeSettingsApiClient.getStoreSettingsLocale({
+            storeHash: this.storeHash,
+            accessToken,
+            apiHost,
+        });
     }
 
     async getChannelUrl(stencilConfig, cliOptions) {
@@ -95,16 +110,6 @@ class StencilStart {
             (channel) => channel.channel_id === parseInt(channelId, 10),
         );
         return foundChannel ? foundChannel.url : null;
-    }
-
-    async getDefaultShopperLanguage(cliOptions, stencilConfig) {
-        const { accessToken } = stencilConfig;
-        const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
-        return this._storeSettingsApiClient.getDefaultShopperLanguage({
-            storeHash: this.storeHash,
-            accessToken,
-            apiHost,
-        });
     }
 
     /**
@@ -148,6 +153,7 @@ class StencilStart {
             useCache: cliOptions.cache,
             themePath: this._themeConfigManager.themePath,
             stencilCliVersion: PACKAGE_INFO.version,
+            storeSettingsLocale: this._storeSettingsLocale,
         });
     }
 
@@ -156,10 +162,6 @@ class StencilStart {
         const DEFAULT_WATCH_IGNORED = ['/assets/scss', '/assets/css'];
         const { themePath, configPath } = this._themeConfigManager;
         const { watchOptions } = this._buildConfigManager;
-        const defaultShopperLanguage = await this.getDefaultShopperLanguage(
-            cliOptions,
-            stencilConfig,
-        );
 
         // Watch sccs directory and automatically reload all css files if a file changes
         const stylesPath = path.join(themePath, 'assets/scss');
@@ -203,7 +205,10 @@ class StencilStart {
         this._browserSync.watch(langsPath, async (event) => {
             try {
                 if (event === 'change') {
-                    await this.checkLangFiles(langsPath, defaultShopperLanguage);
+                    await this.checkLangFiles(
+                        langsPath,
+                        this._storeSettingsLocale.default_shopper_language,
+                    );
                 }
             } catch (e) {
                 this._logger.error(e);
@@ -247,7 +252,7 @@ class StencilStart {
             this._buildConfigManager.initWorker().development(this._browserSync);
         }
 
-        await this.checkLangFiles(langsPath, defaultShopperLanguage);
+        await this.checkLangFiles(langsPath, this._storeSettingsLocale.default_shopper_language);
     }
 
     /**

--- a/lib/store-settings-api-client.js
+++ b/lib/store-settings-api-client.js
@@ -3,24 +3,32 @@ const NetworkUtils = require('./utils/NetworkUtils');
 
 const networkUtils = new NetworkUtils();
 
-async function getDefaultShopperLanguage({ apiHost, storeHash, accessToken }) {
+async function getStoreSettingsLocale({ apiHost, storeHash, accessToken }) {
     try {
         const response = await networkUtils.sendApiRequest({
             url: `${apiHost}/stores/${storeHash}/v3/settings/store/locale`,
             accessToken,
         });
-        if (!response.data.data || !response.data.data.default_shopper_language) {
+
+        if (!response.data.data) {
+            throw new Error('Received empty store locale in the server response'.red);
+        } else if (!response.data.data.default_shopper_language) {
             throw new Error(
-                'Received empty default_shopper_language value in the server response'.red,
+                'Received empty default_shopper_language field in the server response'.red,
+            );
+        } else if (!response.data.data.shopper_language_selection_method) {
+            throw new Error(
+                'Received empty shopper_language_selection_method field in the server response'.red,
             );
         }
-        return response.data.data.default_shopper_language;
+
+        return response.data.data;
     } catch (err) {
-        err.name = 'DefaultShopperLanguageError';
+        err.name = 'StoreSettingsLocaleError';
         throw err;
     }
 }
 
 module.exports = {
-    getDefaultShopperLanguage,
+    getStoreSettingsLocale,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,8 @@ function buildManifest(srcManifest, options) {
         options.dotStencilFile.customLayouts;
     pluginsByName['./plugins/renderer/renderer.module'].themePath = options.themePath;
     pluginsByName['./plugins/renderer/renderer.module'].storeUrl = storeUrl;
+    pluginsByName['./plugins/renderer/renderer.module'].storeSettingsLocale =
+        options.storeSettingsLocale;
     pluginsByName['./plugins/theme-assets/theme-assets.module'].themePath = options.themePath;
 
     resManifest.register.plugins = _.reduce(

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -364,6 +364,16 @@ internals.getTemplatePath = (requestPath, data) => {
     return templatePath || data.template_file;
 };
 
+function getAcceptLanguageHeader(request) {
+    if (
+        internals.options.storeSettingsLocale.shopper_language_selection_method ===
+        'default_shopper_language'
+    ) {
+        return internals.options.storeSettingsLocale.default_shopper_language;
+    }
+    return request.headers['accept-language'];
+}
+
 /**
  * Creates a new Pencil Response object and returns it.
  *
@@ -400,7 +410,7 @@ internals.getPencilResponse = (data, request, response, configuration, renderedR
             context,
             translations: data.translations,
             method: request.method,
-            acceptLanguage: request.headers['accept-language'],
+            acceptLanguage: getAcceptLanguageHeader(request),
             headers: response.headers,
             statusCode: response.status,
         },


### PR DESCRIPTION
#### What?

Properly apply default shopper language when shopper selection mode is set to use it.

<img width="1439" alt="Screen Shot 2021-12-06 at 8 38 41 AM" src="https://user-images.githubusercontent.com/1263106/144865337-fc933c7f-ac5d-4d26-b465-8c5f06580b80.png">

cc @bigcommerce/storefront-team
