### PR TITLE
fix(storefront): strf-9594 loosed frontmatter refex

### DIFF
--- a/lib/utils/frontmatter.js
+++ b/lib/utils/frontmatter.js
@@ -1,4 +1,4 @@
-const frontmatterRegex = /---\r?\n(?:.|\s)*?\r?\n---\r?\n/g;
+const frontmatterRegex = /---[\s\S]+?---/g;
 
 /**
  *

--- a/lib/utils/frontmatter.spec.js
+++ b/lib/utils/frontmatter.spec.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const { getFrontmatterContent } = require('./frontmatter');
+
+const cwd = process.cwd();
+
+describe('frontmatter', () => {
+    it('should successfully get frontmatter content fromt file', async () => {
+        const fileName = `${cwd}/test/_mocks/frontmatter/valid.html`;
+        const fileContent = await fs.promises.readFile(fileName, { encoding: 'utf-8' });
+        const frontmatter = getFrontmatterContent(fileContent);
+        expect(frontmatter).not.toBeNull();
+    });
+
+    it('should return null while getting frontmatter content fromt file', async () => {
+        const fileName = `${cwd}/test/_mocks/frontmatter/absent.html`;
+        const fileContent = await fs.promises.readFile(fileName, { encoding: 'utf-8' });
+        const frontmatter = getFrontmatterContent(fileContent);
+        expect(frontmatter).toBeNull();
+    });
+});

--- a/test/_mocks/frontmatter/absent.html
+++ b/test/_mocks/frontmatter/absent.html
@@ -1,0 +1,19 @@
+<script>
+    // ---
+</script>
+<div class="main full">
+    {{#if products.featured}}
+        {{> components/products/featured products=products.featured columns=theme_settings.homepage_featured_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_featured_products"}}}
+
+    {{#if products.top_sellers}}
+        {{> components/products/top products=products.top_sellers columns=theme_settings.homepage_top_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_top_products"}}}
+
+    {{#if products.new}}
+        {{> components/products/new products=products.new columns=theme_settings.homepage_new_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_new_products"}}}
+</div>

--- a/test/_mocks/frontmatter/valid.html
+++ b/test/_mocks/frontmatter/valid.html
@@ -1,0 +1,45 @@
+---
+products:
+    new:
+        limit: {{theme_settings.homepage_new_products_count}}
+    featured:
+        limit: {{theme_settings.homepage_featured_products_count}}
+    top_sellers:
+        limit: {{theme_settings.homepage_top_products_count}}
+carousel: {{theme_settings.homepage_show_carousel}}
+blog:
+    recent_posts:
+        limit: {{theme_settings.homepage_blog_posts_count}}
+---
+{{#partial "hero"}}
+    {{{region name="home_below_menu"}}}
+    {{#and carousel carousel.slides.length}}
+        {{> components/carousel arrows=theme_settings.homepage_show_carousel_arrows play_pause_button=theme_settings.homepage_show_carousel_play_pause_button}}
+    {{/and}}
+    {{{region name="home_below_carousel"}}}
+{{/partial}}
+
+{{#partial "page"}}
+
+    {{#each shipping_messages}}
+        {{> components/common/alert/alert-info message}}
+    {{/each}}
+
+<div class="main full">
+    {{#if products.featured}}
+        {{> components/products/featured products=products.featured columns=theme_settings.homepage_featured_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_featured_products"}}}
+
+    {{#if products.top_sellers}}
+        {{> components/products/top products=products.top_sellers columns=theme_settings.homepage_top_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_top_products"}}}
+
+    {{#if products.new}}
+        {{> components/products/new products=products.new columns=theme_settings.homepage_new_products_column_count}}
+    {{/if}}
+    {{{region name="home_below_new_products"}}}
+</div>
+{{/partial}}
+{{> layout/base}}


### PR DESCRIPTION
#### What?

Regex to detect frontmatter was causing infinite loop on entry `// ---`
Loosed frontmatter regex to be more simple.

#### Tickets / Documentation


-   [STRF-9594](https://jira.bigcommerce.com/browse/STRF-9594)

#### Screenshots (if appropriate)

<img width="1283" alt="Screenshot 2022-01-14 at 17 44 57" src="https://user-images.githubusercontent.com/68893868/149594903-7d877c6e-0373-41ad-99e8-0018c22975d2.png">


cc @bigcommerce/storefront-team
