### PR TITLE
Fix: Start Development Server Worker

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -232,8 +232,8 @@ class StencilStart {
                 this._browserSync.reload();
             }
         });
+        await this._buildConfigManager.initConfig();
         if (this._buildConfigManager.development) {
-            await this._buildConfigManager.initConfig();
             this._buildConfigManager.initWorker().development(this._browserSync);
         }
         await this.checkLangFiles(langsPath, this._storeSettingsLocale.default_shopper_language);


### PR DESCRIPTION
#### What?
When running `stencil start` in the latest version, v8.8.0, JavaScript files are not watched or bundled.

In `/lib/stencil-start.js` [`this._buildConfigManager.development`](https://github.com/bigcommerce/stencil-cli/blob/80417541f809f4a14cf8b6b2566e58407cbd7cc6/lib/stencil-start.js#L235) on line 235 is `undefined`, so [`initWorker()`](https://github.com/bigcommerce/stencil-cli/blob/80417541f809f4a14cf8b6b2566e58407cbd7cc6/lib/stencil-start.js#L237) is never run. This happens because the BuildConfigManager `development` property is now being set in BuildConfigManager's [async function `initConfig()`](https://github.com/bigcommerce/stencil-cli/blob/80417541f809f4a14cf8b6b2566e58407cbd7cc6/lib/BuildConfigManager.js#L31) rather than being in the constructor where it was previous to https://github.com/bigcommerce/stencil-cli/pull/1271.

To fix, we just need to run `await this._buildConfigManager.initConfig();` before the if check on line 235.

I think there is a similar issue with `stencil-bundle.js` where `buildConfigManager.production` [is checked on line 70](https://github.com/bigcommerce/stencil-cli/blob/80417541f809f4a14cf8b6b2566e58407cbd7cc6/lib/stencil-bundle.js#L70), but [`await buildConfigManager.initConfig();`](https://github.com/bigcommerce/stencil-cli/blob/80417541f809f4a14cf8b6b2566e58407cbd7cc6/lib/stencil-bundle.js#L73C17-L73C55) is called too late on line 73.  However, I don't think most theme developers use `stencil-cli` in production mode so it doesn't affect us, and there's a bit more code I'm unfamiliar with to move around for the fix.

#### Tickets / Documentation
n/a

#### Screenshots (if appropriate)
n/a

cc @bigcommerce/storefront-team
