### PR TITLE
fix: STRF-11523 Enable dynamic partials

### DIFF
--- a/lib/template-assembler.js
+++ b/lib/template-assembler.js
@@ -4,7 +4,7 @@ import fs from 'graceful-fs';
 import path from 'path';
 import upath from 'upath';
 
-const partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9@'"/]+)[^{]*?}}/g;
+const partialRegex = /\{\{#?>\s*([_|\-|a-zA-Z0-9@'"/]+)[^{]*?}}/g;
 const partialWithoutBracketsRegex = /[^>{{}}\s*]+/g;
 const dynamicComponentRegex = /\{\{\s*?dynamicComponent\s*(?:'|")([_|\-|a-zA-Z0-9/]+)(?:'|").*?}}/g;
 const includeRegex = /{{2}>\s*([_|\-|a-zA-Z0-9/]+)[^{]*?}{2}/g;

--- a/test/_mocks/themes/valid/templates/pages/page3.html
+++ b/test/_mocks/themes/valid/templates/pages/page3.html
@@ -7,6 +7,5 @@
 <body>
     <h1>{{theme_settings.customizable_title}}</h1>
     {{> components/c }}
-    {{footer.scripts}}
 </body>
 </html>


### PR DESCRIPTION
#### What?

Fixed regex that allows to add partials with syntax `{{#> components/ul }}`

#### Tickets / Documentation

-   [STRF-11523](https://bigcommercecloud.atlassian.net/browse/STRF-11523)

#### Screenshots (if appropriate)
<img width="300" alt="Screenshot 2024-12-16 at 18 42 21" src="https://github.com/user-attachments/assets/2c77b59c-9f9b-4188-a709-f79c007ecb92" />
<img width="310" alt="Screenshot 2024-12-16 at 18 42 24" src="https://github.com/user-attachments/assets/85661805-b6ad-44ad-9acc-e7ff56e985a2" />

#### QA Steps:
1) Get ready to run stencil start (load theme locally, stencil init, etc.)
2) Run **stencil start**
3) Create a similiar structure of components like [here](https://github.com/bigcommerce/stencil-cli/blob/master/test/_mocks/themes/valid/templates/components/c.html,  [here](https://github.com/bigcommerce/stencil-cli/blob/master/test/_mocks/themes/valid/templates/pages/page.3.html), [here](https://github.com/bigcommerce/stencil-cli/blob/master/test/_mocks/themes/valid/templates/components/li.html) and [here](https://github.com/bigcommerce/stencil-cli/blob/master/test/_mocks/themes/valid/templates/components/ul.html)
4) Observe that list successfully rendered in the browser

cc @bigcommerce/storefront-team


[STRF-11523]: https://bigcommercecloud.atlassian.net/browse/STRF-11523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ