### PR TITLE
chore: bump paper to 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Draft
 
+-   feat: allow .css-files imports within SCSS files ([882](https://github.com/bigcommerce/stencil-cli/pull/882))
+-   bump paper version ([x](https://github.com/bigcommerce/stencil-cli/pull/x))
+
 ### 3.11.0 (2022-03-10)
 
 -   feat: strf-9440 Stencil Bundle: fail on scss failure compilation ([884](https://github.com/bigcommerce/stencil-cli/pull/884))

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,26 +537,26 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0.tgz",
-      "integrity": "sha512-+8Zyln2L7yvoFabDzgXgSE+7it01Q5UZml+pq70qrx9GtsX+leIhdY01RoziDnES1I12qIx+bPUX+vM7oD1NZg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.5.tgz",
+      "integrity": "sha512-jIjISuMcW5CSk2CYwhWl1CpVKBUqsTVDUyvPL05XjWQo8/fzAJm/9JL8r52FjfeUrepHkFfTPMoa0mU76S4qNA==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "4.5.1",
+        "@bigcommerce/stencil-paper-handlebars": "4.5.5",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.5.1.tgz",
-      "integrity": "sha512-drdYQDXFI8BI/H4/ACmYJUA1QfCbpYVp8MxG/B+JNZypg6UzTnWRJOvCKqohfr9obnLbSdL+nMjVol2cq/RmgQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.5.5.tgz",
+      "integrity": "sha512-RoakM7Z5e/wZhKiuUNPCr1SgAMsR2stWnNqZydRqSV7ZSJdKxfCE4R0t8Y+ZMpgZPGvSOrIWrAcMaty5gLZhsw==",
       "requires": {
         "@bigcommerce/handlebars-v4": "4.7.6",
         "handlebars": "3.0.8",
         "handlebars-helpers": "0.8.4",
         "handlebars-utils": "^1.0.6",
         "he": "^1.2.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "stringz": "^0.1.1"
       }
     },
@@ -15436,9 +15436,9 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-      "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
       "optional": true
     },
     "uglify-to-browserify": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "3.0.0",
+    "@bigcommerce/stencil-paper": "3.0.5",
     "@bigcommerce/stencil-styles": "2.1.2",
     "@hapi/boom": "^8.0.1",
     "@hapi/glue": "^6.2.0",


### PR DESCRIPTION
-   bump paper version ([897](https://github.com/bigcommerce/stencil-cli/pull/897))
