### PR TITLE
fix: windows circle ci

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 node: [10.x, 12.x]
-                os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+                os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
 
         runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
#### What?

Fix CircleCI build for windows, as we had _latest_ version in the setup and VS 2022 is in Preview.

https://github.com/actions/virtual-environments/issues/3949

cc @bigcommerce/storefront-team
