### PR TITLE
fix: STRF-11899 Update cart when multiple coupons are removed

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -112,7 +112,7 @@ internals.getResponse = async (request) => {
             responseArgs,
         );
     }
-    if (request.method !== 'get') {
+    if (request.method !== 'get' || request.path === '/cart.php') {
         // clear when making a non-get request because smth may be changed
         cache.clear();
     }


### PR DESCRIPTION
#### What?
When removing multiple coupons, bust the cache because the cart has updated. If we don't the request signature just above this point - https://github.com/bigcommerce/stencil-cli/blob/879019066324c719b623eaf02eb76c26882bec3e/server/plugins/renderer/renderer.module.js#L194 - in the code will be the same as the last and we erroneously return 'cachedResponse2' which is stale.

The request to update the cart is different because it contains the coupon ID, but since it uses  a redirect back to the cart, that request is undifferentiated from the previous request to the cart.php

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   [STRF-11899](https://bigcommercecloud.atlassian.net/browse/STRF-11899)

#### Screenshots (if appropriate)

Before: First coupon removal works as expected, but subsequent removals don't appear to take effect until refresh. 

https://github.com/bigcommerce/stencil-cli/assets/5630999/0c0c1041-6b4f-4e5b-8a5f-91cc2bb9c7ab

After: additional coupons removed as expected

https://github.com/bigcommerce/stencil-cli/assets/5630999/f6af7f05-9354-4346-affa-59064e16ce42

cc @bigcommerce/storefront-team


[STRF-11899]: https://bigcommercecloud.atlassian.net/browse/STRF-11899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ