### PR TITLE
Refactor getStoreChannels function

### DIFF
--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -208,22 +208,20 @@ async function getChannelActiveTheme({ accessToken, apiHost, storeHash, channelI
  */
 async function getStoreChannels({ accessToken, apiHost, storeHash }) {
     try {
-        const sitesResponse = await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/sites`,
-            accessToken,
-        });
-        const channelsResponse = await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/channels`,
-            accessToken,
-        });
-
-        const storefrontChannels = channelsResponse.data.data.filter(
-            (channel) => channel.type === 'storefront',
-        );
+        const [sitesResponse, channelsResponse] = await Promise.all([
+            networkUtils.sendApiRequest({
+                url: `${apiHost}/stores/${storeHash}/v3/sites`,
+                accessToken,
+            }),
+            networkUtils.sendApiRequest({
+                url: `${apiHost}/stores/${storeHash}/v3/channels?type:in=storefront`,
+                accessToken,
+            }),
+        ]);
 
         return sitesResponse.data.data.filter(
             (site) =>
-                storefrontChannels.filter((channel) => channel.id === site.channel_id).length > 0,
+                channelsResponse.data.data.filter((channel) => channel.id === site.channel_id).length > 0,
         );
     } catch (err) {
         throw new Error(`Could not fetch a list of the store channels: ${err.message}`);


### PR DESCRIPTION
#### What?
Within `getStoreChannels` we fetch store channels, then filter them to access only storefront type channels. 
This can be made within the request, reducing the complexity of the codebase, as well as putting the processing on the server side.

#### Tickets / Documentation
N/A

#### Screenshots (if appropriate)
N/A

cc @bigcommerce/storefront-team
