### PR TITLE
feat: allow `.css`-files imports within SCSS files

### DIFF
--- a/lib/css-assembler.js
+++ b/lib/css-assembler.js
@@ -23,17 +23,22 @@ function assemble(cssFiles, absolutePath, type, options, callback) {
 
     const parseImports = (cssFileAlias, parseImportsCallback) => {
         const normalizedCssFileAlias = cssFileAlias.replace(/(\.scss)$/g, '');
-        const cssFilePath = path.join(absolutePath, normalizedCssFileAlias + ext);
+        const typedCssFilePath = path.join(absolutePath, normalizedCssFileAlias + ext);
+        const rawCssFilePath = path.join(absolutePath, normalizedCssFileAlias + '.css');
         const cssFileAliasDir = path.parse(normalizedCssFileAlias).dir;
 
-        const fileParts = path.parse(cssFilePath);
+        const fileParts = path.parse(typedCssFilePath);
         const underscoredFilePath = path.join(fileParts.dir, `_${fileParts.base}`);
         let filePath;
 
-        if (fs.existsSync(cssFilePath)) {
-            filePath = cssFilePath;
+        if (fs.existsSync(typedCssFilePath)) {
+            filePath = typedCssFilePath;
         } else if (fs.existsSync(underscoredFilePath)) {
             filePath = underscoredFilePath;
+        } else if (ext === '.scss' && fs.existsSync(rawCssFilePath)) {
+            // check if actual `.css` file exists and use it as a last resort before throwing
+            console.log(rawCssFilePath);
+            filePath = rawCssFilePath;
         } else {
             // File doesn't exist, just return to skip it
             parseImportsCallback();

--- a/lib/css-assembler.js
+++ b/lib/css-assembler.js
@@ -36,7 +36,6 @@ function assemble(cssFiles, absolutePath, type, options, callback) {
         } else if (fs.existsSync(underscoredFilePath)) {
             filePath = underscoredFilePath;
         } else if (ext === '.scss' && fs.existsSync(rawCssFilePath)) {
-            // check if actual `.css` file exists and use it as a last resort before throwing
             filePath = rawCssFilePath;
         } else {
             // File doesn't exist, just return to skip it

--- a/lib/css-assembler.js
+++ b/lib/css-assembler.js
@@ -37,7 +37,6 @@ function assemble(cssFiles, absolutePath, type, options, callback) {
             filePath = underscoredFilePath;
         } else if (ext === '.scss' && fs.existsSync(rawCssFilePath)) {
             // check if actual `.css` file exists and use it as a last resort before throwing
-            console.log(rawCssFilePath);
             filePath = rawCssFilePath;
         } else {
             // File doesn't exist, just return to skip it


### PR DESCRIPTION
#### What?

[It's not possible currently to import raw css files (i.e. from `node_modules`) within a theme](https://support.bigcommerce.com/s/question/0D54O00006yPDn2SAG/include-plain-css-from-nodemodules-in-theme), because `stencil-cli` [provides no such ability](https://github.com/bigcommerce/stencil-cli/blob/master/lib/css-assembler.js#L26).

The standard for importing `.css` files in SCSS is to [not use any extension](https://sass-lang.com/documentation/at-rules/import#importing-css). The proposed change is to check for existence of `.css` file after all other options are exhausted. 

#### Tickets / Documentation

-   [This problem was recognised before](https://support.bigcommerce.com/s/question/0D54O00006yPDn2SAG/include-plain-css-from-nodemodules-in-theme)

cc @bigcommerce/storefront-team
