### PR TITLE
feat: STRF-12315 Bump stencil-paper version; BREAKING CHANGE: Drop Node 16 Support

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -8,14 +8,21 @@ jobs:
     build:
         strategy:
             matrix:
-                node: [16.x, 18.x]
+                node: [18.x, 20.x, 22.x]
                 os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
+                exclude:
+                    - os: windows-2019
+                      node: 22.x
         env:
             TITLE: ${{ github.event.pull_request.title }}
 
         runs-on: ${{ matrix.os }}
 
         steps:
+            - name: Install python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.10'
             - name: Checkout code
               uses: actions/checkout@v4
 
@@ -23,7 +30,6 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node }}
-                  cache: 'npm'
 
             - name: Install Dependencies
               run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "7.4.0",
+  "version": "7.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "7.4.0",
+      "version": "7.5.4",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "4.10.4",
+        "@bigcommerce/stencil-paper": "4.13.2",
         "@bigcommerce/stencil-styles": "5.3.3",
         "@hapi/boom": "^10.0.0",
         "@hapi/glue": "^8.0.0",
@@ -740,19 +740,19 @@
       }
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.10.4.tgz",
-      "integrity": "sha512-xMr+fDyu4Dne8Qf8bqPT/EDa6HKjtSQ3AU8msW9SpMH9DkoLF1oEzevzVi4cjHIBwc0RpbfgnH6BZtm10ghFzQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.13.2.tgz",
+      "integrity": "sha512-hGKRwoGarmO0FxI/RrOyg8HWPSZWQYNNAD8seY9QG1LZvwFMSCm+B7z2ruGpZBtukxUBFaDADlKx0ghTzSn3rA==",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "5.9.5",
+        "@bigcommerce/stencil-paper-handlebars": "^5.11.2",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.9.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.9.5.tgz",
-      "integrity": "sha512-Pf+5Ai4Yy0C74Zoo1Z/8RiaBEjKTXRjrVfg4lNfBnRKTO6dBO20MElQVy96aAZugLuTKLa5bFwLk0p/T5K4LVw==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.11.2.tgz",
+      "integrity": "sha512-jCWRIuMJ2WGeZZJjjSlhEiU3c/QJt+Ups36NgGchfxh1T/sPFi4hABxT27vBNa2V13nuI1+uwjMYh6sPxLxeGg==",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.8",
         "chrono-node": "^2.6.5",
@@ -5007,9 +5007,9 @@
       }
     },
     "node_modules/chrono-node": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.0.tgz",
-      "integrity": "sha512-0s2vv89LmsbgoibV0AIVgNnGqlU8N5yCCVZXvc3mRCjnmlG/gJw1hCYOmNwjB+AIuwZQdKTXfwvsHDRTs6pwcg==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.6.tgz",
+      "integrity": "sha512-yugKSRLHc6B6kXxm/DwNc94zhaddAjCSO9IOGH3w7NIWNM+gUoLl/2/XLndiw4I+XhU4H2LOhC5Ab2JjS6JWsA==",
       "dependencies": {
         "dayjs": "^1.10.0"
       },
@@ -6481,9 +6481,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -11981,9 +11981,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
@@ -19548,19 +19548,19 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.10.4.tgz",
-      "integrity": "sha512-xMr+fDyu4Dne8Qf8bqPT/EDa6HKjtSQ3AU8msW9SpMH9DkoLF1oEzevzVi4cjHIBwc0RpbfgnH6BZtm10ghFzQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-4.13.2.tgz",
+      "integrity": "sha512-hGKRwoGarmO0FxI/RrOyg8HWPSZWQYNNAD8seY9QG1LZvwFMSCm+B7z2ruGpZBtukxUBFaDADlKx0ghTzSn3rA==",
       "requires": {
-        "@bigcommerce/stencil-paper-handlebars": "5.9.5",
+        "@bigcommerce/stencil-paper-handlebars": "^5.11.2",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.2.2"
       }
     },
     "@bigcommerce/stencil-paper-handlebars": {
-      "version": "5.9.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.9.5.tgz",
-      "integrity": "sha512-Pf+5Ai4Yy0C74Zoo1Z/8RiaBEjKTXRjrVfg4lNfBnRKTO6dBO20MElQVy96aAZugLuTKLa5bFwLk0p/T5K4LVw==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-5.11.2.tgz",
+      "integrity": "sha512-jCWRIuMJ2WGeZZJjjSlhEiU3c/QJt+Ups36NgGchfxh1T/sPFi4hABxT27vBNa2V13nuI1+uwjMYh6sPxLxeGg==",
       "requires": {
         "@bigcommerce/handlebars-v4": "4.7.8",
         "chrono-node": "^2.6.5",
@@ -23000,9 +23000,9 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chrono-node": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.0.tgz",
-      "integrity": "sha512-0s2vv89LmsbgoibV0AIVgNnGqlU8N5yCCVZXvc3mRCjnmlG/gJw1hCYOmNwjB+AIuwZQdKTXfwvsHDRTs6pwcg==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.6.tgz",
+      "integrity": "sha512-yugKSRLHc6B6kXxm/DwNc94zhaddAjCSO9IOGH3w7NIWNM+gUoLl/2/XLndiw4I+XhU4H2LOhC5Ab2JjS6JWsA==",
       "requires": {
         "dayjs": "^1.10.0"
       }
@@ -24147,9 +24147,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -28258,9 +28258,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CLI tool to run BigCommerce Stores locally for theme development.",
   "main": "index.js",
   "engines": {
-    "node": ">=16.0.0 <19.0.0",
+    "node": ">=18",
     "npm": ">=8.0.0"
   },
   "scripts": {
@@ -48,7 +48,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "4.10.4",
+    "@bigcommerce/stencil-paper": "4.13.2",
     "@bigcommerce/stencil-styles": "5.3.3",
     "@hapi/boom": "^10.0.0",
     "@hapi/glue": "^8.0.0",


### PR DESCRIPTION
#### What?

- Bump stencil paper version
- Drop Node 16 Support
- Add Node 20

#### Tickets / Documentation

-   [STRF-12315](https://bigcommercecloud.atlassian.net/browse/STRF-12315)

#### Screenshots (if appropriate)

<img width="1409" alt="Screenshot 2024-07-31 at 13 38 45" src="https://github.com/user-attachments/assets/2df8015d-07ba-4b53-ad49-206aa499aa83">


cc @bigcommerce/storefront-team


[STRF-12315]: https://bigcommercecloud.atlassian.net/browse/STRF-12315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ