### PR TITLE
chore: release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Draft
 
--   fix: debug command ([x](https://github.com/bigcommerce/stencil-cli/pull/x))
+### 5.2.0 (2022-08-30)
+
+-   feat: STRF-9877 Publish stencil cli docker image ([972](https://github.com/bigcommerce/stencil-cli/pull/972))
+-   fix: debug command ([970](https://github.com/bigcommerce/stencil-cli/pull/970))
 
 ### 5.1.0 (2022-07-14)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
-   feat: STRF-9877 Publish stencil cli docker image ([972](https://github.com/bigcommerce/stencil-cli/pull/972))
-   fix: debug command ([970](https://github.com/bigcommerce/stencil-cli/pull/970))

cc @bigcommerce/storefront-team
