### PR TITLE
fix: STRF-11856 - Filter list of channels from getStoreChannels() to storefront channels

### DIFF
--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -208,11 +208,23 @@ async function getChannelActiveTheme({ accessToken, apiHost, storeHash, channelI
  */
 async function getStoreChannels({ accessToken, apiHost, storeHash }) {
     try {
-        const response = await networkUtils.sendApiRequest({
+        const sitesResponse = await networkUtils.sendApiRequest({
             url: `${apiHost}/stores/${storeHash}/v3/sites`,
             accessToken,
         });
-        return response.data.data;
+        const channelsResponse = await networkUtils.sendApiRequest({
+            url: `${apiHost}/stores/${storeHash}/v3/channels`,
+            accessToken,
+        });
+
+        const storefrontChannels = channelsResponse.data.data.filter(
+            (channel) => channel.type === 'storefront',
+        );
+
+        return sitesResponse.data.data.filter(
+            (site) =>
+                storefrontChannels.filter((channel) => channel.id === site.channel_id).length > 0,
+        );
     } catch (err) {
         throw new Error(`Could not fetch a list of the store channels: ${err.message}`);
     }


### PR DESCRIPTION
#### What?
Filter the response from `getStoreChannels()` in `theme-api-client.js` by channel type. Only include `storefront` channels.

This change was requested by users of `stencil-cli` who were finding that the list of URLs given when running `stencil start` or `stencil push` included choices that are not valid. Specifically any channel that is not a "storefront" channel is not a valid choice as there is no template  to display, for example on a marketplace channel that connects to facebook there is no storefront to display.

We are going to filter the list of choices we present to be specifically storefront channels. The changes in this PR are utilized by:
`stencil-start.js`
`stencil-push.js`
`stencil-pull.js`
`stencil-download.js`

**Implementation details**
In order to support filtering the channels we needed to add an additional v3 api call (`/v3/channels`).

Previously the `getStoreChannels()` in `theme-api-client.js` was making a call to GET `/v3/sites` and returning this entire list as possible channels. This output looks like:

```
{
            "id": 1000,
            "url": "https://jznewuitest.mybigcommerce.com",
            "channel_id": 1,
            ...
        },
       {
            "id": 1003,
            "url": "https://store-z4zn3wo-1565458.mybigcommerce.com",
            "channel_id": 1565458,
            ...
        }
```

The `url` seen above is what we list when asking for a channel selection but not all of the "sites" seen above are storefront channels. In order to get that information we needed to add a GET to `/v3/channels` which will give back results like:
```
{
            "id": 1,
            "name": "TESttt",
            "platform": "bigcommerce",
            "type": "storefront",
            ...
            "is_listable_from_ui": true,
            "is_enabled": true,
            "is_visible": true,
            "status": "active"
        },
      {
            "id": 1565458,
            "name": "facebookAnalytics-0",
            "platform": "facebook",
            "type": "marketing",
            ...
            "is_listable_from_ui": false,
            "is_enabled": true,
            "is_visible": false,
            "status": "connected"
        }
```

I am filtering the list of sites we receive by the channel ids that have a type of `storefront`. It looks like maybe I could also filter by channels that have `"is_listable_from_ui": true`.

#### Tickets / Documentation
- [JIRA ticket](https://bigcommercecloud.atlassian.net/browse/STRF-11856)

#### Screenshots (if appropriate)
I added a couple `marketplace` channels to my test store. Here is an example of how `stencil start` looks when using current `master`:
<img width="876" alt="Screenshot 2024-04-04 at 10 44 47 AM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/aa4dcaca-0bd6-4db5-8ab7-d5eca0516702">

The last two choices seen above are my `marketplace` channels. With the channels in this PR we will start filtering to only return channels with a type of `storefront`. These are the results with my changes:
<img width="552" alt="Screenshot 2024-04-04 at 11 25 27 AM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/33cb759c-aa29-446c-8566-bf56f1cd3cc0">

All three of the above output URLs are `storefront` channels.

Here is an example of positive results with the `stencil push` command as well:
<img width="1124" alt="Screenshot 2024-04-04 at 2 08 59 PM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/9bc1d054-17bf-41b6-a150-d7ea0d009cce">

`stencil pull`
<img width="874" alt="Screenshot 2024-04-04 at 2 09 48 PM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/05272a24-b993-4f51-9d22-8e9f5e60e8e5">

`stencil download`
<img width="863" alt="Screenshot 2024-04-04 at 2 10 39 PM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/60545d42-ddc6-4563-a5ed-226826d9d13a">

cc @bigcommerce/storefront-team
