### PR TITLE
fix(storefront): bctheme-1331 Incorrect handling of nested external templates with params

### DIFF
--- a/lib/template-assembler.js
+++ b/lib/template-assembler.js
@@ -5,6 +5,7 @@ const path = require('path');
 const upath = require('upath');
 
 const partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9@'"/]+)[^{]*?}}/g;
+const partialWithoutBracketsRegex = /[^>{{}}\s*]+/g;
 const dynamicComponentRegex = /\{\{\s*?dynamicComponent\s*(?:'|")([_|\-|a-zA-Z0-9/]+)(?:'|").*?}}/g;
 const includeRegex = /{{2}>\s*([_|\-|a-zA-Z0-9/]+)[^{]*?}{2}/g;
 const pathStringRegex = /^["'].+["']$/;
@@ -23,12 +24,24 @@ const defineBaseRoute = (route) => route.split('/').slice(0, 3).join('/');
 const applyExternalPath = (templateName, templates) => {
     return templates.map((t) => `${defineBaseRoute(templateName)}/${t}`);
 };
+const modifyNestedPartial = (partial) => {
+    const partialFragments = partial.match(partialWithoutBracketsRegex);
+
+    if (partialFragments) {
+        return [`${partialFragments.shift()}'`, ...partialFragments].join(' ');
+    }
+
+    return partialFragments;
+};
+
 const replacePartialNames = (content, partialRoute) => {
     return content.replace(
         includeRegex,
-        (__, partialName) => `{{> '${defineBaseRoute(partialRoute)}/${partialName}' }}`,
+        (partialName) =>
+            `{{> '${defineBaseRoute(partialRoute)}/${modifyNestedPartial(partialName)} }}`,
     );
 };
+
 const trimPartial = (partial) => {
     if (pathStringRegex.test(partial)) {
         return partial.slice(1, -1);


### PR DESCRIPTION


#### What?

In case we re-use  external templates in our UI library and these templates receive data via parameters we will face an issue that we 'loose' these data due to incorrect handling of parameters. This PR fixes issue with incorrect handling of external templates that contain parameters.


#### Tickets / Documentation

-   [BCTHEME-1331](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1331)


#### Screenshots (if appropriate)
Before Fix:
![beforeFix_templates](https://user-images.githubusercontent.com/67792608/203054820-83d99f91-f1c8-46f2-b792-313a4778d57a.png)
<img width="1038" alt="beforeFix_UI" src="https://user-images.githubusercontent.com/67792608/203054826-566b8ef1-e395-4a2b-8a49-3e602c5f1580.png">

After Fix:
![afterFix_templates](https://user-images.githubusercontent.com/67792608/203054881-4360cd5d-8e6d-4597-9130-0eb59c3b3beb.png)
<img width="1040" alt="Screenshot 2022-11-21 at 14 10 08" src="https://user-images.githubusercontent.com/67792608/203054884-a3849814-8c41-437e-9589-bd5d4f8e3658.png">


cc @bigcommerce/storefront-team
