### PR TITLE
MERC-8592 Fix stencil CLI Push resulting in intermittent failures

### DIFF
--- a/lib/stencil-push.js
+++ b/lib/stencil-push.js
@@ -13,6 +13,7 @@ function stencilPush(options = {}, callback) {
             utils.notifyUserOfThemeLimitReachedIfNecessary,
             utils.promptUserToDeleteThemesIfNecessary,
             utils.deleteThemesIfNecessary,
+            utils.checkIfDeletionIsComplete(),
             utils.uploadBundleAgainIfNecessary,
             utils.notifyUserOfThemeUploadCompletion,
             utils.pollForJobCompletion((data) => ({ themeId: data.theme_id })),

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -87,6 +87,7 @@ utils.uploadBundle = async (options) => {
         config: { accessToken },
         bundleZipPath,
         storeHash,
+        uploadBundleAgain,
     } = options;
 
     const apiHost = options.apiHost || options.config.apiHost;
@@ -97,6 +98,7 @@ utils.uploadBundle = async (options) => {
             apiHost,
             bundleZipPath,
             storeHash,
+            uploadBundleAgain,
         });
         return {
             ...options,
@@ -193,7 +195,7 @@ utils.uploadBundleAgainIfNecessary = async (options) => {
         return options;
     }
 
-    return utils.uploadBundle(options);
+    return utils.uploadBundle({ ...options, uploadThemeAgain: true });
 };
 
 utils.notifyUserOfThemeUploadCompletion = async (options) => {

--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -190,6 +190,48 @@ utils.deleteThemesIfNecessary = async (options) => {
     return options;
 };
 
+utils.checkIfDeletionIsComplete = () => {
+    return async.retryable(
+        {
+            interval: 1000,
+            errorFilter: (err) => {
+                if (err.message === 'ThemeStillExists') {
+                    console.log(`${'warning'.yellow} -- Theme still exists;Retrying ...`);
+                    return true;
+                }
+                return false;
+            },
+            times: 5,
+        },
+        utils.checkIfThemeIsDeleted(),
+    );
+};
+
+utils.checkIfThemeIsDeleted = () => async (options) => {
+    const {
+        themeLimitReached,
+        config: { accessToken },
+        storeHash,
+        themeIdsToDelete,
+    } = options;
+
+    if (!themeLimitReached) {
+        return options;
+    }
+
+    const apiHost = options.apiHost || options.config.apiHost;
+
+    const result = await themeApiClient.getThemes({ accessToken, apiHost, storeHash });
+
+    const themeStillExists = result.some((theme) => themeIdsToDelete.includes(theme.uuid));
+
+    if (themeStillExists) {
+        throw new Error('ThemeStillExists');
+    }
+
+    return options;
+};
+
 utils.uploadBundleAgainIfNecessary = async (options) => {
     if (!options.themeLimitReached) {
         return options;

--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -278,9 +278,10 @@ async function getVariationsByThemeId({ accessToken, apiHost, storeHash, themeId
  * @param {string} options.accessToken
  * @param {string} options.apiHost
  * @param {string} options.storeHash
+ * @param {boolean} options.uploadBundleAgain
  * @returns {Promise<object>}
  */
-async function postTheme({ bundleZipPath, accessToken, apiHost, storeHash }) {
+async function postTheme({ bundleZipPath, accessToken, apiHost, storeHash, uploadBundleAgain }) {
     const formData = new FormData();
     formData.append('file', fs.createReadStream(bundleZipPath), {
         filename: path.basename(bundleZipPath),
@@ -303,7 +304,12 @@ async function postTheme({ bundleZipPath, accessToken, apiHost, storeHash }) {
         // This status code is overloaded, so we need to check the message to determine
         // if we want to trigger the theme deletion flow.
         const uploadLimitPattern = /You have reached your upload limit/;
-        if (payload && payload.title && uploadLimitPattern.exec(payload.title)) {
+        if (
+            payload &&
+            payload.title &&
+            uploadLimitPattern.exec(payload.title) &&
+            !uploadBundleAgain
+        ) {
             return { themeLimitReached: true };
         }
 


### PR DESCRIPTION
#### What?
**UPDATED**
There are 2 bugs behind this issue. 
1. When posting a new theme, it sometimes returns 409 because the theme that was supposed to be deleted is still not done at that point. To resolve this issue, I added `checkIfDeletionIsComplete` to check if the theme deletion is done before uploading a new theme. This will prevent the 409 error that [we saw on kibana](https://kibana.bigcommerce.net/goto/f4662170-d6a3-11ec-877f-6d90996b8d5d). 
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/19962441/171486849-87708b15-d703-44a0-8d2b-d6d40a50bea7.png">
As you can see from the screenshot above, it will check if the theme that is supposed to be deleted still exists before pushing a new theme

2. The 409 error above is not caught in the right place, so it fails at the wrong place.
The fix above (adding `checkIfDeletionIsComplete`) will fix this issue automatically, since 409 won't happen when uploading a theme. Still, I think it's a good idea to fix this issue since it's not catching the error in the right place.

I found that when the 409 error occurs, there's no job id passed to the `getJob` method. And this causes an error when fetching a job because it's trying to fetch a job with  an`undefined` job id.
<img width="1564" alt="image" src="https://user-images.githubusercontent.com/19962441/169415537-9a66a6d9-90da-4962-b899-564b5a1c3c1f.png">

These are the process that happens when you push a theme. 
```
            async.constant(options),
            utils.readStencilConfigFile,
            utils.getStoreHash,
            utils.getThemes,
            utils.generateBundle,
            utils.uploadBundle,      <===== First upload trial
            utils.notifyUserOfThemeLimitReachedIfNecessary,  <===== Prompt user to delete a theme if it reaches the limit
            utils.promptUserToDeleteThemesIfNecessary,
            utils.deleteThemesIfNecessary,
            utils.uploadBundleAgainIfNecessary, <===== Second upload trial
            utils.notifyUserOfThemeUploadCompletion,
            utils.pollForJobCompletion((data) => ({ themeId: data.theme_id })), <===== This is where the error happens
            utils.promptUserWhetherToApplyTheme,
            utils.getChannels,
            utils.promptUserForChannels,
            utils.getVariations,
            utils.promptUserForVariation,
            utils.requestToApplyVariationWithRetrys(),
            utils.notifyUserOfCompletion,
```
As you can see, after the first upload theme trial, it returns 409 if the number of themes reaches the limit. When that happens, it goes to `notifyUserOfThemeLimitReachedIfNecessary` and asks the user to delete one of their themes.

After the user deletes a theme, it goes to the second upload trial and that's when this bug happens. If when there's 409 error, instead of raising an error, it returns `{ themeLimitReached: true }` which leaves the `job_id` as `undefined`. And since there's no job id, `pollForJobCompletion` will fail while fetching a job status. 



#### Tickets / Documentation

Add links to any relevant tickets and documentation.

https://bigcommercecloud.atlassian.net/browse/MERC-8592



cc @bigcommerce/storefront-team
