### PR TITLE
fix: return channel id as an iterable when a store only has a single storefront

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -356,7 +356,7 @@ utils.promptUserForChannel = async (options) => {
 
 utils.promptUserToSelectChannel = async (channels) => {
     if (channels.length < 2) {
-        return channels[0].channel_id;
+        return [channels[0].channel_id];
     }
 
     const questions = [

--- a/lib/stencil-push.utils.spec.js
+++ b/lib/stencil-push.utils.spec.js
@@ -1,7 +1,12 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
 
-const { getStoreHash, promptUserForChannel, getChannels } = require('./stencil-push.utils');
+const {
+    getStoreHash,
+    promptUserForChannel,
+    promptUserToSelectChannel,
+    getChannels,
+} = require('./stencil-push.utils');
 const utils = require('./stencil-push.utils');
 const themeApiClient = require('./theme-api-client');
 
@@ -156,6 +161,26 @@ describe('stencil push utils', () => {
             promptUserForChannel(options);
 
             expect(utilsPromptUserForChannelStub).toHaveBeenCalled();
+        });
+    });
+
+    describe('promptUserToSelectChannel', () => {
+        it('should return an array with a single channel ID if a store only has a single channel', async () => {
+            const channels = [
+                {
+                    id: 1000,
+                    url: 'https://abc.com',
+                    channel_id: 1,
+                    created_at: '2021-06-17T00:20:30Z',
+                    updated_at: '2021-06-17T00:20:36Z',
+                },
+            ];
+
+            const expected = [1];
+
+            const result = await promptUserToSelectChannel(channels);
+
+            expect(result).toEqual(expect.arrayContaining(expected));
         });
     });
 });


### PR DESCRIPTION
#### What?

After adding the ability to use `stencil-push` to push themes to multiple storefronts, users began reporting an error `not ok -- VariationActivationError: channelIds.map is not a function`

This PR includes a fix to return an iterable from the `promptUserToSelectChannel` method even when a store only has a single storefront. 

#### Tickets / Documentation

- #848 

#### Screenshots (if appropriate)

<img width="1438" alt="Screen Shot 2022-01-21 at 12 03 57 PM" src="https://user-images.githubusercontent.com/28374851/150577925-541c30f3-2ac7-40cb-8514-76c1a3005152.png">
<img width="1440" alt="Screen Shot 2022-01-21 at 12 05 20 PM" src="https://user-images.githubusercontent.com/28374851/150577948-3a9e57c2-a402-4f0c-97a7-5573ff976b2e.png">

cc @bigcommerce/storefront-team
