### PR TITLE
docs(release): 5.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Draft
 
+### 5.2.5 (2022-10-18)
+
+-   fix: STRF-10130 fix 404s on pagination in brands/categories ([1004](https://github.com/bigcommerce/stencil-cli/pull/1004))
+
 ### 5.2.4 (2022-10-10)
 
 -   fix: STRF-10118 fix redirects stalling locally ([1000](https://github.com/bigcommerce/stencil-cli/pull/1000))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- fix: STRF-10130 fix 404s on pagination in brands/categories ([1004](https://github.com/bigcommerce/stencil-cli/pull/1004))

cc @bigcommerce/storefront-team
