### PR TITLE
docs(release): release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 3.7.0 (2021-12-08)
+
+-   fix: strf-9535 Add fallback for shopper language default ([804](https://github.com/bigcommerce/stencil-cli/pull/804))
+-   feat: strf-9245 Warn user if shopper default language file is missing or has missing keys ([802](https://github.com/bigcommerce/stencil-cli/pull/802))
+-   Bump paper to rc52
+
+Note: BREAKING CHANGE!
+In order to get stencil cli working with this version, new Stencil CLI token should be created
+
 ### 3.6.5 (2021-11-22)
 
 -   fix: strf-4307 Frontmatter/yaml validation and trailing symbols checks ([798](https://github.com/bigcommerce/stencil-cli/pull/798))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -570,19 +570,19 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0-rc.51",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.51.tgz",
-      "integrity": "sha512-ZnGgG3i8HLhevSOU/Rher2ovPMSLwhqBvDD0m1GA2dp7R8oaZSBlIMSAqvZ1/gtTTk4R0kBsBYC6cz2YbAqwJg==",
+      "version": "3.0.0-rc.52",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.52.tgz",
+      "integrity": "sha512-hANH4m0dh9YJuXIlirXj2F9HeWv8k2kJXH1lZkDWx7Ukl0Mn+caibBFprb4Ds+maAc9mHjg9ECUZ5WFT2wBSgA==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "4.5.0",
+        "@bigcommerce/stencil-paper-handlebars": "4.5.1",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.5.0.tgz",
-      "integrity": "sha512-ADkNTYC7U6IaWPY3PKz1nEH3oyuKBA6XKBhKnpeTLhGxORwnYAde+fC1XZ8+OHweAEE0/EXsumqhierYBrvAhw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.5.1.tgz",
+      "integrity": "sha512-drdYQDXFI8BI/H4/ACmYJUA1QfCbpYVp8MxG/B+JNZypg6UzTnWRJOvCKqohfr9obnLbSdL+nMjVol2cq/RmgQ==",
       "requires": {
         "@bigcommerce/handlebars-v4": "4.7.6",
         "handlebars": "3.0.8",
@@ -18125,9 +18125,9 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
-      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.4.tgz",
+      "integrity": "sha512-AbiSR44J0GoCeV81+oxcy/jDOElO2Bx3d0MfQCUShq7JRXaM4KtQopZsq2vFv8bCq2yMaGrw1FgygUd03RyRDA==",
       "optional": true
     },
     "uglify-to-browserify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
@@ -44,7 +44,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "^3.0.0-rc.51",
+    "@bigcommerce/stencil-paper": "^3.0.0-rc.52",
     "@bigcommerce/stencil-styles": "2.1.0",
     "@hapi/boom": "^8.0.1",
     "@hapi/glue": "^6.2.0",


### PR DESCRIPTION
-   fix: strf-9535 Add fallback for shopper language default ([804](https://github.com/bigcommerce/stencil-cli/pull/804))
-   feat: strf-9245 Warn user if shopper default language file is missing or has missing keys ([802](https://github.com/bigcommerce/stencil-cli/pull/802))
-   Bump paper to rc52

Note: BREAKING CHANGE!
In order to get stencil cli working with this version, new Stencil CLI token should be created


cc @bigcommerce/storefront-team
