### PR TITLE
docs(release): 5.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ### Draft
 
+### 5.2.4 (2022-10-10)
+
+-   fix: STRF-10118 fix redirects stalling locally ([1000](https://github.com/bigcommerce/stencil-cli/pull/1000))
+
 ### 5.2.3 (2022-09-29)
 
--   fix: STRF-10049 npm 8 install fix ([x](https://github.com/bigcommerce/stencil-cli/pull/x))
+-   fix: STRF-10049 npm 8 install fix ([997](https://github.com/bigcommerce/stencil-cli/pull/997))
 
 ### 5.2.2 (2022-09-29)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- fix: STRF-10118 fix redirects stalling locally ([1000](https://github.com/bigcommerce/stencil-cli/pull/1000))

cc @bigcommerce/storefront-team
