### PR TITLE
feat: STRF-9877 Publish stencil cli docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Stencil CLI
 on:
     release:
         types: [created]
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -14,3 +19,33 @@ jobs:
             # Setup .npmrc file to publish to npm registry
             - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
             - run: npm publish
+
+    build-and-push-image:
+        runs-on: ubuntu-latest
+        permissions:
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v3
+              with:
+                  context: .
+                  push: ${{ github.event_name != 'pull_request' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#### What?

On release publish docker image with stencil cli in it to Github Packages

#### Tickets / Documentation

-   [STRF-9877](https://bigcommercecloud.atlassian.net/browse/STRF-9877)

#### Proof of work 
https://github.com/bigcommerce/stencil-cli/runs/8058234104?check_suite_focus=true
https://github.com/bigcommerce/stencil-cli/pkgs/container/stencil-cli

cc @bigcommerce/storefront-team
