### PR TITLE
feat: STRF-9807 Dockerize stencil cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:14
+
+WORKDIR /usr/src/app
+
+RUN npm install -g --unsafe-perm @bigcommerce/stencil-cli
+

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ If you need any help or experience any bugs, please create a GitHub issue in thi
 If you would like to improve this project check out the [Contributing Guide](./CONTRIBUTING.md). Also, you can find
 the implementation details there.
 
+## Running in docker
+
+There is possibility to run stencil-cli in docker.
+Here are steps to have this functionality.
+First of all, build a docker image, let's name it `bc/stencil-cli`
+Run `docker build . -t bc/stencil-cli` in stencil-cli repo directory.
+
+Then, after the image is built, you want to run some commands against your theme.
+
+For example
+`docker run -p 3005:3005 -v /bigcommerce/cornerstone:/usr/src/app -it bc/stencil-cli stencil init`, where `3005` is port number definded in `config.stencil.json` and `/bigcommerce/cornerstone` path to where theme is located.
+
+`docker run -p 3005:3005 -v /bigcommerce/cornerstone:/usr/src/app -it bc/stencil-cli stencil start` and so on
+
 ## License
 
 Copyright (c) 2015-present, BigCommerce Inc.


### PR DESCRIPTION
#### What?

Dockerize stencil cli 

#### Steps to run it locally

`docker build . -t bc/stencil-cli` (_bc/stencil-cli_ - name of image, it's possible to set any)
`docker run -p 3005:3005  -v /bigcommerce/cornerstone:/usr/src/app -it bc/stencil-cli  stencil start`
`3005` - port from `config.stencil.json`
`/bigcommerce/cornerstone` - path to the theme directory

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [STRF-9807](https://bigcommercecloud.atlassian.net/browse/STRF-9807)

#### Screenshots (if appropriate)

<img width="1086" alt="Screenshot 2022-05-24 at 13 59 09" src="https://user-images.githubusercontent.com/68893868/170060301-8f045953-7002-4e31-99be-a04cc347fce6.png">


cc @bigcommerce/storefront-team
