### PR TITLE
fix(storefront): MERC-9452 Return variation id when activating theme

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -515,7 +515,7 @@ utils.requestToApplyVariation = async (options) => {
 };
 
 utils.notifyUserOfCompletion = (options, callback) => {
-    callback(null, 'Stencil Push Finished');
+    callback(null, `Stencil Push Finished. Variation ID: ${options.variationId}`);
 };
 
 module.exports = utils;


### PR DESCRIPTION
#### What?

Currently Kibana and CP staff logs are logging variation ID when a theme is applied. Return a variation ID when activating a theme using Stencil CLI so that a developer can match the log with the corresponding variation ID.

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/MERC-9452

#### Screenshots (if appropriate)
![Screen Shot 2023-04-21 at 1 26 16 PM](https://user-images.githubusercontent.com/45639285/233728545-00fc3d1f-cf01-412c-8568-23ad75840512.png)


cc @bigcommerce/storefront-team
