### PR TITLE
fix: STRF-11898 fix undefined variable stencil scss autofix

### DIFF
--- a/lib/nodeSass/UndefinedVariableFixer.js
+++ b/lib/nodeSass/UndefinedVariableFixer.js
@@ -13,7 +13,7 @@ class UndefinedVariableFixer extends BaseFixer {
     }
 
     getUndefinedVariableName(errorMessage) {
-        const match = errorMessage.match(/\$([a-zA-Z]{1,})/gi);
+        const match = errorMessage.match(/\$[a-zA-Z_-]+/gi);
         if (!match) {
             throw new Error("Couldn't detemine undefined variable name!");
         }


### PR DESCRIPTION
#### What?

Fix regex to detect undefined variable scss error

#### Tickets / Documentation

-   [STRF-11898](https://bigcommercecloud.atlassian.net/browse/STRF-11898)

#### Screenshots (if appropriate)

<img width="905" alt="Screenshot 2024-04-04 at 13 18 39" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/356f294b-82dc-4b24-97ad-41590b94ca40">


cc @bigcommerce/storefront-team


[STRF-11898]: https://bigcommercecloud.atlassian.net/browse/STRF-11898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ