### PR TITLE
fix: disable checking changelog, that was auto-generated

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules
 .coverage/
 test/_mocks/
 
+CHANGELOG.md


### PR DESCRIPTION
#### What?

Disable changelog.md check from prettier, since it's auto-generated 

Came from https://github.com/bigcommerce/stencil-cli/pull/1019

#### Screenshots (if appropriate)
<img width="730" alt="Screenshot 2022-11-02 at 10 57 36" src="https://user-images.githubusercontent.com/68893868/199460142-f0aa9b70-f118-49cd-9b6b-7ab2b5b2b876.png">

cc @bigcommerce/storefront-team
