### PR TITLE
Show channel IDs in channel prompt when starting dev server

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -442,7 +442,7 @@ utils.promptUserToSelectChannel = async (channels) => {
             name: 'channelId',
             message: 'Which channel would you like to use?',
             choices: channels.map((channel) => ({
-                name: channel.url,
+                name: `${channel.url} [${channel.channel_id}] `,
                 value: channel.channel_id,
             })),
         },


### PR DESCRIPTION
#### What?

This simply shows the channel ID in the list of available channels when starting the server. Some themes may use the channel ID, so this smooths the experience of selecting the right channel.


#### Tickets / Documentation

None.


#### Screenshots (if appropriate)

![Screenshot 2024-08-28 at 5 42 26 PM](https://github.com/user-attachments/assets/31aa5c13-87d7-4954-bb58-939d29a682b6)


cc @bigcommerce/storefront-team