### PR TITLE
fix(storefront): strf-10118 Fix redirects stalling locally

### DIFF
--- a/server/plugins/renderer/responses/redirect-response.js
+++ b/server/plugins/renderer/responses/redirect-response.js
@@ -16,6 +16,7 @@ class RedirectResponse {
         for (const [name, values] of Object.entries(this.headers)) {
             switch (name) {
                 case 'transfer-encoding':
+                case 'content-length':
                     break;
                 case 'set-cookie':
                     // Cookies should be an array


### PR DESCRIPTION
## What?
Fix redirects not working locally. Currently, any redirects happening within Stencil CLI will hang, and the redirect will never finish. This can be seen by creating a redirect and attempting to browse to the redirect in Stencil CLI, or by simply attempting to browse to a product without the trailing slash.

## Why?
We should expect redirects to demonstrate the same behavior that one would see in the production environment of BigCommerce.

This issue was occurring because our `RedirectsResponse.respond` method was not stripping the `'content-length'` header, causing the redirected response to be treated as a stream that would never resolve.

## Tickets / Documentation
-   [STRF-10118](https://bigcommercecloud.atlassian.net/browse/STRF-10118)

## Video proof of fix

**Before:**

https://user-images.githubusercontent.com/19815878/194952585-25482c58-4d2d-4a46-98f3-d88a71ec3638.mov

**After:**


https://user-images.githubusercontent.com/19815878/194952784-aca9a275-06b7-4d5f-ab09-9db1333b7846.mov




cc @bigcommerce/storefront-team
