### PR TITLE
fix: when there's no regions on the page

### DIFF
--- a/lib/content-api-client.js
+++ b/lib/content-api-client.js
@@ -31,6 +31,9 @@ async function getRenderedRegionsByPageType({ accessToken, storeUrl, pageType })
             }),
         });
 
+        if (!response.data.data) {
+            return  { renderedRegions: []};
+        }
         const {
             site: {
                 content: {
@@ -75,6 +78,9 @@ async function getRenderedRegionsByPageTypeAndEntityId({
             }),
         });
 
+        if (!response.data.data) {
+            return  { renderedRegions: []};
+        }
         const {
             site: {
                 content: {

--- a/lib/content-api-client.js
+++ b/lib/content-api-client.js
@@ -32,7 +32,7 @@ async function getRenderedRegionsByPageType({ accessToken, storeUrl, pageType })
         });
 
         if (!response.data.data) {
-            return  { renderedRegions: []};
+            return { renderedRegions: [] };
         }
         const {
             site: {
@@ -79,7 +79,7 @@ async function getRenderedRegionsByPageTypeAndEntityId({
         });
 
         if (!response.data.data) {
-            return  { renderedRegions: []};
+            return { renderedRegions: [] };
         }
         const {
             site: {


### PR DESCRIPTION
#### What?

Sometimes, when new theme is applied to the store, I don't receive `regions` object from the API.


#### Screenshots (if appropriate)
<img width="1221" alt="Screenshot 2022-02-18 at 17 57 12" src="https://user-images.githubusercontent.com/68893868/155389537-7d59a1f4-7d66-4712-989a-5032a4f7f957.png">


cc @bigcommerce/storefront-team, @jkanive 
