### PR TITLE
fix(storefront): BCTHEME-1000 handle correctly css extension in stencil

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Set a consistent line-ending styles across different OS to avoid problems with linters
 * text eol=lf
+*.png binary
+*.jpg binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Draft
+
+-   fix(storefront): bctheme-1000 handle regular css in stencil ([845](https://github.com/bigcommerce/stencil-cli/pull/845))
+
 ### 3.9.2 (2022-01-31)
 
 -   chore: bump paper to latest ([863](https://github.com/bigcommerce/stencil-cli/pull/863))

--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -110,7 +110,12 @@ class Bundle {
             bundle: true,
         };
         return (callback) => {
-            const basePath = path.join(this.themePath, 'assets', compiler);
+            let basePath;
+            if (compiler === 'css') {
+                basePath = path.join(this.themePath, 'assets/dist', compiler);
+            } else {
+                basePath = path.join(this.themePath, 'assets', compiler);
+            }
 
             console.log('%s Parsing Started...', compiler.toUpperCase());
             fs.readdir(basePath, (err, files) => {
@@ -395,7 +400,12 @@ class Bundle {
                 case 'css':
                     // Create the parsed tree files
                     for (const [filename, data] of Object.entries(result)) {
-                        archiveJsonFile(data, `parsed/scss/${filename}.json`);
+                        const ext =
+                            this.configuration.css_compiler === 'css'
+                                ? this.configuration.css_compiler
+                                : 'scss';
+
+                        archiveJsonFile(data, `parsed/${ext}/${filename}.json`);
                     }
                     break;
 

--- a/server/plugins/theme-assets/theme-assets.module.js
+++ b/server/plugins/theme-assets/theme-assets.module.js
@@ -60,20 +60,20 @@ internals.cssHandler = async (request, h) => {
     request.app.themeConfig.setVariation(variationIndex);
 
     // Get the theme configuration
+    const configuration = await request.app.themeConfig.getConfig();
     const fileName = internals.getOriginalFileName(request.params.fileName);
     const fileParts = path.parse(fileName);
-    const pathToFile = path.join(fileParts.dir, `${fileParts.name}.scss`);
-    const basePath = path.join(internals.getThemeAssetsPath(), 'scss');
+    const ext = configuration.css_compiler === 'css' ? configuration.css_compiler : 'scss';
+    const pathToFile = path.join(fileParts.dir, `${fileParts.name}.${ext}`);
+    const basePath = path.join(internals.getThemeAssetsPath(), `${ext}`);
 
     let files;
     try {
-        files = await promisify(cssAssembler.assemble)(pathToFile, basePath, 'scss', {});
+        files = await promisify(cssAssembler.assemble)(pathToFile, basePath, `${ext}`, {});
     } catch (err) {
         console.error(err);
         throw Boom.badData(err);
     }
-
-    const configuration = await request.app.themeConfig.getConfig();
 
     const params = {
         data: files[pathToFile],


### PR DESCRIPTION
#### What?

While working on Prelude POC we would like to change new Stencil Theme structure:
- keep SCSS directory under assets but generate css files under `dist/css` dir,
- use regular `css` extension for it.
- use `css_compiler` flag

If we use mentioned structure, `stencil-cli` gives us an error in local development. For this reason we would like to add possibility for `stencil-cli` to work  with  regular css as well as `aseets/scss` directory. On theme side, we will use `css_compiler` flag  from `config.json` that can be switched between `scss` and `css`. On Stencil side we will provide this extension to `CSS Compiler Handler` which then will assemble CSS accordingly.
 

#### Tickets / Documentation
-   [BCTHEME-1000](https://jira.bigcommerce.com/browse/BCTHEME-1000)

#### Screenshots (if appropriate)
<img width="317" alt="new_assets_dir" src="https://user-images.githubusercontent.com/67792608/152141655-7a93bf9b-b377-4c92-b785-cce3e8ed4ef2.png">

https://user-images.githubusercontent.com/67792608/152140829-20e241d6-da21-42e9-ba8a-d7070657c5a2.mov

https://user-images.githubusercontent.com/67792608/152141281-d87c6429-4421-4f10-816f-969c40097ed6.mov



Here our Theme structure at the moment



cc @bigcommerce/storefront-team
