### PR TITLE
feat: Add source maps option to bundle and push process

### DIFF
--- a/bin/stencil-bundle.js
+++ b/bin/stencil-bundle.js
@@ -14,6 +14,10 @@ program
         'Where to save the zip file. It defaults to the current directory you are in when bundling',
     )
     .option(
+        '-S, --source-maps',
+        'Include source-maps in the bundle. This is useful for debugging',
+    ) 
+    .option(
         '-n, --name  [filename]',
         'What do you want to call the zip file. It defaults to stencil-bundle.zip',
     )

--- a/bin/stencil-bundle.js
+++ b/bin/stencil-bundle.js
@@ -13,10 +13,7 @@ program
         '-d, --dest [dest]',
         'Where to save the zip file. It defaults to the current directory you are in when bundling',
     )
-    .option(
-        '-S, --source-maps',
-        'Include source-maps in the bundle. This is useful for debugging',
-    )
+    .option('-S, --source-maps', 'Include source-maps in the bundle. This is useful for debugging')
     .option(
         '-n, --name  [filename]',
         'What do you want to call the zip file. It defaults to stencil-bundle.zip',

--- a/bin/stencil-bundle.js
+++ b/bin/stencil-bundle.js
@@ -16,7 +16,7 @@ program
     .option(
         '-S, --source-maps',
         'Include source-maps in the bundle. This is useful for debugging',
-    ) 
+    )
     .option(
         '-n, --name  [filename]',
         'What do you want to call the zip file. It defaults to stencil-bundle.zip',

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -18,7 +18,7 @@ program
     .option(
         '-S, --source-maps',
         'Include source-maps in the bundle. This is useful for debugging',
-    )     
+    )
     .option(
         '-a, --activate [variationname]',
         'specify the variation of the theme to activate'

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -7,19 +7,34 @@ import { prepareCommand, printCliResultErrorAndExit } from '../lib/cliCommon.js'
 
 program
     .version(PACKAGE_INFO.version)
-    .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
-    .option('-s, --save [filename]', 'specify the filename to save the bundle as')
+    .option(
+        '-f, --file [filename]',
+        'specify the filename of the bundle to upload'
+    )
+    .option(
+        '-s, --save [filename]',
+        'specify the filename to save the bundle as'
+    )
     .option(
         '-S, --source-maps',
         'Include source-maps in the bundle. This is useful for debugging',
     )     
-    .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
-    .option('-d, --delete', 'delete oldest private theme if upload limit reached')
+    .option(
+        '-a, --activate [variationname]',
+        'specify the variation of the theme to activate'
+    )
+    .option(
+        '-d, --delete',
+        'delete oldest private theme if upload limit reached'
+    )
     .option(
         '-c, --channel_ids <channelIds...>',
         'specify the channel IDs of the storefront to push the theme to',
     )
-    .option('-allc, --all_channels', 'push a theme to all available channels');
+    .option(
+        '-allc, --all_channels',
+        'push a theme to all available channels'
+    );
 const cliOptions = prepareCommand(program);
 const options = {
     apiHost: cliOptions.host,

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -9,6 +9,10 @@ program
     .version(PACKAGE_INFO.version)
     .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
     .option('-s, --save [filename]', 'specify the filename to save the bundle as')
+    .option(
+        '-S, --source-maps',
+        'Include source-maps in the bundle. This is useful for debugging',
+    )     
     .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
     .option('-d, --delete', 'delete oldest private theme if upload limit reached')
     .option(
@@ -25,6 +29,7 @@ const options = {
     saveBundleName: cliOptions.save,
     deleteOldest: cliOptions.delete,
     allChannels: cliOptions.all_channels,
+    sourceMaps: cliOptions.source_maps,
 };
 stencilPush(options, (err, result) => {
     if (err) {

--- a/bin/stencil-push.js
+++ b/bin/stencil-push.js
@@ -7,34 +7,16 @@ import { prepareCommand, printCliResultErrorAndExit } from '../lib/cliCommon.js'
 
 program
     .version(PACKAGE_INFO.version)
-    .option(
-        '-f, --file [filename]',
-        'specify the filename of the bundle to upload'
-    )
-    .option(
-        '-s, --save [filename]',
-        'specify the filename to save the bundle as'
-    )
-    .option(
-        '-S, --source-maps',
-        'Include source-maps in the bundle. This is useful for debugging',
-    )
-    .option(
-        '-a, --activate [variationname]',
-        'specify the variation of the theme to activate'
-    )
-    .option(
-        '-d, --delete',
-        'delete oldest private theme if upload limit reached'
-    )
+    .option('-f, --file [filename]', 'specify the filename of the bundle to upload')
+    .option('-s, --save [filename]', 'specify the filename to save the bundle as')
+    .option('-S, --source-maps', 'Include source-maps in the bundle. This is useful for debugging')
+    .option('-a, --activate [variationname]', 'specify the variation of the theme to activate')
+    .option('-d, --delete', 'delete oldest private theme if upload limit reached')
     .option(
         '-c, --channel_ids <channelIds...>',
         'specify the channel IDs of the storefront to push the theme to',
     )
-    .option(
-        '-allc, --all_channels',
-        'push a theme to all available channels'
-    );
+    .option('-allc, --all_channels', 'push a theme to all available channels');
 const cliOptions = prepareCommand(program);
 const options = {
     apiHost: cliOptions.host,

--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -387,9 +387,9 @@ class Bundle {
      */
     _bundleThemeFiles(archive, themePath) {
         for (const { pattern, ignore } of PATHS_TO_ZIP) {
-            if (pattern === "assets/**/*" && !this.options.sourceMaps) {
-                ignore.push("assets/**/*.js.map");
-            }            
+            if (pattern === 'assets/**/*' && !this.options.sourceMaps) {
+                ignore.push('assets/**/*.js.map');
+            }
             archive.glob(pattern, { ignore, cwd: themePath });
         }
     }

--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -18,7 +18,7 @@ const MAX_SIZE_BUNDLE = MEGABYTE * 50;
 const PATHS_TO_ZIP = [
     {
         pattern: 'assets/**/*',
-        ignore: ['assets/cdn/**', 'assets/**/*.js.map'],
+        ignore: ['assets/cdn/**'],
     },
     { pattern: 'CHANGELOG.md' },
     { pattern: 'config.json' },
@@ -387,6 +387,9 @@ class Bundle {
      */
     _bundleThemeFiles(archive, themePath) {
         for (const { pattern, ignore } of PATHS_TO_ZIP) {
+            if (pattern === "assets/**/*" && !this.options.sourceMaps) {
+                ignore.push("assets/**/*.js.map");
+            }            
             archive.glob(pattern, { ignore, cwd: themePath });
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "5.0.0",


### PR DESCRIPTION
## What?

Adds -S and --source-maps options to stencil-bundle and stencil-push to allow for the inclusion of source-maps in the theme.

This helps with debugging by providing a mapping between the minified code and the original source.

Tools like Noibu may benefit from source maps as debug messages will not be obfuscated: https://help.noibu.com/hc/en-us/articles/7770357274637-Source-Maps-Overview

## Screenshots
<img width="834" alt="Screenshot 2024-12-12 at 09 10 01" src="https://github.com/user-attachments/assets/a41c0255-7c15-4063-8c99-d3cc2ec92d28" />


cc @bigcommerce/team-storefront 