### PR TITLE
fix: strf-11280 Exclude any css files from scss validation

### DIFF
--- a/lib/ScssValidator.js
+++ b/lib/ScssValidator.js
@@ -65,6 +65,7 @@ class ScssValidator {
                     const filePath = item[1].slice(1, -1);
                     const fileName = this.tryToResolveCssFileLocation(filePath);
                     if (
+                        fileName &&
                         !this.isStyleSheetAComment(content, filePath) &&
                         !cssFiles.includes(fileName)
                     ) {
@@ -107,6 +108,9 @@ class ScssValidator {
         for (const location of possibleLocations) {
             const fullFilePath = path.join(this.themePath, location);
             if (fs.existsSync(fullFilePath)) {
+                if (fullFilePath.endsWith('.css')) {
+                    return null;
+                }
                 if (!this.isRootCssFile(location)) {
                     return this.getCssFileWithoutRootFolder(location);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "7.1.1",
+  "version": "7.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "7.1.1",
+      "version": "7.2.1",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "4.2.1",
+        "@bigcommerce/stencil-paper": "4.10.4",
         "@bigcommerce/stencil-styles": "5.1.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/glue": "^8.0.0",
@@ -40,6 +40,7 @@
         "object-to-spawn-args": "^2.0.0",
         "parse-json": "^5.2.0",
         "postcss": "^8.4.21",
+        "postcss-safe-parser": "^6.0.0",
         "postcss-scss": "^4.0.6",
         "progress": "^2.0.3",
         "recursive-readdir": "^2.2.2",
@@ -709,20 +710,20 @@
       "dev": true
     },
     "node_modules/@bigcommerce/handlebars-v4": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.6.tgz",
-      "integrity": "sha512-LaZo02o9LLux24bN0Wv/+AZRVSR6ccPgWWJAhoRcDQ39qWRctR98cgTGhe0r2iZmb37AiayQT8vfB/sIvkqYZQ==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.8.tgz",
+      "integrity": "sha512-1gu8AtGfryFCnmbhoPmCqQh4FLEWMwgwJ/RMn71NpppLBJlrTYVfpnt3kqUUfpE8inqU/pnkCCIqQfCaBcz/KA==",
       "dependencies": {
-        "handlebars": "4.7.6"
+        "handlebars": "4.7.8"
       }
     },
     "node_modules/@bigcommerce/handlebars-v4/node_modules/handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -737,31 +738,30 @@
       }
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.2.1.tgz",
-      "integrity": "sha512-M5gKH713SeiwoSEZD95u9UQvsoYkgW0fu5nm/1sx33QVvfYbSbO6gcO6fVySD+SEZ89SZ2Kp8sz8dVMhrXdwXg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.10.4.tgz",
+      "integrity": "sha512-xMr+fDyu4Dne8Qf8bqPT/EDa6HKjtSQ3AU8msW9SpMH9DkoLF1oEzevzVi4cjHIBwc0RpbfgnH6BZtm10ghFzQ==",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "5.2.6",
+        "@bigcommerce/stencil-paper-handlebars": "5.9.5",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.2.6.tgz",
-      "integrity": "sha512-rptUwWByRWZxSR8K2Fzv90Lps7lcaVaeVb/IRlHcuw/YM9P3UVUzFA5enrsZWmHg2mRM70eSEGwCXdSLMEm2ag==",
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.9.5.tgz",
+      "integrity": "sha512-Pf+5Ai4Yy0C74Zoo1Z/8RiaBEjKTXRjrVfg4lNfBnRKTO6dBO20MElQVy96aAZugLuTKLa5bFwLk0p/T5K4LVw==",
       "dependencies": {
-        "@bigcommerce/handlebars-v4": "4.7.6",
-        "date.js": "^0.3.3",
+        "@bigcommerce/handlebars-v4": "4.7.8",
+        "chrono-node": "^2.6.5",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
-        "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "remarkable": "^2.0.1",
-        "stringz": "^0.1.1"
+        "stringz": "2.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/@bigcommerce/stencil-styles": {
@@ -4751,9 +4751,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4762,12 +4762,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -5291,9 +5295,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5302,13 +5306,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5546,9 +5554,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001543",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz",
+      "integrity": "sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5557,6 +5565,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -5605,7 +5617,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -5735,6 +5746,17 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.0.tgz",
+      "integrity": "sha512-0s2vv89LmsbgoibV0AIVgNnGqlU8N5yCCVZXvc3mRCjnmlG/gJw1hCYOmNwjB+AIuwZQdKTXfwvsHDRTs6pwcg==",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/ci-info": {
@@ -7147,14 +7169,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/date.js": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
-      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
-      "dependencies": {
-        "debug": "~3.1.0"
-      }
-    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -7164,13 +7178,10 @@
         "node": "*"
       }
     },
-    "node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -7566,9 +7577,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "version": "1.4.539",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.539.tgz",
+      "integrity": "sha512-wRmWJ8F7rgmINuI32S6r2SLrw/h/bJQsDSvBiq9GBfvc2Lh73qTOwn73r3Cf67mjVgFGJYcYtmERzySa5jIWlg=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -9032,15 +9043,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -14162,9 +14173,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/node-sass": {
       "version": "8.0.0",
@@ -17628,6 +17639,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
     "node_modules/postcss-scss": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
@@ -19610,9 +19636,12 @@
       }
     },
     "node_modules/stringz": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stringz/-/stringz-0.1.2.tgz",
-      "integrity": "sha512-suyTsEDN28681++SG+ysb97glPipDClXNtm/OVy1RtrdT5DMg2PVdA5HAt3obrMKT/MFQF7fqh0p55s6Vc2GRw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
+      "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
+      "dependencies": {
+        "char-regex": "^1.0.2"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
@@ -20365,9 +20394,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -20376,6 +20405,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -20383,7 +20416,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -21362,20 +21395,20 @@
       "dev": true
     },
     "@bigcommerce/handlebars-v4": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.6.tgz",
-      "integrity": "sha512-LaZo02o9LLux24bN0Wv/+AZRVSR6ccPgWWJAhoRcDQ39qWRctR98cgTGhe0r2iZmb37AiayQT8vfB/sIvkqYZQ==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.8.tgz",
+      "integrity": "sha512-1gu8AtGfryFCnmbhoPmCqQh4FLEWMwgwJ/RMn71NpppLBJlrTYVfpnt3kqUUfpE8inqU/pnkCCIqQfCaBcz/KA==",
       "requires": {
-        "handlebars": "4.7.6"
+        "handlebars": "4.7.8"
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.7.6",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-          "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+          "version": "4.7.8",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+          "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
           "requires": {
             "minimist": "^1.2.5",
-            "neo-async": "^2.6.0",
+            "neo-async": "^2.6.2",
             "source-map": "^0.6.1",
             "uglify-js": "^3.1.4",
             "wordwrap": "^1.0.0"
@@ -21384,28 +21417,27 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.2.1.tgz",
-      "integrity": "sha512-M5gKH713SeiwoSEZD95u9UQvsoYkgW0fu5nm/1sx33QVvfYbSbO6gcO6fVySD+SEZ89SZ2Kp8sz8dVMhrXdwXg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.10.4.tgz",
+      "integrity": "sha512-xMr+fDyu4Dne8Qf8bqPT/EDa6HKjtSQ3AU8msW9SpMH9DkoLF1oEzevzVi4cjHIBwc0RpbfgnH6BZtm10ghFzQ==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "5.2.6",
+        "@bigcommerce/stencil-paper-handlebars": "5.9.5",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.2.6.tgz",
-      "integrity": "sha512-rptUwWByRWZxSR8K2Fzv90Lps7lcaVaeVb/IRlHcuw/YM9P3UVUzFA5enrsZWmHg2mRM70eSEGwCXdSLMEm2ag==",
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.9.5.tgz",
+      "integrity": "sha512-Pf+5Ai4Yy0C74Zoo1Z/8RiaBEjKTXRjrVfg4lNfBnRKTO6dBO20MElQVy96aAZugLuTKLa5bFwLk0p/T5K4LVw==",
       "requires": {
-        "@bigcommerce/handlebars-v4": "4.7.6",
-        "date.js": "^0.3.3",
+        "@bigcommerce/handlebars-v4": "4.7.8",
+        "chrono-node": "^2.6.5",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
-        "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "remarkable": "^2.0.1",
-        "stringz": "^0.1.1"
+        "stringz": "2.1.0"
       }
     },
     "@bigcommerce/stencil-styles": {
@@ -24666,13 +24698,13 @@
       }
     },
     "autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "requires": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -25066,14 +25098,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "bs-recipes": {
@@ -25238,9 +25270,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
+      "version": "1.0.30001543",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz",
+      "integrity": "sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA=="
     },
     "cardinal": {
       "version": "2.1.1",
@@ -25277,8 +25309,7 @@
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -25370,6 +25401,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "chrono-node": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.0.tgz",
+      "integrity": "sha512-0s2vv89LmsbgoibV0AIVgNnGqlU8N5yCCVZXvc3mRCjnmlG/gJw1hCYOmNwjB+AIuwZQdKTXfwvsHDRTs6pwcg==",
+      "requires": {
+        "dayjs": "^1.10.0"
+      }
     },
     "ci-info": {
       "version": "3.5.0",
@@ -26472,27 +26511,16 @@
         }
       }
     },
-    "date.js": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
-      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
-      "requires": {
-        "debug": "~3.1.0"
-      }
-    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
+    "dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -26785,9 +26813,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "version": "1.4.539",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.539.tgz",
+      "integrity": "sha512-wRmWJ8F7rgmINuI32S6r2SLrw/h/bJQsDSvBiq9GBfvc2Lh73qTOwn73r3Cf67mjVgFGJYcYtmERzySa5jIWlg=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -27880,9 +27908,9 @@
       }
     },
     "fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -31706,9 +31734,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node-sass": {
       "version": "8.0.0",
@@ -34144,6 +34172,12 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "requires": {}
+    },
     "postcss-scss": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
@@ -35663,9 +35697,12 @@
       }
     },
     "stringz": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stringz/-/stringz-0.1.2.tgz",
-      "integrity": "sha512-suyTsEDN28681++SG+ysb97glPipDClXNtm/OVy1RtrdT5DMg2PVdA5HAt3obrMKT/MFQF7fqh0p55s6Vc2GRw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
+      "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
+      "requires": {
+        "char-regex": "^1.0.2"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -36223,9 +36260,9 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "4.2.1",
+    "@bigcommerce/stencil-paper": "4.10.4",
     "@bigcommerce/stencil-styles": "5.1.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/glue": "^8.0.0",
@@ -79,6 +79,7 @@
     "object-to-spawn-args": "^2.0.0",
     "parse-json": "^5.2.0",
     "postcss": "^8.4.21",
+    "postcss-safe-parser": "^6.0.0",
     "postcss-scss": "^4.0.6",
     "progress": "^2.0.3",
     "recursive-readdir": "^2.2.2",


### PR DESCRIPTION
#### What?

Some themes have css files presented in other folders rather than ones related to css. So any css files should be excluded from scss validation.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [STRF-11280](https://bigcommercecloud.atlassian.net/browse/STRF-11280)

#### Screenshots (if appropriate)
Before:
<img width="982" alt="Screenshot 2023-10-04 at 15 21 32" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/2e5e1d08-d0e9-46b6-a8c2-2d82ded5063e">
After:
<img width="1086" alt="Screenshot 2023-10-04 at 15 23 36" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/b523d749-9957-4ac4-9f8b-c426acb5b364">


cc @bigcommerce/storefront-team
