### PR TITLE
fix(release): registry env var for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,6 @@ on:
     release:
         types: [created]
 
-env:
-    REGISTRY: ghcr.io
-    IMAGE_NAME: ${{ github.repository }}
-
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -21,6 +17,9 @@ jobs:
             - run: npm publish
 
     build-and-push-image:
+        env:
+            REGISTRY: ghcr.io
+            IMAGE_NAME: ${{ github.repository }}
         runs-on: ubuntu-latest
         permissions:
             packages: write


### PR DESCRIPTION
#### What?

Fix Github Actions Release by moving registry env var to the specific job, rather than setting on the global level

Issue: https://github.com/bigcommerce/stencil-cli/actions/runs/3126162483/jobs/5071345200 

cc @bigcommerce/storefront-team
