### PR TITLE
fix: STRF-11281 Narrow comma separation cases and Improve Base Rules Error

### DIFF
--- a/lib/nodeSass/AutoFixer.js
+++ b/lib/nodeSass/AutoFixer.js
@@ -109,7 +109,7 @@ class AutoFixer {
             }
             if (
                 err.formatted.includes('Invalid CSS after') &&
-                err.formatted.includes('expected selector, was ', '')
+                err.formatted.includes('expected selector, was ",')
             ) {
                 return POSSIBLE_WRONG_COMMA;
             }

--- a/lib/nodeSass/BaseRulesFixer.js
+++ b/lib/nodeSass/BaseRulesFixer.js
@@ -13,18 +13,27 @@ class BaseRulesFixer extends BaseFixer {
     }
 
     transform() {
+        const self = this;
         return {
             postcssPlugin: 'Transform Base Rules Issues into Comments',
             Rule(rule, { Comment }) {
                 if (
                     rule.parent.type === 'root' &&
-                    (rule.selector.startsWith('&--') || rule.selector.startsWith('&.'))
+                    (rule.selector.startsWith('&') ||
+                        rule.selector.startsWith(':not(&)') ||
+                        rule.selector.startsWith('* &'))
                 ) {
-                    const comment = new Comment({ text: rule.toString() });
+                    const comment = new Comment({ text: self.replaceInnerComments(rule) });
                     rule.replaceWith(comment);
                 }
             },
         };
+    }
+
+    // when we replace rule with comment, there might be a case when comment is inside another rule
+    // which breaks the commenting root rule
+    replaceInnerComments(rule) {
+        return rule.toString().replace(/\/\*(.*)\*\//g, '//$1');
     }
 }
 


### PR DESCRIPTION
#### What?

Fixed and improved couple autofix rules:
- Narrowed bad-comma detection mechanism (previously some cases where detected as bad-comma while they weren't)
- fixed issues with comments in base-level rules  containing parent selector &.

#### Tickets / Documentation

-   [STRF-11281](https://bigcommercecloud.atlassian.net/browse/STRF-11281)

#### Screenshots (if appropriate)

1 case
Before:
<img width="1118" alt="Screenshot 2023-10-06 at 15 31 12" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/b6389175-e899-476a-abaa-11e439d02d06">
After:
<img width="1107" alt="Screenshot 2023-10-06 at 17 53 18" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/8455f25a-1c9a-4778-b1f1-7b8c1b9e6e55">

2 case: 
Before:
<img width="1133" alt="Screenshot 2023-10-06 at 20 36 14" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/10a97820-87e4-4ec4-b642-34bdc0192c95">
After:
<img width="1132" alt="Screenshot 2023-10-06 at 20 36 43" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/8b39c3a7-d329-4281-9af4-869673659521">


cc @bigcommerce/storefront-team


[STRF-11281]: https://bigcommercecloud.atlassian.net/browse/STRF-11281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ