### PR TITLE
chore: bump paper to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Draft
 
 -   fix(storefront): bctheme-1000 handle regular css in stencil ([845](https://github.com/bigcommerce/stencil-cli/pull/845))
+-   chore: bump paper to 3.0.0 ([868](https://github.com/bigcommerce/stencil-cli/pull/868))
 
 ### 3.9.2 (2022-01-31)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,9 +537,9 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0-rc.54",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.54.tgz",
-      "integrity": "sha512-vCjVW7zBrsRu7CypgHs3WHoRGHvKXFTn3N8TJ3ZCaDbOuZJbPKE/+cr5M9Yl+OOglAQ5LCVwjPG7cn5HUg5OvA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0.tgz",
+      "integrity": "sha512-+8Zyln2L7yvoFabDzgXgSE+7it01Q5UZml+pq70qrx9GtsX+leIhdY01RoziDnES1I12qIx+bPUX+vM7oD1NZg==",
       "requires": {
         "@bigcommerce/stencil-paper-handlebars": "4.5.1",
         "accept-language-parser": "~1.4.1",
@@ -15436,9 +15436,9 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
+      "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
       "optional": true
     },
     "uglify-to-browserify": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "3.0.0-rc.54",
+    "@bigcommerce/stencil-paper": "3.0.0",
     "@bigcommerce/stencil-styles": "2.1.1",
     "@hapi/boom": "^8.0.1",
     "@hapi/glue": "^6.2.0",


### PR DESCRIPTION
-   chore: bump paper to 3.0.0 ([868](https://github.com/bigcommerce/stencil-cli/pull/868))
