### PR TITLE
fix: Properly add stencil-cli headers to internalapi requests

### DIFF
--- a/server/plugins/router/router.module.js
+++ b/server/plugins/router/router.module.js
@@ -20,6 +20,18 @@ const internals = {
     },
 };
 
+function mapUri(req) {
+    const host = `https://${internals.options.storeUrl.replace(/http[s]?:\/\//, '')}`;
+    const urlParams = req.url.search || '';
+    const uri = `${host}${req.path}${urlParams}`;
+    const headers = {
+        'stencil-cli': internals.options.stencilCliVersion,
+        'x-auth-token': internals.options.accessToken,
+    };
+
+    return { uri, headers };
+}
+
 function register(server, options) {
     internals.options = _.defaultsDeep(options, internals.options);
 
@@ -96,10 +108,8 @@ internals.registerRoutes = (server) => {
             path: internals.paths.internalApi,
             handler: {
                 proxy: {
-                    host: internals.options.storeUrl.replace(/http[s]?:\/\//, ''),
+                    mapUri,
                     rejectUnauthorized: false,
-                    protocol: 'https',
-                    port: 443,
                     passThrough: true,
                 },
             },
@@ -114,20 +124,8 @@ internals.registerRoutes = (server) => {
             path: internals.paths.storefrontAPI,
             handler: {
                 proxy: {
+                    mapUri,
                     rejectUnauthorized: false,
-                    mapUri: (req) => {
-                        const host = `https://${internals.options.storeUrl.replace(
-                            /http[s]?:\/\//,
-                            '',
-                        )}`;
-                        const urlParams = req.url.search || '';
-                        const uri = `${host}${req.path}${urlParams}`;
-                        const headers = {
-                            'stencil-cli': internals.options.stencilCliVersion,
-                            'x-auth-token': internals.options.accessToken,
-                        };
-                        return { uri, headers };
-                    },
                     passThrough: true,
                 },
             },


### PR DESCRIPTION
#### What?

Correctly add headers indicating this is a stencil cli request to /internalapi routes. This allows us, among other things, to properly set cookies in the browser from checkout when running on localhost.

#### Screenshots (if appropriate)

Before:
<img width="1218" alt="Screenshot 2024-02-27 at 8 05 14 AM" src="https://github.com/bigcommerce/stencil-cli/assets/1263106/e7b9b50c-f97a-4d75-8104-d1da38d53316">

We can see cookies are incorrectly coming back with `SameSite=None` which isnt allowed here, so the cookies fail to persist in the browser and no login occurs. We can see internally that the incoming request in this case doesnt have the `stencil-cli` header.

After:
<img width="1440" alt="Screenshot 2024-02-27 at 9 07 46 AM" src="https://github.com/bigcommerce/stencil-cli/assets/1263106/b9c4d7e8-5fe2-4735-9053-d0a112efff07">

We can see that due to now propagating the header the cookies correctly have empty `SameSite` attribute and persist to the browser allowing login.


cc @bigcommerce/storefront-team
