### PR TITLE
feat(config): add ability to specify the secret file name

### DIFF
--- a/lib/StencilConfigManager.js
+++ b/lib/StencilConfigManager.js
@@ -50,9 +50,8 @@ class StencilConfigManager {
         const generalConfig = this._fs.existsSync(this.configPath)
             ? await this._fsUtils.parseJsonFile(this.configPath)
             : null;
-        const secretsConfig = this._fs.existsSync(this.secretsPath)
-            ? await this._fsUtils.parseJsonFile(this.secretsPath)
-            : null;
+        const secretsConfig = await this._getSecretsConfig(generalConfig);
+
         if (generalConfig || secretsConfig) {
             const parsedConfig = { ...generalConfig, ...secretsConfig };
             return this._validateStencilConfig(parsedConfig, ignoreMissingFields);
@@ -91,6 +90,25 @@ class StencilConfigManager {
             },
             { secretsConfig: {}, generalConfig: {} },
         );
+    }
+
+    /**
+     * @private
+     * @param {object | null} config
+     * @returns {Promise<object | null>}
+     */
+    async _getSecretsConfig(generalConfig) {
+        if (generalConfig && generalConfig.secretsFileName) {
+            const secretsPath = path.join(this.themePath, generalConfig.secretsFileName);
+
+            if (this._fs.existsSync(secretsPath)) {
+                return this._fsUtils.parseJsonFile(secretsPath);
+            }
+        }
+
+        return this._fs.existsSync(this.secretsPath)
+            ? this._fsUtils.parseJsonFile(this.secretsPath)
+            : null;
     }
 
     /**


### PR DESCRIPTION
#### What?
In situations where several stores are in the same repository, but in different branches, when you change from one branch to another, you always have to enter **accessToken**, which is quite inconvenient. This PR adds the ability to specify the name of the secret file in config.stencil.json, adding flexibility.

#### Screenshots (if appropriate)

![Example Image](https://i.postimg.cc/3RMVgV2Q/Screenshot-2022-07-07-at-19-30-40.png)

Closes #956 