### PR TITLE
fix(storefront): bctheme-1284 Fix error on using scoped nested external templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Draft
 
+-   fix: BCTHEME-1284 fix error on using scoped nested external templates ([1003](https://github.com/bigcommerce/stencil-cli/pull/1003))
+
 ### 5.2.4 (2022-10-10)
 
 -   fix: STRF-10118 fix redirects stalling locally ([1000](https://github.com/bigcommerce/stencil-cli/pull/1000))

--- a/lib/template-assembler.js
+++ b/lib/template-assembler.js
@@ -26,7 +26,7 @@ const applyExternalPath = (templateName, templates) => {
 const replacePartialNames = (content, partialRoute) => {
     return content.replace(
         includeRegex,
-        (__, partialName) => `{{> ${defineBaseRoute(partialRoute)}/${partialName} }}`,
+        (__, partialName) => `{{> '${defineBaseRoute(partialRoute)}/${partialName}' }}`,
     );
 };
 const trimPartial = (partial) => {


### PR DESCRIPTION
#### What?

Currently we experience an error on attempt to use nested templates from external scoped modules due to special symbols .  For instance, if we use some external template in our stencil theme where we re-use some other nested template from external and scoped module (like an UI library with styles and templates) we receive parsing error due to special symbol `@`. We've wrapped  all such nested templates into quotes to prevent this behaviour.

#### Tickets / Documentation

-   [BCTHEME-1284](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1284)


#### Screenshots (if appropriate)

![Screenshot 2022-10-17 at 21 28 38](https://user-images.githubusercontent.com/67792608/196254710-4e5337d8-f47e-4ee8-a18c-d4faef56fb8b.png)
`categories-test` template uses a nested template inside:
![Screenshot 2022-10-17 at 21 27 53](https://user-images.githubusercontent.com/67792608/196254675-a981ab0f-c7f5-4f25-927b-a3e2627c2209.png)

![Screenshot 2022-10-17 at 21 33 31](https://user-images.githubusercontent.com/67792608/196255670-3087c64b-da7a-44dd-b0be-c27566acb38d.png)



cc @bigcommerce/storefront-team, @bigcommerce/themes-team
