### PR TITLE
chore(merc): Bump paper version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "4.2.1",
+        "@bigcommerce/stencil-paper": "git@github.com:kchu93/paper.git#MERC-9364",
         "@bigcommerce/stencil-styles": "5.1.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/glue": "^8.0.0",
@@ -737,28 +737,27 @@
       }
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.2.1.tgz",
-      "integrity": "sha512-M5gKH713SeiwoSEZD95u9UQvsoYkgW0fu5nm/1sx33QVvfYbSbO6gcO6fVySD+SEZ89SZ2Kp8sz8dVMhrXdwXg==",
+      "version": "4.8.6",
+      "resolved": "git+ssh://git@github.com/kchu93/paper.git#1ed0abaec99aa3e2a2a3e6034ece4526d1960ed1",
+      "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "5.2.6",
+        "@bigcommerce/stencil-paper-handlebars": "git@github.com:kchu93/paper-handlebars.git#MERC-9364",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.2.6.tgz",
-      "integrity": "sha512-rptUwWByRWZxSR8K2Fzv90Lps7lcaVaeVb/IRlHcuw/YM9P3UVUzFA5enrsZWmHg2mRM70eSEGwCXdSLMEm2ag==",
+      "version": "5.7.8",
+      "resolved": "git+ssh://git@github.com/kchu93/paper-handlebars.git#69c2c4753d1e46e253a559b3e89b4ac2a5c6eed8",
+      "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.6",
         "date.js": "^0.3.3",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
-        "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "remarkable": "^2.0.1",
-        "stringz": "^0.1.1"
+        "stringz": "2.1.0"
       },
       "engines": {
         "node": ">=10"
@@ -5605,7 +5604,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -19610,9 +19608,12 @@
       }
     },
     "node_modules/stringz": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stringz/-/stringz-0.1.2.tgz",
-      "integrity": "sha512-suyTsEDN28681++SG+ysb97glPipDClXNtm/OVy1RtrdT5DMg2PVdA5HAt3obrMKT/MFQF7fqh0p55s6Vc2GRw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
+      "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
+      "dependencies": {
+        "char-regex": "^1.0.2"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
@@ -21384,28 +21385,25 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.2.1.tgz",
-      "integrity": "sha512-M5gKH713SeiwoSEZD95u9UQvsoYkgW0fu5nm/1sx33QVvfYbSbO6gcO6fVySD+SEZ89SZ2Kp8sz8dVMhrXdwXg==",
+      "version": "git+ssh://git@github.com/kchu93/paper.git#1ed0abaec99aa3e2a2a3e6034ece4526d1960ed1",
+      "from": "@bigcommerce/stencil-paper@git@github.com:kchu93/paper.git#MERC-9364",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "5.2.6",
+        "@bigcommerce/stencil-paper-handlebars": "git@github.com:kchu93/paper-handlebars.git#MERC-9364",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.2.6.tgz",
-      "integrity": "sha512-rptUwWByRWZxSR8K2Fzv90Lps7lcaVaeVb/IRlHcuw/YM9P3UVUzFA5enrsZWmHg2mRM70eSEGwCXdSLMEm2ag==",
+      "version": "git+ssh://git@github.com/kchu93/paper-handlebars.git#69c2c4753d1e46e253a559b3e89b4ac2a5c6eed8",
+      "from": "@bigcommerce/stencil-paper-handlebars@git@github.com:kchu93/paper-handlebars.git#MERC-9364",
       "requires": {
         "@bigcommerce/handlebars-v4": "4.7.6",
         "date.js": "^0.3.3",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
-        "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "remarkable": "^2.0.1",
-        "stringz": "^0.1.1"
+        "stringz": "2.1.0"
       }
     },
     "@bigcommerce/stencil-styles": {
@@ -25277,8 +25275,7 @@
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -35663,9 +35660,12 @@
       }
     },
     "stringz": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stringz/-/stringz-0.1.2.tgz",
-      "integrity": "sha512-suyTsEDN28681++SG+ysb97glPipDClXNtm/OVy1RtrdT5DMg2PVdA5HAt3obrMKT/MFQF7fqh0p55s6Vc2GRw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
+      "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
+      "requires": {
+        "char-regex": "^1.0.2"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "4.2.1",
+    "@bigcommerce/stencil-paper": "git@github.com:kchu93/paper.git#MERC-9364",
     "@bigcommerce/stencil-styles": "5.1.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/glue": "^8.0.0",


### PR DESCRIPTION
- [ ] [Paper Handlebars](https://github.com/bigcommerce/paper-handlebars/pull/273)
- [ ] [Paper](https://github.com/bigcommerce/paper/pull/343) (bump version)
- [ ] [Stencil Cli (bump version)](https://github.com/bigcommerce/stencil-cli/pull/1125)
- [ ] Storefront Renderer (bump verion) 

## What? Why?
Use CDN Original images for webdav - cache control. 

If a developer/merchant decide to use the handlebar to import images from WebDav into the theme `({{cdn "webdav:/img/image.jpg"}})`, there is no cache-control header when the image is presented to the storefront.

Similar to our Image Manager, we should be using the cdn original images (Similar to Jinsoo's PR here [MERC-7127](https://github.com/bigcommerce/bigcommerce/pull/47254)


Example images:
[Original /content/](https://cdn11.bigcommerce.com/s-hc1qesrzsh/content/webdev-pat.jpg)

[Updated /images/stencil/original/content/](https://cdn11.bigcommerce.com/s-hc1qesrzsh/images/stencil/original/content/webdev-pat.jpg)

## How was it tested?
Tested locally

cc @bigcommerce/storefront-team


[MERC-7127]: https://bigcommercecloud.atlassian.net/browse/MERC-7127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ