### PR TITLE
fix: print cli errors to stderr

### DIFF
--- a/lib/cliCommon.js
+++ b/lib/cliCommon.js
@@ -40,7 +40,7 @@ function printNetworkError(config) {
  * @returns {void}
  */
 function printCliResultError(error) {
-    console.log(`\n\n${'not ok'.red} -- ${error || 'Unknown error'}\n`);
+    console.error(`\n\n${'not ok'.red} -- ${error || 'Unknown error'}\n`);
 
     if (error && Array.isArray(error.messages)) {
         for (const item of error.messages) {

--- a/lib/cliCommon.spec.js
+++ b/lib/cliCommon.spec.js
@@ -5,9 +5,11 @@ const { printCliResultError, messages } = require('./cliCommon');
 describe('cliCommon', () => {
     describe('printCliResultError', () => {
         let consoleLogStub;
+        let consoleErrorStub;
 
         beforeAll(() => {
             consoleLogStub = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+            consoleErrorStub = jest.spyOn(console, 'error').mockImplementation(jest.fn());
         });
 
         afterEach(() => {
@@ -21,8 +23,8 @@ describe('cliCommon', () => {
         it('should log "Unknown error" and general recommendations if input is empty', () => {
             printCliResultError(null);
 
-            expect(consoleLogStub).toHaveBeenCalledTimes(3);
-            expect(consoleLogStub).toHaveBeenCalledWith(expect.stringMatching('Unknown error'));
+            expect(consoleLogStub).toHaveBeenCalledTimes(2);
+            expect(consoleErrorStub).toHaveBeenCalledWith(expect.stringMatching('Unknown error'));
             expect(consoleLogStub).toHaveBeenCalledWith(messages.visitTroubleshootingPage);
             expect(consoleLogStub).toHaveBeenCalledWith(messages.submitGithubIssue);
         });
@@ -32,8 +34,8 @@ describe('cliCommon', () => {
 
             printCliResultError(err);
 
-            expect(consoleLogStub).toHaveBeenCalledTimes(3);
-            expect(consoleLogStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
+            expect(consoleLogStub).toHaveBeenCalledTimes(2);
+            expect(consoleErrorStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
             expect(consoleLogStub).toHaveBeenCalledWith(messages.visitTroubleshootingPage);
             expect(consoleLogStub).toHaveBeenCalledWith(messages.submitGithubIssue);
         });
@@ -43,8 +45,8 @@ describe('cliCommon', () => {
 
             printCliResultError(errStr);
 
-            expect(consoleLogStub).toHaveBeenCalledTimes(3);
-            expect(consoleLogStub).toHaveBeenCalledWith(expect.stringMatching(errStr));
+            expect(consoleLogStub).toHaveBeenCalledTimes(2);
+            expect(consoleErrorStub).toHaveBeenCalledWith(expect.stringMatching(errStr));
             expect(consoleLogStub).toHaveBeenCalledWith(messages.visitTroubleshootingPage);
             expect(consoleLogStub).toHaveBeenCalledWith(messages.submitGithubIssue);
         });
@@ -55,8 +57,8 @@ describe('cliCommon', () => {
 
             printCliResultError(err);
 
-            expect(consoleLogStub).toHaveBeenCalledTimes(5);
-            expect(consoleLogStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
+            expect(consoleLogStub).toHaveBeenCalledTimes(4);
+            expect(consoleErrorStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
             expect(consoleLogStub).toHaveBeenCalledWith(`${err.messages[0].message.red}\n`);
             expect(consoleLogStub).toHaveBeenCalledWith(`${err.messages[1].message.red}\n`);
             expect(consoleLogStub).toHaveBeenCalledWith(messages.visitTroubleshootingPage);
@@ -77,8 +79,8 @@ describe('cliCommon', () => {
 
             printCliResultError(err);
 
-            expect(consoleLogStub).toHaveBeenCalledTimes(5);
-            expect(consoleLogStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
+            expect(consoleLogStub).toHaveBeenCalledTimes(4);
+            expect(consoleErrorStub).toHaveBeenCalledWith(expect.stringMatching(err.toString()));
             expect(consoleLogStub).toHaveBeenCalledWith(`${'first_error'.red}\n`);
             expect(consoleLogStub).toHaveBeenCalledWith(`${'2nd_error'.red}\n`);
             expect(consoleLogStub).toHaveBeenCalledWith(messages.visitTroubleshootingPage);


### PR DESCRIPTION
#### What?

Currently with some of our scripts this blocks to catch an error, since the error goes to stdout instead of stderr

#### Tickets / Documentation

-   [STRF-11118](https://bigcommercecloud.atlassian.net/browse/STRF-11118)


cc @bigcommerce/storefront-team


[STRF-11118]: https://bigcommercecloud.atlassian.net/browse/STRF-11118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ