### PR TITLE
fix: STRF-11741 Provide stencil init options to set up package manager and skip packages install

### DIFF
--- a/bin/stencil-init.js
+++ b/bin/stencil-init.js
@@ -11,7 +11,9 @@ program
     .option('-u, --url [url]', 'Store URL')
     .option('-t, --token [token]', 'Access Token')
     .option('-p, --port [port]', 'Port')
-    .option('-h, --apiHost [host]', 'API Host');
+    .option('-h, --apiHost [host]', 'API Host')
+    .option('-pm, --packageManager [pm]', 'Package manager')
+    .option('-skip, --skipInstall', 'Skip packages installation');
 
 const cliOptions = prepareCommand(program);
 
@@ -21,5 +23,7 @@ new StencilInit()
         accessToken: cliOptions.token,
         port: cliOptions.port,
         apiHost: cliOptions.apiHost,
+        packageManager: cliOptions.packageManager,
+        skipInstall: cliOptions.skipInstall,
     })
     .catch(printCliResultErrorAndExit);

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -47,7 +47,7 @@ class StencilInit {
         const answers = await this.askQuestions(questions);
         const updatedStencilConfig = this.applyAnswers(oldStencilConfig, answers, cliOptions);
         await this._stencilConfigManager.save(updatedStencilConfig);
-        await this.installDependencies(THEME_PATH, answers.packageManager);
+        await this.installDependencies(THEME_PATH, answers.packageManager, cliOptions);
 
         this._logger.log(
             'You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan,
@@ -195,9 +195,13 @@ class StencilInit {
      *
      * @param {string} projectDir
      * @param {object} packageManager
+     * @param {object} cliOptions
      * @returns
      */
-    installDependencies(projectDir, packageManager) {
+    installDependencies(projectDir, packageManager, cliOptions) {
+        if (cliOptions.skipInstall) {
+            return Promise.resolve();
+        }
         return this._spinner(
             this._nypm.installDependencies({
                 cwd: projectDir,


### PR DESCRIPTION
#### What?

Add -pm and -skip options for stencil init to have disruptive experience in pipelines


#### Screenshots (if appropriate)
<img width="1314" alt="Screenshot 2024-04-10 at 12 35 55" src="https://github.com/bigcommerce/stencil-cli/assets/68893868/f9f9b817-b3d2-43d8-a370-c028ba6316fe">


cc @bigcommerce/storefront-team
