### PR TITLE
fix: STRF-9883 Interm fix to grab 1st variation

### DIFF
--- a/lib/bundle-validator.js
+++ b/lib/bundle-validator.js
@@ -410,7 +410,7 @@ class BundleValidator {
     async _validateCssFiles() {
         const assetsPath = path.join(this.themePath, 'assets');
         const stylesPath = path.join(this.themePath, 'assets/scss');
-        const rawConfig = await this.themeConfig.getRawConfig();
+        const rawConfig = await this.themeConfig.getConfig();
         const cssFiles = await this.getCssFiles();
 
         for (const file of cssFiles) {


### PR DESCRIPTION
#### What?

Currently stencil bundle during scss compilation takes only default settings variables, rather then checking if each of variation is able to compile. This is a temporary fix to grab 1st variation.

#### Tickets / Documentation

-   [STRF-9883](https://bigcommercecloud.atlassian.net/browse/STRF-9883)

#### Screenshots (if appropriate)

<img width="1369" alt="Screenshot 2022-06-23 at 11 08 00" src="https://user-images.githubusercontent.com/68893868/175262325-3594411c-3e59-430c-b7e4-33c25f50293d.png">


cc @bigcommerce/storefront-team
