### PR TITLE
feat: STRF-12941 Add channelUrl parameter to stencil start

### DIFF
--- a/bin/stencil-start.js
+++ b/bin/stencil-start.js
@@ -19,7 +19,11 @@ program
         '-n, --no-cache',
         'Turns off caching for API resource data per storefront page. The cache lasts for 5 minutes before automatically refreshing.',
     )
-    .option('-t, --timeout', 'Set a timeout for the bundle operation. Default is 20 secs', '60');
+    .option('-t, --timeout', 'Set a timeout for the bundle operation. Default is 20 secs', '60')
+    .option(
+        '-cu, --channelUrl [channelUrl]',
+        'Set a custom domain url to bypass dns/proxy protection',
+    );
 const cliOptions = prepareCommand(program);
 const options = {
     open: cliOptions.open,
@@ -28,6 +32,7 @@ const options = {
     apiHost: cliOptions.host,
     tunnel: cliOptions.tunnel,
     cache: cliOptions.cache,
+    channelUrl: cliOptions.channelUrl,
 };
 const timeout = cliOptions.timeout * 1000; // seconds
 const buildConfigManager = new BuildConfigManager({ timeout });

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -91,6 +91,9 @@ class StencilStart {
         this.storeHash = await this._themeApiClient.getStoreHash({
             storeUrl: stencilConfig.normalStoreUrl,
         });
+        if (cliOptions.channelUrl) {
+            return cliOptions.channelUrl;
+        }
         const channels = await this._themeApiClient.getStoreChannels({
             storeHash: this.storeHash,
             accessToken,

--- a/lib/stencil-start.spec.js
+++ b/lib/stencil-start.spec.js
@@ -134,5 +134,21 @@ describe('StencilStart unit tests', () => {
             const result = await instance.getChannelUrl({ accessToken }, { apiHost });
             expect(result).toEqual(storeUrl);
         });
+
+        it('should obtain channel url from the CLI', async () => {
+            const channelUrl = 'https://shop.bigcommerce.com';
+            const channels = [{ channel_id: channelId, url: storeUrl }];
+            const themeApiClientStub = {
+                checkCliVersion: jest.fn(),
+                getStoreHash: jest.fn().mockResolvedValue(storeHash),
+                getStoreChannels: jest.fn().mockResolvedValue(channels),
+            };
+            const { instance } = createStencilStartInstance({
+                themeApiClient: themeApiClientStub,
+                stencilPushUtils: stencilPushUtilsModule,
+            });
+            const result = await instance.getChannelUrl({ accessToken }, { apiHost, channelUrl });
+            expect(result).toEqual(channelUrl);
+        });
     });
 });


### PR DESCRIPTION
#### What?

Some users have a proxy or dns settings on the custom domain that block requests from stencil cli. By using --channelUrl you can directly set up bigcommerce domain to bypass custom domain protections

#### Tickets / Documentation

-   [STRF-12622](https://bigcommercecloud.atlassian.net/browse/STRF-12622)

#### Screenshots (if appropriate)

<img width="1030" alt="Screenshot 2025-01-16 at 16 51 21" src="https://github.com/user-attachments/assets/99ff24ea-3907-4872-84da-7f3f12f3389b" />


cc @bigcommerce/storefront-team


[STRF-12622]: https://bigcommercecloud.atlassian.net/browse/STRF-12622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ