### PR TITLE
fix: STRF-12941 Fix stencil release in case of having .git extension in the remote name

### DIFF
--- a/lib/release/release.js
+++ b/lib/release/release.js
@@ -57,7 +57,7 @@ class StencilRelease {
                 name: remote.name,
                 url,
                 owner: match ? match[1] : null,
-                repo: match ? match[2] : null,
+                repo: match ? match[2].replace('.git', '') : null,
             };
         });
         const dirty =


### PR DESCRIPTION
#### What?

Removing .git extension in the git remote name, so github release API can handle it succesfully 

#### Tickets / Documentation

-   [STRF-12941](https://bigcommercecloud.atlassian.net/browse/STRF-12941)

#### Screenshots (if appropriate)
Before:
<img width="1057" alt="Screenshot 2025-01-09 at 13 48 40" src="https://github.com/user-attachments/assets/df54ec52-a122-4cfc-966d-959bba2395b9" />

After:
<img width="842" alt="Screenshot 2025-01-09 at 13 48 20" src="https://github.com/user-attachments/assets/b72d088a-851d-4213-a294-210c57e0a08f" />


cc @bigcommerce/storefront-team


[STRF-12941]: https://bigcommercecloud.atlassian.net/browse/STRF-12941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ