### PR TITLE
fix(storefront): bctheme-1138 fix error on import components with @ symbol in the path

### DIFF
--- a/lib/template-assembler.js
+++ b/lib/template-assembler.js
@@ -4,9 +4,10 @@ const fs = require('graceful-fs');
 const path = require('path');
 const upath = require('upath');
 
-const partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9/]+)[^{]*?}}/g;
+const partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9@'"/]+)[^{]*?}}/g;
 const dynamicComponentRegex = /\{\{\s*?dynamicComponent\s*(?:'|")([_|\-|a-zA-Z0-9/]+)(?:'|").*?}}/g;
 const includeRegex = /{{2}>\s*([_|\-|a-zA-Z0-9/]+)[^{]*?}{2}/g;
+const pathStringRegex = /^["'].+["']$/;
 const packageMarker = 'external/';
 
 /**
@@ -27,6 +28,12 @@ const replacePartialNames = (content, partialRoute) => {
         includeRegex,
         (__, partialName) => `{{> ${defineBaseRoute(partialRoute)}/${partialName} }}`,
     );
+};
+const trimPartial = (partial) => {
+    if (pathStringRegex.test(partial)) {
+        return partial.slice(1, -1);
+    }
+    return partial;
 };
 
 /**
@@ -127,7 +134,8 @@ function getTemplatePaths(templatesFolder, templates, options, callback) {
         return callback(null, templatePaths);
     });
 
-    function resolvePartials(templateName, cb2) {
+    function resolvePartials(t, cb2) {
+        const templateName = trimPartial(t);
         const templatePath = getCustomPath(templatesFolder, templateName);
 
         fs.readFile(templatePath, { encoding: 'utf-8' }, (err, content) => {


### PR DESCRIPTION
#### What?

This PR adds ability for theme developers to add components with `@` symbol in the path. 
For this component is required to wrap up its path with `' '` or `" "`
Any other components will work at the same way as it was previously

#### Tickets / Documentation

[BCTHEME-1138](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1138)

#### Screenshots (if appropriate)
<img width="721" alt="importing" src="https://user-images.githubusercontent.com/66325265/177180495-c6976270-0270-4b77-9b6f-18513ce43eb8.png">

