### PR TITLE
fix: bump paper to 5.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "5.0.0",
+        "@bigcommerce/stencil-paper": "5.1.4",
         "@bigcommerce/stencil-styles": "^6.1.1",
         "@hapi/boom": "^10.0.0",
         "@hapi/glue": "^9.0.1",
@@ -797,20 +797,39 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.0.0.tgz",
-      "integrity": "sha512-x7Y8i1zBHKc2AsHjilrN3ByrDUzuhb9gDQWkdeUaPWj19i0fQ+4fugdnJOr1U7cOw9bIdVmYP05jfO23Edkd1Q==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.1.4.tgz",
+      "integrity": "sha512-AJuDFioKOAPiFg+nJ1t489FkfivKq5M69AVfad9mQuPVjCcjUEeG1MHwDnKyIEWCJ0/PscAexjLjGmIbFz/piw==",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "6.0.0",
+        "@bigcommerce/stencil-paper-handlebars": "6.2.4",
+        "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
         "accept-language-parser": "~1.4.1",
-        "messageformat": "~0.2.2"
+        "messageformat": "~0.3.1"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.0.0.tgz",
-      "integrity": "sha512-XIglekQh016fhanI5D55lvVdsQNGquoFRjDGkfZeMqro2/VFjg09n/dBrrEWtpjAz1q7eIyLgTvaT6JhB41eLQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.2.4.tgz",
+      "integrity": "sha512-ivPdeEyJuMY0r6WD0fJFbmCuF42uQ+kUPfH2qUaMfsKZkeFyxQThBxYnAMnQ6FWDG6SE161tzGNIP/KwdDBahg==",
+      "license": "BSD-4-Clause",
+      "dependencies": {
+        "@bigcommerce/handlebars-v4": "4.7.8",
+        "chrono-node": "^2.6.5",
+        "handlebars": "3.0.8",
+        "he": "^1.2.0",
+        "moment": "^2.29.4",
+        "remarkable": "^2.0.1",
+        "stringz": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bigcommerce/stencil-paper-handlebars-v2": {
+      "name": "@bigcommerce/stencil-paper-handlebars",
+      "version": "6.2.4",
+      "resolved": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#04830459f9468f2f05ca89dbbac2208a80355d91",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.8",
@@ -5047,9 +5066,9 @@
       }
     },
     "node_modules/chrono-node": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.6.tgz",
-      "integrity": "sha512-yugKSRLHc6B6kXxm/DwNc94zhaddAjCSO9IOGH3w7NIWNM+gUoLl/2/XLndiw4I+XhU4H2LOhC5Ab2JjS6JWsA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.0.tgz",
+      "integrity": "sha512-//a/HhnCQ4zFHxRfi1m+jQwr8o0Gxsg0GUjZ39O6ud9lkhrnuLGX1oOKjGsivm9AVMS79cn0PmTa6JCRlzgfWA==",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.10.0"
@@ -5321,23 +5340,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/coffee-script": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
-      "integrity": "sha512-W3s+SROY73OmrSGtPTTW/2wp2rmW5vuh0/tUuCK1NvTuyzLOVPccIP9whmhZ4cYWcr2NJPNENZIFaAMkTD5G3w==",
-      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "~0.3.5"
-      },
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -11692,6 +11694,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/make-plural": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
+      "integrity": "sha512-OIqncXB9uqrhcnUCY9YWXFB6zlvCA+OJIced+I3T4fifrdR69somipFdaOLzRDvbjb1/GNMLMKBnnp3+I2DaUQ==",
+      "license": "ISC",
+      "bin": {
+        "make-plural": "bin/make-plural"
+      },
+      "optionalDependencies": {
+        "minimist": "^1.2.0"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -11838,56 +11852,39 @@
       }
     },
     "node_modules/messageformat": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-0.2.2.tgz",
-      "integrity": "sha512-MMr7IW4+Q/kSBLOi6S5GtikrJVjMMFm+WH6xA+dMt+LwlOSEwajEtQ4WLcG5H4BQaRp1Uw8Kd60BsNCcqU/4sA==",
-      "license": "To use or fork, Apache License, Version 2.0. To contribute back, Dojo CLA",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-0.3.1.tgz",
+      "integrity": "sha512-GlAt04yc1qRtJyocVngwY98mDrvkmgevGBYFO9UGzYGtUWgswGTHMpBnl79wXCVU94F+kmOliBicr26lGHydyg==",
+      "license": "MIT",
       "dependencies": {
-        "async": "~0.2.10",
-        "coffee-script": "~1.7.0",
-        "glob": "~3.2.8",
-        "nopt": "~2.1.2",
-        "underscore": "~1.5.2",
-        "watchr": "~2.4.9"
+        "async": "~1.5.2",
+        "glob": "~6.0.4",
+        "make-plural": "~3.0.3",
+        "nopt": "~3.0.6",
+        "watchr": "~2.4.13"
       },
       "bin": {
         "messageformat": "bin/messageformat.js"
       }
     },
     "node_modules/messageformat/node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "license": "MIT"
     },
     "node_modules/messageformat/node_modules/glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "BSD",
+      "license": "ISC",
       "dependencies": {
+        "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "0.3"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/messageformat/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
-      "license": "ISC"
-    },
-    "node_modules/messageformat/node_modules/minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
         "node": "*"
@@ -12111,13 +12108,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-      "license": "MIT"
-    },
-    "node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -12618,10 +12608,10 @@
       }
     },
     "node_modules/nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha512-x8vXm7BZ2jE1Txrxh/hO74HTuYZQEbo8edoRcANgdZ4+PCV+pbjd/xdummkmjjC7LU5EjPzlu8zEq/oxWylnKA==",
-      "license": "MIT",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "license": "ISC",
       "dependencies": {
         "abbrev": "1"
       },
@@ -21817,12 +21807,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
-      "license": "ISC"
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -23338,11 +23322,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-      "integrity": "sha512-yejOFsRnTJs0N9CK5Apzf6maDO2djxGoLLrlZlvGs2o9ZQuhIhDL18rtFyy4FBIbOkzA6+4hDgXbgz5EvDQCXQ=="
     },
     "node_modules/undici": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "5.0.0",
+    "@bigcommerce/stencil-paper": "5.1.4",
     "@bigcommerce/stencil-styles": "^6.1.1",
     "@hapi/boom": "^10.0.0",
     "@hapi/glue": "^9.0.1",


### PR DESCRIPTION
#### What?

Bump paper to 5.1.4


#### Screenshots (if appropriate)

<img width="964" alt="Screenshot 2025-05-13 at 18 11 39" src="https://github.com/user-attachments/assets/3b15d43c-58a3-410f-8608-dc8a281309e0" />

cc @bigcommerce/storefront-team
