### PR TITLE
fix: strf-9576 Fix graphql queries

### DIFF
--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -170,6 +170,7 @@ internals.registerRoutes = (server) => {
                             },
                         ),
                     }),
+                    rejectUnauthorized: false,
                     passThrough: true,
                 },
             },


### PR DESCRIPTION
#### What?

Queries to GraphlQL API are broken now. This PR aims to fix by not verifying certificates. 

#### Tickets / Documentation

-   [STRF-9576](https://jira.bigcommerce.com/browse/STRF-9576)

#### Screenshots (if appropriate)


<img width="556" alt="Screenshot 2021-12-16 at 18 28 35" src="https://user-images.githubusercontent.com/68893868/146410343-cfbf7ead-b0ab-4fd9-aa7e-da607f88fd63.png">
410277-24510a41-4491-4cc3-a395-f6f83c6919dc.png">

cc @bigcommerce/storefront-team
