### PR TITLE
fix: STRF-11923 - Handle Missing a New Channels Permission Requirement in Auth Token

### DIFF
--- a/lib/theme-api-client.js
+++ b/lib/theme-api-client.js
@@ -212,19 +212,28 @@ async function getStoreChannels({ accessToken, apiHost, storeHash }) {
             url: `${apiHost}/stores/${storeHash}/v3/sites`,
             accessToken,
         });
-        const channelsResponse = await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/channels`,
-            accessToken,
-        });
+        const channelsResponse = await networkUtils
+            .sendApiRequest({
+                url: `${apiHost}/stores/${storeHash}/v3/channels?type:in=storefront`,
+                accessToken,
+            })
+            .catch((error) => {
+                if (error.response.status === 403) {
+                    console.log(
+                        'WARNING: Version 7.4.2+ of stencil-cli added a request to the Channels resource which requires a permission missing on your current stencil cli auth token. Please generate a new auth token at your convenience which includes the "read-only channels" permission to clear up this warning. You can read more about correcting this issue here: https://github.com/bigcommerce/stencil-cli/issues/1185',
+                    );
+                }
+            });
 
-        const storefrontChannels = channelsResponse.data.data.filter(
-            (channel) => channel.type === 'storefront',
-        );
+        if (channelsResponse) {
+            return sitesResponse.data.data.filter(
+                (site) =>
+                    channelsResponse.data.data.filter((channel) => channel.id === site.channel_id)
+                        .length > 0,
+            );
+        }
 
-        return sitesResponse.data.data.filter(
-            (site) =>
-                storefrontChannels.filter((channel) => channel.id === site.channel_id).length > 0,
-        );
+        return sitesResponse.data.data;
     } catch (err) {
         throw new Error(`Could not fetch a list of the store channels: ${err.message}`);
     }


### PR DESCRIPTION
#### What?
This PR handles the possibility of missing the `Channels` auth permission when making a GET for a list of channels in `getStoreChannels()`. 

When [this update](https://github.com/bigcommerce/stencil-cli/pull/1180) was made I overlooked that the standard Stencil CLI auth token that we recommend providing to 3rd parties does not include the "read channel settings" permission by default. So people utilizing the Stencil CLI token, or any v3 token that does not include "read/manage channel settings" permission, can end up with this error when making `start`, `push`, `pull`, or `download` commands:
<img width="949" alt="Screenshot 2024-04-10 at 7 14 28 AM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/4e76d7fa-2515-4cb4-9059-79bae33d5f2a">

We will be updating that permission on the Stencil CLI token but people with errors will still have to generate a new token to get this permission. As such, this PR will avoid failures if the `Channels` permission is missing. Instead we will ignore the error and return an unfiltered list of urls the same way we did prior to the change in version 4.7.2.

**Refactor**
Also incorporates some smart improvements to the fetching of channels that I found in this PR:
https://github.com/bigcommerce/stencil-cli/pull/1187

#### Tickets / Documentation
[Previous related pr.](https://github.com/bigcommerce/stencil-cli/pull/1180) 

#### Screenshots (if appropriate)
With this changes in this PR we will now give a "warning" message if the "channels" permission is missing and still proceed with an unfiltered response as we did before:
<img width="1728" alt="Screenshot 2024-04-10 at 7 17 32 AM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/d293348a-8627-4109-858a-151d7a5f494a">

However, if you do have an updated token that includes the correct permission then we will filter the list of channels returned using this new information:
<img width="905" alt="Screenshot 2024-04-10 at 7 19 12 AM" src="https://github.com/bigcommerce/stencil-cli/assets/6527334/9a249383-27c5-48a8-9642-b3c7866ace80">

cc @bigcommerce/storefront-team
