### PR TITLE
add note about npm version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Note: Stencil requires the Node.js runtime environment,
 version 10.x and 12.x (Recommended) are supported.
 We do not yet have support for versions greater than Node 12._
 
-_Review package.json for the required npm version, <7.0.0 at the time of writing_
+_Review package.json for the required npm version, [>=v6.11.3 <7.0.0](https://github.com/bigcommerce/stencil-cli/blob/14d6781d4973e5458224aa0f2b236a16625cc5cf/package.json#L8) at the time of writing_
 
 Run `npm install -g @bigcommerce/stencil-cli`.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ _Note: Stencil requires the Node.js runtime environment,
 version 10.x and 12.x (Recommended) are supported.
 We do not yet have support for versions greater than Node 12._
 
+_Review package.json for the required npm version, <7.0.0 at the time of writing_
+
 Run `npm install -g @bigcommerce/stencil-cli`.
 
 Visit the [installation guide](https://developer.bigcommerce.com/stencil-docs/getting-started/installing-stencil)


### PR DESCRIPTION
#### What?

there are a number of issues that report being unable to install with newer npm versions. the config in package.json only produces a warning when running with a newer npm version, which is drowned out by deprecation notice for other packages. adding it to the readme at least puts a reference where people would typically start.

cc @bigcommerce/storefront-team
