### PR TITLE
fix: STRF-9781 Bump simple-git

### DIFF
--- a/bin/stencil-debug.js
+++ b/bin/stencil-debug.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('colors');
 const program = require('../lib/commander');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,9 +2242,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -13711,19 +13711,19 @@
       "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q=="
     },
     "simple-git": {
-      "version": "2.45.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.45.1.tgz",
-      "integrity": "sha512-NmEoThiLTJxl26WNtZxtJTue18ReTcSrf3so5vJG/O8KY9uMxH+yAhXV/DElBJyOYZrrBbVsH8JOFxgENdc9Xg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+      "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.3"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "stencil-push": "./bin/stencil-push.js",
     "stencil-pull": "./bin/stencil-pull.js",
     "stencil-start": "./bin/stencil-start.js",
-    "stencil-release": "./bin/stencil-release.js"
+    "stencil-release": "./bin/stencil-release.js",
+    "stencil-debug": "./bin/stencil-debug.js"
   },
   "config": {
     "stencil_version": "1.0"
@@ -77,7 +78,7 @@
     "progress": "^2.0.3",
     "recursive-readdir": "^2.2.2",
     "semver": "^7.3.2",
-    "simple-git": "^2.20.1",
+    "simple-git": "^3.7.1",
     "tarjan-graph": "^2.0.0",
     "tmp-promise": "^3.0.2",
     "upath": "^1.2.0",


### PR DESCRIPTION
#### What?

Bump simple-git, that is used in release command to provide interface for git commands

#### Tickets / Documentation

-   [STRF-9781](https://bigcommercecloud.atlassian.net/browse/STRF-9781)


cc @bigcommerce/storefront-team
