### PR TITLE
build(release): release 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.9.2 (2022-01-31)
+
+-   chore: bump paper to latest ([863](https://github.com/bigcommerce/stencil-cli/pull/863))
+
 ### 3.9.1 (2022-01-25)
 
 -   fix: strf-9612 Fix stencil pull when there is 1 channel ([859](https://github.com/bigcommerce/stencil-cli/pull/859))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
#### What?

Release 3.9.2. Contains:
-   chore: bump paper to latest ([863](https://github.com/bigcommerce/stencil-cli/pull/863))


cc @bigcommerce/storefront-team
