### PR TITLE
feat(storefront): strf-9923 CLI should not ask users for which API hostname to use:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 -   fix: STRF-9835 Bump paper ([947](https://github.com/bigcommerce/stencil-cli/pull/947))
 -   feat: strf-9791 Drop Node 12 Support ([945](https://github.com/bigcommerce/stencil-cli/pull/945))
--   feat: STRF-9807 Dockerize stencil cli ([938]https://github.com/bigcommerce/stencil-cli/pull/938)
--   merc-8592 Fix stencil CLI Push resulting in intermittent failures ([935]https://github.com/bigcommerce/stencil-cli/pull/935)
+-   feat: STRF-9807 Dockerize stencil cli ([938](https://github.com/bigcommerce/stencil-cli/pull/938))
+-   merc-8592 Fix stencil CLI Push resulting in intermittent failures ([935](https://github.com/bigcommerce/stencil-cli/pull/935))
+-   feat: strf-9923 CLI should not ask users for which API hostname to use ([955](https://github.com/bigcommerce/stencil-cli/pull/955))
 
 ### 4.1.1 (2022-05-24)
 

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -78,8 +78,8 @@ class StencilInit {
     }
 
     /**
-     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string), apiHost: (string)}} defaultAnswers
-     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string), apiHost: (string)}} cliOptions
+     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} defaultAnswers
+     * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} cliOptions
      * @returns {{object[]}}
      */
     getQuestions(defaultAnswers, cliOptions) {
@@ -102,15 +102,6 @@ class StencilInit {
                 message: 'What is your Stencil OAuth Access Token?',
                 default: defaultAnswers.accessToken,
                 filter: (val) => val.trim(),
-            });
-        }
-
-        if (!cliOptions.apiHost) {
-            prompts.push({
-                type: 'input',
-                name: 'apiHost',
-                message: 'What API Host would you like to use?',
-                default: defaultAnswers.apiHost,
             });
         }
 

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -52,12 +52,6 @@ const getQuestions = () => [
     },
     {
         type: 'input',
-        name: 'apiHost',
-        message: 'What API Host would you like to use?',
-        default: API_HOST,
-    },
-    {
-        type: 'input',
         name: 'port',
         message: 'What port would you like to run the server on?',
         default: 3003,


### PR DESCRIPTION
#### What?

CLI is asking all users which API hostname to use, when this is only necessary for BC employees who want to connect to non-prod.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [STRF-9923](https://bigcommercecloud.atlassian.net/browse/STRF-9923)


#### Screenshots (if appropriate)

<img width="911" alt="image" src="https://user-images.githubusercontent.com/95914987/177511002-1738335e-6e8c-4aa5-8b18-40c1ba4406f8.png">

<img width="887" alt="image" src="https://user-images.githubusercontent.com/95914987/177512867-bba23873-4041-4420-9761-65f38d96ec42.png">


cc @bigcommerce/storefront-team
