### PR TITLE
Revert "docs(release): 5.2.1:"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ### Draft
 
-### 5.2.1 (2022-09-30)
-
--   fix: STRF-9832 custom template frontmatter is prioritized over default one ([983](https://github.com/bigcommerce/stencil-cli/pull/983))
-
 ### 5.2.0 (2022-08-30)
 
 -   feat: STRF-9877 Publish stencil cli docker image ([972](https://github.com/bigcommerce/stencil-cli/pull/972))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "5.2.1",
+      "version": "5.2.0",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Reverts bigcommerce/stencil-cli#986 due to package-lock issues