### PR TITLE
chore: release 5.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Draft
 
+### 5.2.3 (2022-09-29)
+
 -   fix: STRF-10049 npm 8 install fix ([x](https://github.com/bigcommerce/stencil-cli/pull/x))
 
 ### 5.2.2 (2022-09-29)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
-   fix: STRF-10049 npm 8 install fix ([x](https://github.com/bigcommerce/stencil-cli/pull/x))
