### PR TITLE
feat: warn npm users if npm is above 7 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
-    "node": "^10.17 || ^12"
+    "node": "^10.17 || ^12",
+    "npm": ">=v6.11.3 <7.0.0"
   },
   "scripts": {
     "lint": "eslint . && prettier --check . --ignore-unknown",


### PR DESCRIPTION
#### What?

Warn npm users about supported version

https://github.com/bigcommerce/stencil-cli/issues/721#issuecomment-1016884032

#### Screenshots (if appropriate)

<img width="647" alt="Screenshot 2022-01-20 at 10 28 18" src="https://user-images.githubusercontent.com/68893868/150369113-25f6845c-277d-48c9-954c-dfea4e05abfd.png">


cc @bigcommerce/storefront-team
