### PR TITLE
Revert "docs(release): 5.2.1:"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ### Draft
 
-### 5.2.1 (2022-09-30)
-
--   fix: STRF-9832 custom template frontmatter is prioritized over default one ([983](https://github.com/bigcommerce/stencil-cli/pull/983))
-
 ### 5.2.0 (2022-08-30)
 
 -   feat: STRF-9877 Publish stencil cli docker image ([972](https://github.com/bigcommerce/stencil-cli/pull/972))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "5.2.1",
+      "version": "5.2.0",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "4.0.0",
@@ -19619,20 +19619,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ua-parser-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
@@ -21002,7 +20988,6 @@
       "dependencies": {
         "@bigcommerce/node-sass": {
           "version": "git+https://git@github.com/bigcommerce-labs/node-sass.git#34dbe47ad10c908af37f77681f33d1759ea28575",
-          "integrity": "sha512-4aTSR4dbpd/Q+pD1o7xAkmeXjVrd/oFYEsH+D8Ly35nT9yhUE2VsxmNKBDJwAX4UNd3PP4ntEJd0P58KPRk2VA==",
           "from": "@bigcommerce/node-sass@git+https://git@github.com/bigcommerce-labs/node-sass.git#34dbe47ad10c908af37f77681f33d1759ea28575",
           "requires": {
             "async-foreach": "^0.1.3",
@@ -35233,13 +35218,6 @@
       "requires": {
         "kind-of": "^3.1.0"
       }
-    },
-    "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true,
-      "peer": true
     },
     "ua-parser-js": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Reverts bigcommerce/stencil-cli#984 due to package-lock json issues.