### PR TITLE
fix: strf-9245 don't try to load default shopper lang file, when it doesn't exist

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -286,9 +286,13 @@ class StencilStart {
                     'Warning'.yellow
                 }: "missing language file for default shopper language: ${defaultShopperLanguage}"`,
             );
+        } else {
+            try {
+                await this._langHelper.checkLangKeysPresence(filesPaths, defaultShopperLanguage);
+            } catch (e) {
+                this._logger.error(e);
+            }
         }
-
-        await this._langHelper.checkLangKeysPresence(filesPaths, defaultShopperLanguage);
     }
 
     /**


### PR DESCRIPTION
#### What?

Noticed a small bug, that should be fixed with this PR. It happens when we delete the default shopper lang file and still try to load it. So moved that check into else condition. 

#### Tickets / Documentation

-   [STRF-9245](https://jira.bigcommerce.com/browse/STRF-9245)

#### Screenshots (if appropriate)
<img width="1044" alt="Screenshot 2021-12-08 at 14 25 27" src="https://user-images.githubusercontent.com/68893868/145208098-4aee681a-bf03-4166-9942-c961c48d1e0f.png">


cc @bigcommerce/storefront-team
