### PR TITLE
docs(release): release 3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.8.3 (2022-01-12)
+
+-   fix: add activate sass engine name logic ([837](https://github.com/bigcommerce/stencil-cli/pull/837))
+
 ### 3.8.2 (2022-01-11)
 
 -   fix: strf-9600 bump stencil styles version ([832](https://github.com/bigcommerce/stencil-cli/pull/832))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
-   fix: add activate sass engine name logic ([837](https://github.com/bigcommerce/stencil-cli/pull/837))
