### PR TITLE
feat: strf-10482 Bad comma in the selectors

### DIFF
--- a/lib/nodeSass/AutoFixer.js
+++ b/lib/nodeSass/AutoFixer.js
@@ -9,9 +9,11 @@ const cssCompiler = require('../css/compile');
 
 const BaseRulesFixer = require('./BaseRulesFixer');
 const ConditionaImportFixer = require('./ConditionalImportFixer');
+const CommaRemovalFixer = require('./CommaRemovalFixer');
 
 const CONDITIONAL_IMPORT = 'conditional-import';
 const BASE_LEVEL_RULES = 'base-level-rules';
+const POSSIBLE_WRONG_COMMA = 'possible-wrong-comma';
 
 class AutoFixer {
     /**
@@ -69,6 +71,10 @@ class AutoFixer {
             } else if (problem === BASE_LEVEL_RULES) {
                 const baseRulesFixer = new BaseRulesFixer(dirname, err.file);
                 files = await baseRulesFixer.run();
+            } else if (problem === POSSIBLE_WRONG_COMMA) {
+                const toFixFile = err.file === 'stdin' ? file : err.file;
+                const commaRemovalFixer = new CommaRemovalFixer(dirname, toFixFile);
+                files = await commaRemovalFixer.run();
             }
             this.parseChangedFiles(files);
         } else {
@@ -94,6 +100,12 @@ class AutoFixer {
                 )
             ) {
                 return BASE_LEVEL_RULES;
+            }
+            if (
+                err.formatted.includes('Invalid CSS after') &&
+                err.formatted.includes('expected selector, was ', '')
+            ) {
+                return POSSIBLE_WRONG_COMMA;
             }
         }
 

--- a/lib/nodeSass/CommaRemovalFixer.js
+++ b/lib/nodeSass/CommaRemovalFixer.js
@@ -1,0 +1,28 @@
+// There can be the case, when you have a comma at the beginning or at the end of the selector, which now is not allowed.
+// Previously it was just ignored, but now it will cause an error.
+
+const fs = require('fs');
+const BaseFixer = require('./BaseFixer');
+
+class CommaRemovalFixer extends BaseFixer {
+    async run() {
+        const scss = fs.readFileSync(this.filePath, 'utf8');
+        const processedFile = await this.processCss(scss, this.transform());
+
+        return [{ filePath: this.filePath, data: processedFile.css }];
+    }
+
+    transform() {
+        return {
+            postcssPlugin: 'Unwanted comma removal',
+            Rule(rule) {
+                if (rule.selector.startsWith(',') || rule.selector.endsWith(',')) {
+                    /* eslint-disable-next-line no-param-reassign */
+                    rule.selector = rule.selector.trim().replace(/^,?|,?$/g, '');
+                }
+            },
+        };
+    }
+}
+
+module.exports = CommaRemovalFixer;


### PR DESCRIPTION
#### What?

Comma after or before selectors will cause the theme to fail on compilation 

#### Tickets / Documentation

-   [STRF-10482](https://bigcommercecloud.atlassian.net/browse/STRF-10482)

#### Screenshots (if appropriate)
<img width="1044" alt="Screenshot 2023-03-03 at 16 10 46" src="https://user-images.githubusercontent.com/68893868/222755898-80796d66-5f60-48c2-82c1-5b89546c5801.png">


cc @bigcommerce/storefront-team


[STRF-10482]: https://bigcommercecloud.atlassian.net/browse/STRF-10482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ