### PR TITLE
fix: strf-9553 bundled lang.json has lowercase lang keys

### DIFF
--- a/lib/lang-assembler.js
+++ b/lib/lang-assembler.js
@@ -26,7 +26,7 @@ function assemble(callback) {
         for (const localeFile of filteredLocaleFiles) {
             const localeName = path.basename(localeFile, '.json');
 
-            localesToLoad[localeName] = (cb2) => {
+            localesToLoad[localeName.toLowerCase()] = (cb2) => {
                 const localeFilePath = `${LOCALE_DIRECTORY}/${localeFile}`;
 
                 fs.readFile(localeFilePath, 'utf-8', cb2);

--- a/lib/lang-assembler.spec.js
+++ b/lib/lang-assembler.spec.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const { assemble } = require('./lang-assembler');
+
+describe('lang-assembler', () => {
+    const langFiles = ['en.json', 'pt-BR.json', 'pt.json', 'fr.json', 'fr-CA.json'];
+    beforeEach(() => {
+        jest.spyOn(fs, 'readdir').mockImplementation((dir, cb) => {
+            cb(null, langFiles);
+        });
+        jest.spyOn(fs, 'readFile').mockImplementation((filename, encoding, cb) => {
+            cb(null, filename);
+        });
+    });
+
+    it('should run lang assemble task successfully', async () => {
+        assemble((err, result) => {
+            const keys = Object.keys(result);
+            expect(keys).toHaveLength(langFiles.length);
+        });
+    });
+
+    it('should return lower case lang keys', () => {
+        assemble((err, result) => {
+            Object.keys(result).forEach((lang) => {
+                expect(lang).toEqual(lang.toLowerCase());
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### What?

During bundle process parsed/lang.json now will have lang keys in lowercase.

#### Tickets / Documentation

-   [STRF-9553](https://jira.bigcommerce.com/browse/STRF-9553)


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/68893868/145610831-ae9d198c-b640-4edf-900e-5c7e7864a205.mov



cc @bigcommerce/storefront-team
