### PR TITLE
feat(storefront): strf-9582 stencil push: apply theme to multiple storefronts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Run `stencil push` to bundle the local theme and upload it to your store, so it 
 To push the theme and also activate it, use `stencil push -a`. To automatically delete the oldest theme if you are at
 your theme limit, use `stencil push -d`. These can be used together, as `stencil push -a -d`. You can apply the theme to
 multiple storefronts, just specify ids of desired storefronts/channels after `-c` option `stencil push -a -c 123 456 789`.
+If you want to apply theme to all available storefronts, just use `-allc` option: `stencil push -a -allc`.
 
 Run `stencil pull` to sync changes to your theme configuration from your live store. For example, if Page Builder has
 been used to change certain theme settings, this will update those settings in config.json in your theme files so you

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This is useful for tracking your changes in your Theme, and is the tool we use t
 
 Run `stencil push` to bundle the local theme and upload it to your store, so it will be available in My Themes.
 To push the theme and also activate it, use `stencil push -a`. To automatically delete the oldest theme if you are at
-your theme limit, use `stencil push -d`. These can be used together, as `stencil push -a -d`.
+your theme limit, use `stencil push -d`. These can be used together, as `stencil push -a -d`. You can apply the theme to
+multiple storefronts, just specify ids of desired storefronts/channels after `-c` option `stencil push -a -c 123 456 789`.
 
 Run `stencil pull` to sync changes to your theme configuration from your live store. For example, if Page Builder has
 been used to change certain theme settings, this will update those settings in config.json in your theme files so you

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -18,6 +18,7 @@ program
         '-c, --channel_ids <channelIds...>',
         'specify the channel IDs of the storefront to push the theme to',
     )
+    .option('-allc, --all_channels', 'push a theme to all available channels')
     .parse(process.argv);
 
 checkNodeVersion();
@@ -30,6 +31,7 @@ const options = {
     activate: cliOptions.activate,
     saveBundleName: cliOptions.save,
     deleteOldest: cliOptions.delete,
+    allChannels: cliOptions.all_channels,
 };
 stencilPush(options, (err, result) => {
     if (err) {

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -15,9 +15,8 @@ program
     .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
     .option('-d, --delete', 'delete oldest private theme if upload limit reached')
     .option(
-        '-c, --channel_id [channelId]',
-        'specify the channel ID of the storefront to push the theme to',
-        parseInt,
+        '-c, --channel_ids <channelIds...>',
+        'specify the channel IDs of the storefront to push the theme to',
     )
     .parse(process.argv);
 
@@ -26,7 +25,7 @@ checkNodeVersion();
 const cliOptions = program.opts();
 const options = {
     apiHost: cliOptions.host,
-    channelId: cliOptions.channel_id,
+    channelIds: cliOptions.channel_ids,
     bundleZipPath: cliOptions.file,
     activate: cliOptions.activate,
     saveBundleName: cliOptions.save,

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -339,14 +339,14 @@ utils.getVariations = async (options) => {
 };
 
 utils.promptUserForChannel = async (options) => {
-    const { applyTheme, channelId, channels } = options;
+    const { applyTheme, channelIds, channels } = options;
 
-    if (!applyTheme || channelId) {
+    if (!applyTheme || channelIds) {
         return options;
     }
 
-    const selectedChannelId = await utils.promptUserToSelectChannel(channels);
-    return { ...options, channelId: selectedChannelId };
+    const selectedChannelIds = await utils.promptUserToSelectChannel(channels);
+    return { ...options, channelIds: selectedChannelIds };
 };
 
 utils.promptUserToSelectChannel = async (channels) => {
@@ -356,9 +356,9 @@ utils.promptUserToSelectChannel = async (channels) => {
 
     const questions = [
         {
-            type: 'list',
-            name: 'channelId',
-            message: 'Which channel would you like to use?',
+            type: 'checkbox',
+            name: 'channelIds',
+            message: 'Which channel(s) would you like to use?',
             choices: channels.map((channel) => ({
                 name: channel.url,
                 value: channel.channel_id,
@@ -367,7 +367,7 @@ utils.promptUserToSelectChannel = async (channels) => {
     ];
 
     const answer = await Inquirer.prompt(questions);
-    return answer.channelId;
+    return answer.channelIds;
 };
 
 utils.promptUserForVariation = async (options) => {
@@ -414,18 +414,18 @@ utils.requestToApplyVariation = async (options) => {
         config: { accessToken },
         storeHash,
         variationId,
-        channelId,
+        channelIds,
     } = options;
 
     const apiHost = options.apiHost || options.config.apiHost;
 
     if (options.applyTheme) {
         await themeApiClient.activateThemeByVariationId({
-            accessToken,
+            variationId,
+            channelIds,
             apiHost,
             storeHash,
-            variationId,
-            channelId,
+            accessToken,
         });
     }
 

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -425,15 +425,13 @@ utils.requestToApplyVariation = async (options) => {
     const apiHost = options.apiHost || options.config.apiHost;
 
     if (options.applyTheme) {
-        await Promise.all(
-            await themeApiClient.activateThemeByVariationId({
-                variationId,
-                channelIds,
-                apiHost,
-                storeHash,
-                accessToken,
-            }),
-        );
+        await themeApiClient.activateThemeByVariationId({
+            variationId,
+            channelIds,
+            apiHost,
+            storeHash,
+            accessToken,
+        });
     }
 
     return options;

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -425,13 +425,15 @@ utils.requestToApplyVariation = async (options) => {
     const apiHost = options.apiHost || options.config.apiHost;
 
     if (options.applyTheme) {
-        await themeApiClient.activateThemeByVariationId({
-            variationId,
-            channelIds,
-            apiHost,
-            storeHash,
-            accessToken,
-        });
+        await Promise.all(
+            await themeApiClient.activateThemeByVariationId({
+                variationId,
+                channelIds,
+                apiHost,
+                storeHash,
+                accessToken,
+            }),
+        );
     }
 
     return options;

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -274,14 +274,14 @@ utils.promptUserWhetherToApplyTheme = async (options) => {
 utils.getChannels = async (options) => {
     const {
         config: { accessToken },
-        channelId,
+        channelIds,
         storeHash,
         applyTheme,
     } = options;
 
     const apiHost = options.apiHost || options.config.apiHost;
 
-    if (!applyTheme || channelId) {
+    if (!applyTheme || channelIds) {
         return options;
     }
 
@@ -339,10 +339,15 @@ utils.getVariations = async (options) => {
 };
 
 utils.promptUserForChannel = async (options) => {
-    const { applyTheme, channelIds, channels } = options;
+    const { applyTheme, channelIds, channels, allChannels } = options;
 
     if (!applyTheme || channelIds) {
         return options;
+    }
+
+    if (allChannels) {
+        const allIds = channels.map((chanel) => chanel.channel_id);
+        return { ...options, channelIds: allIds };
     }
 
     const selectedChannelIds = await utils.promptUserToSelectChannel(channels);

--- a/lib/stencil-push.utils.spec.js
+++ b/lib/stencil-push.utils.spec.js
@@ -1,7 +1,12 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
 
-const { getStoreHash } = require('./stencil-push.utils');
+const {
+    getStoreHash,
+    promptUserForChannel,
+    // promptUserToSelectChannel,
+    getChannels,
+} = require('./stencil-push.utils');
 
 const axiosMock = new MockAdapter(axios);
 
@@ -11,10 +16,37 @@ describe('stencil push utils', () => {
         port: 4000,
         accessToken: 'accessTokenValue',
     };
+    const optionsApplyThemeIsFalse = {
+        config: { accessToken: 'asdasd33' },
+        applyTheme: false,
+        apiHost: 'abc2342',
+    };
+    const optionsApplyThemeIsTrueAndChannels = {
+        config: { accessToken: 'asdasd33' },
+        applyTheme: true,
+        channelIds: [1, 2],
+    };
+    const optionsResult = {
+        applyTheme: true,
+        apiHost: 'abc2342',
+        allChannels: true,
+        channels: [
+            {
+                url: 'https://abc.com',
+                channel_id: 1,
+            },
+            {
+                url: 'https://fff.com',
+                channel_id: 2,
+            },
+        ],
+        channelIds: [1, 2],
+    };
 
     afterEach(() => {
         jest.restoreAllMocks();
         axiosMock.reset();
+        jest.clearAllMocks();
     });
 
     describe('.getStoreHash()', () => {
@@ -37,6 +69,82 @@ describe('stencil push utils', () => {
             await expect(getStoreHash({ config: mockConfig })).rejects.toThrow(
                 'Received empty store_hash value in the server response',
             );
+        });
+    });
+
+    describe('.getChannels', () => {
+        it('should return options when applyTheme is false', async () => {
+            const result = await getChannels(optionsApplyThemeIsFalse);
+            expect(result).toEqual(optionsApplyThemeIsFalse);
+        });
+
+        it('should return options when applyTheme is true and channelIds available', async () => {
+            const result = await getChannels(optionsApplyThemeIsTrueAndChannels);
+            expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
+        });
+
+        // TODO: check that getStoreChannels function is called
+    });
+
+    // TODO: check that promptUserToSelectChannel method is not called in majority cases;
+    describe('.promptUserForChannel', () => {
+        it('should return options when applyTheme is false and no channelIds available', async () => {
+            const result = await promptUserForChannel(optionsApplyThemeIsFalse);
+            expect(result).toEqual(optionsApplyThemeIsFalse);
+        });
+
+        it('should return options when applyTheme is true and channelIds available', async () => {
+            const result = await promptUserForChannel(optionsApplyThemeIsTrueAndChannels);
+            expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
+        });
+
+        it('should return options with all channelIds available when -allc option used', async () => {
+            const options = {
+                applyTheme: true,
+                apiHost: 'abc2342',
+                allChannels: true,
+                channels: [
+                    {
+                        url: 'https://abc.com',
+                        channel_id: 1,
+                    },
+                    {
+                        url: 'https://fff.com',
+                        channel_id: 2,
+                    },
+                ],
+            };
+
+            const result = await promptUserForChannel(options);
+
+            expect(result).toEqual(optionsResult);
+        });
+
+        it('should call promptUserToSelectChannel when applyTheme is true and no channelIds available', async () => {
+            const options = {
+                applyTheme: true,
+                apiHost: 'abc2342',
+                channels: [
+                    {
+                        url: 'https://abc.com',
+                        channel_id: 1,
+                    },
+                ],
+            };
+
+            const spy = jest.spyOn(promptUserForChannel.prototype, 'promptUserToSelectChannel');
+            //  .mockReturnValue([1, 2]);
+            spy.mockImplementation(() => Promise.resolve([1, 2]));
+            // const result = await promptUserForChannel(options);
+            // const call = promptUserToSelectChannel(options.channels).mockImplementation(() =>
+            //     Promise.resolve([1, 2]),
+            // );
+            // console.log(result);
+            expect.assertions(1);
+
+            promptUserForChannel(options);
+
+            expect(spy).toHaveBeenCalled();
         });
     });
 });

--- a/lib/stencil-push.utils.spec.js
+++ b/lib/stencil-push.utils.spec.js
@@ -1,12 +1,9 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
 
-const {
-    getStoreHash,
-    promptUserForChannel,
-    // promptUserToSelectChannel,
-    getChannels,
-} = require('./stencil-push.utils');
+const { getStoreHash, promptUserForChannel, getChannels } = require('./stencil-push.utils');
+const utils = require('./stencil-push.utils');
+const themeApiClient = require('./theme-api-client');
 
 const axiosMock = new MockAdapter(axios);
 
@@ -83,18 +80,37 @@ describe('stencil push utils', () => {
             expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
         });
 
-        // TODO: check that getStoreChannels function is called
+        it('should call getStoreChannels', async () => {
+            const options = {
+                applyTheme: true,
+                config: {
+                    accessToken: 'asdasdqweq',
+                },
+            };
+            const spy = jest.spyOn(themeApiClient, 'getStoreChannels').mockReturnValue([]);
+
+            await getChannels(options);
+
+            expect(spy).toHaveBeenCalled();
+        });
     });
 
-    // TODO: check that promptUserToSelectChannel method is not called in majority cases;
     describe('.promptUserForChannel', () => {
+        const mockPromptUserToSelectChannel = jest
+            .spyOn(utils, 'promptUserToSelectChannel')
+            .mockReturnValue({});
+
         it('should return options when applyTheme is false and no channelIds available', async () => {
             const result = await promptUserForChannel(optionsApplyThemeIsFalse);
+
+            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
             expect(result).toEqual(optionsApplyThemeIsFalse);
         });
 
         it('should return options when applyTheme is true and channelIds available', async () => {
             const result = await promptUserForChannel(optionsApplyThemeIsTrueAndChannels);
+
+            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
             expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
         });
 
@@ -117,6 +133,7 @@ describe('stencil push utils', () => {
 
             const result = await promptUserForChannel(options);
 
+            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
             expect(result).toEqual(optionsResult);
         });
 
@@ -132,19 +149,13 @@ describe('stencil push utils', () => {
                 ],
             };
 
-            const spy = jest.spyOn(promptUserForChannel.prototype, 'promptUserToSelectChannel');
-            //  .mockReturnValue([1, 2]);
-            spy.mockImplementation(() => Promise.resolve([1, 2]));
-            // const result = await promptUserForChannel(options);
-            // const call = promptUserToSelectChannel(options.channels).mockImplementation(() =>
-            //     Promise.resolve([1, 2]),
-            // );
-            // console.log(result);
-            expect.assertions(1);
+            const utilsPromptUserForChannelStub = jest
+                .spyOn(utils, 'promptUserToSelectChannel')
+                .mockReturnValue([]);
 
             promptUserForChannel(options);
 
-            expect(spy).toHaveBeenCalled();
+            expect(utilsPromptUserForChannelStub).toHaveBeenCalled();
         });
     });
 });

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -69,7 +69,7 @@ async function checkCliVersion({ storeUrl, currentCliVersion = PACKAGE_INFO.vers
  * @param {string} options.apiHost
  * @param {string} options.storeHash
  * @param {string} options.accessToken
- * @returns {Promise<any>}
+ * @returns {Promise<array<any>>}
  */
 async function activateThemeByVariationId({
     variationId,

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -65,7 +65,7 @@ async function checkCliVersion({ storeUrl, currentCliVersion = PACKAGE_INFO.vers
 /**
  * @param {object} options
  * @param {string} options.variationId
- * @param {string} options.channelId
+ * @param {array} options.channelIds
  * @param {string} options.apiHost
  * @param {string} options.storeHash
  * @param {string} options.accessToken
@@ -73,25 +73,27 @@ async function checkCliVersion({ storeUrl, currentCliVersion = PACKAGE_INFO.vers
  */
 async function activateThemeByVariationId({
     variationId,
-    channelId,
+    channelIds,
     apiHost,
     storeHash,
     accessToken,
 }) {
     try {
-        return await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/themes/actions/activate`,
-            headers: {
-                'content-type': 'application/json',
-            },
-            method: 'POST',
-            accessToken,
-            data: {
-                variation_id: variationId,
-                channel_id: channelId,
-                which: 'original',
-            },
-        });
+        return channelIds.map((id) =>
+            networkUtils.sendApiRequest({
+                url: `${apiHost}/stores/${storeHash}/v3/themes/actions/activate`,
+                headers: {
+                    'content-type': 'application/json',
+                },
+                method: 'POST',
+                accessToken,
+                data: {
+                    variation_id: variationId,
+                    channel_id: Number(id),
+                    which: 'original',
+                },
+            }),
+        );
     } catch (err) {
         err.name =
             err.response && err.response.status === 504

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -69,7 +69,7 @@ async function checkCliVersion({ storeUrl, currentCliVersion = PACKAGE_INFO.vers
  * @param {string} options.apiHost
  * @param {string} options.storeHash
  * @param {string} options.accessToken
- * @returns {Promise<array<any>>}
+ * @returns {Promise<Object[]>}
  */
 async function activateThemeByVariationId({
     variationId,
@@ -79,7 +79,7 @@ async function activateThemeByVariationId({
     accessToken,
 }) {
     try {
-        return channelIds.map((id) =>
+        const promises = channelIds.map((id) =>
             networkUtils.sendApiRequest({
                 url: `${apiHost}/stores/${storeHash}/v3/themes/actions/activate`,
                 headers: {
@@ -94,6 +94,7 @@ async function activateThemeByVariationId({
                 },
             }),
         );
+        return Promise.all(promises);
     } catch (err) {
         err.name =
             err.response && err.response.status === 504


### PR DESCRIPTION
#### What?

This feature allows users to apply one theme to multiple storefronts/channels. There are several options available for users:

- `stencil push` command will check whether multiple storefronts/channels available. If yes, user will be prompted to chose one or several/all ids (list of available channels will be shown in radio button style);
- `stencil push -a -c 123 456` allows to apply a theme to selected channels and further system questions will be skipped;
- `stencil push -a -allc` allows to apply a theme to all available channels. 

#### Tickets / Documentation

[STRF-9582](https://jira.bigcommerce.com/browse/STRF-9582)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/95914987/148229720-e866c94e-9464-4755-844b-0539b2b71bdd.png)

![image](https://user-images.githubusercontent.com/95914987/148229860-77ff5d43-0856-43db-97e3-aec34611a94c.png)

![image](https://user-images.githubusercontent.com/95914987/148912026-9ddeb47a-8492-4fdc-ab8f-616c564a1dc0.png)


cc @bigcommerce/storefront-team
