### PR TITLE
feat: strf-9718 Add OAuth token to headers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,8 @@ function buildManifest(srcManifest, options) {
     pluginsByName['./plugins/router/router.module'].apiKey = options.dotStencilFile.apiKey;
     pluginsByName['./plugins/router/router.module'].port = options.dotStencilFile.port;
     pluginsByName['./plugins/router/router.module'].stencilCliVersion = options.stencilCliVersion;
+    pluginsByName['./plugins/router/router.module'].accessToken =
+        options.dotStencilFile.accessToken;
     pluginsByName['./plugins/renderer/renderer.module'].useCache = options.useCache;
     pluginsByName['./plugins/renderer/renderer.module'].username = options.dotStencilFile.username;
     pluginsByName['./plugins/renderer/renderer.module'].token = options.dotStencilFile.token;

--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -119,7 +119,10 @@ internals.registerRoutes = (server) => {
                         )}`;
                         const urlParams = req.url.search || '';
                         const uri = `${host}${req.path}${urlParams}`;
-                        const headers = { 'stencil-cli': internals.options.stencilCliVersion };
+                        const headers = {
+                            'stencil-cli': internals.options.stencilCliVersion,
+                            'x-auth-token': internals.options.accessToken,
+                        };
                         return { uri, headers };
                     },
                     passThrough: true,
@@ -167,6 +170,8 @@ internals.registerRoutes = (server) => {
                             {
                                 origin: internals.options.storeUrl,
                                 host: internals.options.storeUrl.replace(/http[s]?:\/\//, ''),
+                                'stencil-cli': internals.options.stencilCliVersion,
+                                'x-auth-token': internals.options.accessToken,
                             },
                         ),
                     }),


### PR DESCRIPTION
#### What?

Send OAuth token to storefront api paths and graphql

#### Tickets / Documentation

-   [STRF-9718](https://jira.bigcommerce.com/browse/STRF-9718)

cc @bigcommerce/storefront-team
