### PR TITLE
feat: Add port option to stencil start

### DIFF
--- a/bin/stencil-start.js
+++ b/bin/stencil-start.js
@@ -19,7 +19,9 @@ program
         '-n, --no-cache',
         'Turns off caching for API resource data per storefront page. The cache lasts for 5 minutes before automatically refreshing.',
     )
-    .option('-t, --timeout', 'Set a timeout for the bundle operation. Default is 20 secs', '60');
+    .option('-t, --timeout', 'Set a timeout for the bundle operation. Default is 20 secs', '60')
+    .option('-p --port [portnumber]', 'Set port number to listen dev server');
+
 const cliOptions = prepareCommand(program);
 const options = {
     open: cliOptions.open,
@@ -28,6 +30,7 @@ const options = {
     apiHost: cliOptions.host,
     tunnel: cliOptions.tunnel,
     cache: cliOptions.cache,
+    port: cliOptions.port,
 };
 const timeout = cliOptions.timeout * 1000; // seconds
 const buildConfigManager = new BuildConfigManager({ timeout });

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -55,7 +55,14 @@ class StencilStart {
         if (cliOptions.variation) {
             await this._themeConfigManager.setVariationByName(cliOptions.variation);
         }
+
         const initialStencilConfig = await this._stencilConfigManager.read();
+
+        // Override Port Number if Cli option Exsist
+        if (cliOptions.port) {
+            initialStencilConfig.port = cliOptions.port;
+        }
+
         // Use initial (before updates) port for BrowserSync
         const browserSyncPort = initialStencilConfig.port;
         const channelUrl = await this.getChannelUrl(initialStencilConfig, cliOptions);


### PR DESCRIPTION
#### What?

Adds port option to stencil start. 

#### Why?


Our company manages multiple dev servers that each run on a unique port using config.stencil.port. It has become challenging to work efficiently on localhost as we need to track different ports. This way, when closing a tab or browser, we won't have to copy the URL or restart the dev server with stencil start -o again.

cc @bigcommerce/storefront-team
