### PR TITLE
fix: Add new stencil config file to zip bundle

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -31,6 +31,7 @@ const PATHS_TO_ZIP = [
     { pattern: 'package.json' },
     { pattern: 'README.md' },
     { pattern: '.scss-lint.yml' },
+    { pattern: 'stencil.conf.cjs' },
     { pattern: 'stencil.conf.js' },
     { pattern: 'templates/**/*' },
     { pattern: 'webpack.*.js' },


### PR DESCRIPTION
#### What?

Stencil Bundle does not zip new stencil.conf.cjs file https://github.com/bigcommerce/cornerstone/blob/master/stencil.conf.cjs

#### Screenshots (if appropriate)
<img width="254" alt="Screenshot 2025-04-10 at 15 33 42" src="https://github.com/user-attachments/assets/41dd4cca-68b4-4c1b-a116-413ae2b87cb9" />


![Example Image](http://placehold.it/300x200)

cc @bigcommerce/storefront-team
