### PR TITLE
fix: STRF-11934 Separate Github PR Title check 

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Tests
 
 on:
@@ -20,24 +17,16 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Use Node.js ${{ matrix.node }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node }}
+                  cache: 'npm'
 
             - name: Install Dependencies
               run: npm ci
-
-            - name: Verify Github PR Title TEST
-              run: echo '${{ env.TITLE }}'
-
-            - name: Verify Github PR Title
-              run: echo '${{ env.TITLE }}' | npx commitlint
-
-            - name: Verify Git Commit Name
-              run: git log -1 --pretty=format:"%s" |  npx commitlint
 
             - name: Lint the code
               run: npm run lint

--- a/.github/workflows/pull_request_title_check.yml
+++ b/.github/workflows/pull_request_title_check.yml
@@ -1,0 +1,26 @@
+name: Pull Request Title Check
+
+on:
+    pull_request:
+        branches: [master, main]
+
+jobs:
+    check-pr-title:
+        env:
+            TITLE: ${{ github.event.pull_request.title }}
+
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '18.x'
+                  cache: 'npm'
+            - name: Install Dependencies
+              run: npm ci
+
+            - name: Verify Github PR Title
+              run: echo $TITLE | npx commitlint
+
+            - name: Verify Git Commit Name
+              run: git log -1 --pretty=format:"%s" |  npx commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '18.x'
             - run: npm i

--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Log in to the Container registry
               uses: docker/login-action@v2


### PR DESCRIPTION
#### What?

Improve workflow by moving Github PR Title check into separate CI job

#### Tickets / Documentation


-   [STRF-11934](https://bigcommercecloud.atlassian.net/browse/STRF-11934)


cc @bigcommerce/storefront-team


[STRF-11934]: https://bigcommercecloud.atlassian.net/browse/STRF-11934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ