### PR TITLE
Updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "axios": "^0.24.0",
     "browser-sync": "^2.26.12",
     "cheerio": "^1.0.0-rc.10",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^6.1.0",
     "confidence": "^4.0.2",
     "form-data": "^3.0.0",


### PR DESCRIPTION
Forced use of colors version 1.4.0 as latest versions are not useable at this time.

#### What?

Fixes issue related to colors latest version mentioned here: https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [Source Article](https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/)

cc @bigcommerce/storefront-team
