### PR TITLE
fix: STRF-10081 stencil pull overrides only variation config

### DIFF
--- a/lib/stencil-pull.js
+++ b/lib/stencil-pull.js
@@ -12,6 +12,7 @@ function stencilPull(options = {}, callback) {
             stencilPushUtils.promptUserForChannel,
             stencilPullUtils.getChannelActiveTheme,
             stencilPullUtils.getThemeConfiguration,
+            stencilPullUtils.getCurrentVariation,
             stencilPullUtils.mergeThemeConfiguration,
         ],
         callback,

--- a/lib/stencil-pull.utils.js
+++ b/lib/stencil-pull.utils.js
@@ -26,6 +26,28 @@ utils.getChannelActiveTheme = async (options) => {
     return { ...options, activeTheme };
 };
 
+utils.getCurrentVariation = async (options) => {
+    const {
+        config: { accessToken },
+        storeHash,
+        activeTheme,
+        saved,
+        remoteThemeConfiguration,
+    } = options;
+    const apiHost = options.apiHost || options.config.apiHost;
+    const themeId = activeTheme.active_theme_uuid;
+    const variations = await themeApiClient.getVariationsByThemeId({
+        accessToken,
+        apiHost,
+        storeHash,
+        themeId,
+    });
+    const variation = variations.find((v) => v.uuid === remoteThemeConfiguration.variation_uuid);
+
+    console.log('ok'.green + ` -- Fetched ${saved ? 'saved' : 'active'} variation name`);
+    return { ...options, variation };
+};
+
 utils.getThemeConfiguration = async (options) => {
     const {
         config: { accessToken },
@@ -59,6 +81,7 @@ utils.mergeThemeConfiguration = async (options) => {
     const { remoteThemeConfiguration } = options;
 
     const localConfig = await parseJsonFile('config.json');
+    const variation = localConfig.variations.find((v) => v.name === options.variation.name);
     let diffDetected = false;
 
     // For any keys the remote configuration has in common with the local configuration,
@@ -67,19 +90,22 @@ utils.mergeThemeConfiguration = async (options) => {
         if (!(key in localConfig.settings)) {
             continue;
         }
-        const localVal = localConfig.settings[key];
+        const defaultVal = localConfig.settings[key];
 
         // Check for different types, and throw an error if they are found
-        if (typeof localVal !== typeof remoteVal) {
+        if (typeof defaultVal !== typeof remoteVal) {
             throw new Error(
                 `Theme configuration key "${key}" cannot be merged because it is not of the same type. ` +
-                    `Remote configuration is of type ${typeof remoteVal} while local configuration is of type ${typeof localVal}.`,
+                    `Remote configuration is of type ${typeof remoteVal} while local configuration is of type ${typeof defaultVal}.`,
             );
         }
 
         // If a different value is found, overwrite the local config
-        if (!_.isEqual(localVal, remoteVal)) {
-            localConfig.settings[key] = remoteVal;
+        if (!_.isEqual(defaultVal, remoteVal)) {
+            if (!variation.settings) {
+                variation.settings = {};
+            }
+            variation.settings[key] = remoteVal;
             diffDetected = true;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "4.2.1",


### PR DESCRIPTION
#### What?

Stencil Pull now will always override only variation settings config

#### Tickets / Documentation

-   [STRF-10081](https://bigcommercecloud.atlassian.net/browse/STRF-10081)

#### Screenshots (if appropriate)

Video is too long for Github, so put it on google drive
https://drive.google.com/file/d/1htRCmNgM3u2JqJC-zF0Ib9LgRitnmngK/view?usp=sharing

cc @bigcommerce/storefront-team


[STRF-10081]: https://bigcommercecloud.atlassian.net/browse/STRF-10081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ