### PR TITLE
fix: strf-9612 Fix stencil pull when there is 1 channel

### DIFF
--- a/lib/stencil-push.js
+++ b/lib/stencil-push.js
@@ -18,7 +18,7 @@ function stencilPush(options = {}, callback) {
             utils.pollForJobCompletion((data) => ({ themeId: data.theme_id })),
             utils.promptUserWhetherToApplyTheme,
             utils.getChannels,
-            utils.promptUserForChannel,
+            utils.promptUserForChannels,
             utils.getVariations,
             utils.promptUserForVariation,
             utils.requestToApplyVariationWithRetrys(),

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -274,6 +274,7 @@ utils.promptUserWhetherToApplyTheme = async (options) => {
 utils.getChannels = async (options) => {
     const {
         config: { accessToken },
+        channelId,
         channelIds,
         storeHash,
         applyTheme,
@@ -281,7 +282,7 @@ utils.getChannels = async (options) => {
 
     const apiHost = options.apiHost || options.config.apiHost;
 
-    if (!applyTheme || channelIds) {
+    if (!applyTheme || channelIds || channelId) {
         return options;
     }
 
@@ -338,7 +339,7 @@ utils.getVariations = async (options) => {
     return { ...options, variations };
 };
 
-utils.promptUserForChannel = async (options) => {
+utils.promptUserForChannels = async (options) => {
     const { applyTheme, channelIds, channels, allChannels } = options;
 
     if (!applyTheme || channelIds) {
@@ -350,11 +351,11 @@ utils.promptUserForChannel = async (options) => {
         return { ...options, channelIds: allIds };
     }
 
-    const selectedChannelIds = await utils.promptUserToSelectChannel(channels);
+    const selectedChannelIds = await utils.promptUserToSelectChannels(channels);
     return { ...options, channelIds: selectedChannelIds };
 };
 
-utils.promptUserToSelectChannel = async (channels) => {
+utils.promptUserToSelectChannels = async (channels) => {
     if (channels.length < 2) {
         return [channels[0].channel_id];
     }
@@ -373,6 +374,38 @@ utils.promptUserToSelectChannel = async (channels) => {
 
     const answer = await Inquirer.prompt(questions);
     return answer.channelIds;
+};
+
+utils.promptUserForChannel = async (options) => {
+    const { applyTheme, channelId, channels } = options;
+
+    if (!applyTheme || channelId) {
+        return options;
+    }
+
+    const selectedChannelId = await utils.promptUserToSelectChannel(channels);
+    return { ...options, channelId: selectedChannelId };
+};
+
+utils.promptUserToSelectChannel = async (channels) => {
+    if (channels.length < 2) {
+        return channels[0].channel_id;
+    }
+
+    const questions = [
+        {
+            type: 'list',
+            name: 'channelId',
+            message: 'Which channel would you like to use?',
+            choices: channels.map((channel) => ({
+                name: channel.url,
+                value: channel.channel_id,
+            })),
+        },
+    ];
+
+    const answer = await Inquirer.prompt(questions);
+    return answer.channelId;
 };
 
 utils.promptUserForVariation = async (options) => {

--- a/lib/stencil-push.utils.spec.js
+++ b/lib/stencil-push.utils.spec.js
@@ -4,7 +4,8 @@ const MockAdapter = require('axios-mock-adapter');
 const {
     getStoreHash,
     promptUserForChannel,
-    promptUserToSelectChannel,
+    promptUserForChannels,
+    promptUserToSelectChannels,
     getChannels,
 } = require('./stencil-push.utils');
 const utils = require('./stencil-push.utils');
@@ -112,36 +113,6 @@ describe('stencil push utils', () => {
             expect(result).toEqual(optionsApplyThemeIsFalse);
         });
 
-        it('should return options when applyTheme is true and channelIds available', async () => {
-            const result = await promptUserForChannel(optionsApplyThemeIsTrueAndChannels);
-
-            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
-            expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
-        });
-
-        it('should return options with all channelIds available when -allc option used', async () => {
-            const options = {
-                applyTheme: true,
-                apiHost: 'abc2342',
-                allChannels: true,
-                channels: [
-                    {
-                        url: 'https://abc.com',
-                        channel_id: 1,
-                    },
-                    {
-                        url: 'https://fff.com',
-                        channel_id: 2,
-                    },
-                ],
-            };
-
-            const result = await promptUserForChannel(options);
-
-            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
-            expect(result).toEqual(optionsResult);
-        });
-
         it('should call promptUserToSelectChannel when applyTheme is true and no channelIds available', async () => {
             const options = {
                 applyTheme: true,
@@ -164,7 +135,45 @@ describe('stencil push utils', () => {
         });
     });
 
-    describe('promptUserToSelectChannel', () => {
+    describe('.promptUserForChannels', () => {
+        let mockPromptUserToSelectChannel;
+        beforeEach(() => {
+            mockPromptUserToSelectChannel = jest
+                .spyOn(utils, 'promptUserToSelectChannels')
+                .mockReturnValue({});
+        });
+
+        it('should return options when applyTheme is true and channelIds available', async () => {
+            const result = await promptUserForChannels(optionsApplyThemeIsTrueAndChannels);
+
+            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
+            expect(result).toEqual(optionsApplyThemeIsTrueAndChannels);
+        });
+
+        it('should return options with all channelIds available when -allc option used', async () => {
+            const options = {
+                applyTheme: true,
+                apiHost: 'abc2342',
+                allChannels: true,
+                channels: [
+                    {
+                        url: 'https://abc.com',
+                        channel_id: 1,
+                    },
+                    {
+                        url: 'https://fff.com',
+                        channel_id: 2,
+                    },
+                ],
+            };
+
+            const result = await promptUserForChannels(options);
+
+            expect(mockPromptUserToSelectChannel).toHaveBeenCalledTimes(0);
+            expect(result).toEqual(optionsResult);
+        });
+    });
+    describe('promptUserToSelectChannels', () => {
         it('should return an array with a single channel ID if a store only has a single channel', async () => {
             const channels = [
                 {
@@ -178,7 +187,7 @@ describe('stencil push utils', () => {
 
             const expected = [1];
 
-            const result = await promptUserToSelectChannel(channels);
+            const result = await promptUserToSelectChannels(channels);
 
             expect(result).toEqual(expect.arrayContaining(expected));
         });


### PR DESCRIPTION
#### What?

Stencil pull is broken, when store has 1 channel

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [STRF-9612](https://jira.bigcommerce.com/browse/STRF-9612)

#### Screenshots (if appropriate)
<img width="924" alt="Screenshot 2022-01-25 at 12 09 37" src="https://user-images.githubusercontent.com/68893868/151026742-7fd665a9-9367-4ee0-a9b7-cff31b16d045.png">
<img width="1096" alt="Screenshot 2022-01-25 at 12 09 51" src="https://user-images.githubusercontent.com/68893868/151026757-40ff97ee-25ad-4e7d-9736-1de8d11d7448.png">




cc @bigcommerce/storefront-team
