### PR TITLE
fix: by default should compile node sass fork

### DIFF
--- a/lib/css/compile.js
+++ b/lib/css/compile.js
@@ -7,7 +7,12 @@ const cssAssembler = require('../css-assembler');
 const FALLBACK_SASS_ENGINE_NAME = 'node-sass-fork';
 const SASS_ENGINE_NAME = 'node-sass';
 
-const compile = async (configuration, themeAssetsPath, fileName, engineName = SASS_ENGINE_NAME) => {
+const compile = async (
+    configuration,
+    themeAssetsPath,
+    fileName,
+    engineName = FALLBACK_SASS_ENGINE_NAME,
+) => {
     const fileParts = path.parse(fileName);
     const ext = configuration.css_compiler === 'css' ? configuration.css_compiler : 'scss';
     const pathToFile = path.join(fileParts.dir, `${fileParts.name}.${ext}`);


### PR DESCRIPTION
#### What?

Node sass fork default engine for compiling

#### Screenshots (if appropriate)

Attach images or add image links here.
<img width="1079" alt="Screenshot 2022-05-25 at 13 23 00" src="https://user-images.githubusercontent.com/68893868/1702510
<img width="1034" alt="Screenshot 2022-05-25 at 13 23 15" src="https://user-images.githubusercontent.com/68893868/170251136-5bd2c462-6caa-4729-bb29-89278cfbf41f.png">
98-8b7c1277-48fa-42cc-a8b3-64e346b9bfd4.png">
<img width="1082" alt="Screenshot 2022-05-25 at 13 23 24" src="https://user-images.githubusercontent.com/68893868/170251159-dc712f22-16ab-4497-b3c2-6ffa2cf8c39f.png">



cc @bigcommerce/storefront-team
