### PR TITLE
fix: bump paper to 5.1.6; fix chrono-node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "5.1.4",
+        "@bigcommerce/stencil-paper": "5.1.6",
         "@bigcommerce/stencil-styles": "^6.1.1",
         "@hapi/boom": "^10.0.0",
         "@hapi/glue": "^9.0.1",
@@ -797,25 +797,25 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.1.4.tgz",
-      "integrity": "sha512-AJuDFioKOAPiFg+nJ1t489FkfivKq5M69AVfad9mQuPVjCcjUEeG1MHwDnKyIEWCJ0/PscAexjLjGmIbFz/piw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.1.6.tgz",
+      "integrity": "sha512-AMHu+ZArrBPBa1/38alQnXfZ1iwLEUu2Yan/Q1xMA6zxNmt+YkSggMhDeIE758fRBE0OtyIUKJhuS5rP7Wry3Q==",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "6.2.4",
+        "@bigcommerce/stencil-paper-handlebars": "6.3.2",
         "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.3.1"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.2.4.tgz",
-      "integrity": "sha512-ivPdeEyJuMY0r6WD0fJFbmCuF42uQ+kUPfH2qUaMfsKZkeFyxQThBxYnAMnQ6FWDG6SE161tzGNIP/KwdDBahg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.3.2.tgz",
+      "integrity": "sha512-NWX0nFRPdJIqcwFl84WIqh2F4ldU41FiWX5tw9lHic4CUrROgSuYBe1aZ7vOr7xJQeef1gUAriVeMqVmZcjMpA==",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.8",
-        "chrono-node": "^2.6.5",
+        "chrono-node": "2.8.0",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "5.1.4",
+    "@bigcommerce/stencil-paper": "5.1.6",
     "@bigcommerce/stencil-styles": "^6.1.1",
     "@hapi/boom": "^10.0.0",
     "@hapi/glue": "^9.0.1",


### PR DESCRIPTION
#### What?

set chrono-node version to a fixed one 2.8.0

#### Tickets / Documentation

-   [STRF-13378](https://bigcommercecloud.atlassian.net/browse/STRF-13378)


cc @bigcommerce/storefront-team
