### PR TITLE
Cypress error on load

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -373,7 +373,8 @@ function getAcceptLanguageHeader(request) {
     ) {
         return internals.options.storeSettingsLocale.default_shopper_language;
     }
-    return request.headers['accept-language'].toLowerCase();
+
+    return request.headers['accept-language']?.toLowerCase() || '';
 }
 
 /**


### PR DESCRIPTION
#### What?
I noticed that when running Cypress for your E2E tests, it returns a 500 error. This occurs because for some reason, Cypress fails to include the `accept-language` header in the requests, resulting in an error during test execution.

To resolve this issue, I have made a modification by adding a validation step to check if `request.headers['accept-language']` is undefined before applying the `toLowerCase` method.

#### Screenshots (if appropriate)

![image](https://github.com/bigcommerce/stencil-cli/assets/48190882/fbfc9206-2930-4fd4-b012-5e83cc80f0c9)

![image](https://github.com/bigcommerce/stencil-cli/assets/48190882/78283c79-f1e4-470d-87c5-79ab13c70184)

cc @bigcommerce/storefront-team