### PR TITLE
fix: update changelog and add tag format w/o 'v'

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,6 @@
 {
     "branches": ["master"],
+    "tagFormat": "${version}",
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-### Draft
-
--   fix: BCTHEME-1284 fix error on using scoped nested external templates ([1003](https://github.com/bigcommerce/stencil-cli/pull/1003))
-
 ### 5.2.5 (2022-10-18)
 
+-   fix: BCTHEME-1284 fix error on using scoped nested external templates ([1003](https://github.com/bigcommerce/stencil-cli/pull/1003))
 -   fix: STRF-10130 fix 404s on pagination in brands/categories ([1004](https://github.com/bigcommerce/stencil-cli/pull/1004))
 
 ### 5.2.4 (2022-10-10)


### PR DESCRIPTION
#### What?

1. Fix changelog (adjust to the current state).
2. Add tag format, since we don't use v-prefix for the package versioning and tag format. 


cc @bigcommerce/storefront-team
