### PR TITLE
fix: stop sending 'stencil-cli' header due to forbidden responses

### DIFF
--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -119,8 +119,7 @@ internals.registerRoutes = (server) => {
                         )}`;
                         const urlParams = req.url.search || '';
                         const uri = `${host}${req.path}${urlParams}`;
-                        const headers = { 'stencil-cli': internals.options.stencilCliVersion };
-                        return { uri, headers };
+                        return { uri };
                     },
                     passThrough: true,
                 },


### PR DESCRIPTION
#### What?

Fixes issue #889 by removing `stencil-cli` request header from being added to Storefront API upstream requests.
Storefront API server seems to not accept the `stencil-cli` request header, causing 403 Forbidden response statuses.

#### Tickets / Documentation

#### Screenshots

<img width="654" alt="Screen Shot 2022-03-16 at 4 23 12 PM" src="https://user-images.githubusercontent.com/34232894/158707409-dd74906a-1d82-4f86-97a6-86ee8b5ed41c.png">

<img width="653" alt="Screen Shot 2022-03-16 at 4 24 00 PM" src="https://user-images.githubusercontent.com/34232894/158707474-d9e6c0e3-1246-4ba6-a194-96d05df23e4d.png">

<img width="655" alt="Screen Shot 2022-03-16 at 4 31 58 PM" src="https://user-images.githubusercontent.com/34232894/158708299-2ee0eecb-d887-47be-bc06-2571e2de8c24.png">

cc @bigcommerce/storefront-team
