### PR TITLE
fix: STRF-12935 Fix docker image publishing

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -1,8 +1,8 @@
-name: Stencil CLI
+name: Docker image release
 
 on:
     release:
-        types: [created]
+        types: [published]
 
 jobs:
     build-and-push-image:
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Log in to the Container registry
-              uses: docker/login-action@v2
+              uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
@@ -26,12 +26,12 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
-              uses: docker/metadata-action@v4
+              uses: docker/metadata-action@v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
             - name: Build and push Docker image
-              uses: docker/build-push-action@v3
+              uses: docker/build-push-action@v6
               with:
                   context: .
                   push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
#### What?

Publish docker image on publishing release. Updated CI versions to most recent

#### Tickets / Documentation

-   [STRF-12935](https://bigcommercecloud.atlassian.net/browse/STRF-12935)


cc @bigcommerce/storefront-team
