### PR TITLE
fix: STRF-000 Fix async config loading in theme bundling

### DIFF
--- a/lib/stencil-bundle.js
+++ b/lib/stencil-bundle.js
@@ -68,16 +68,19 @@ class Bundle {
         tasks.schemaTranslations = this.assembleSchemaTranslations.bind(this);
         tasks.stencilContext = this.assembleStencilContextTask.bind(this);
         if (typeof buildConfigManager.production === 'function') {
-            tasks.theme = async (callback) => {
+            tasks.theme = (callback) => {
                 console.log('Theme task Started...');
-                await buildConfigManager.initConfig();
-                buildConfigManager.initWorker().production((err) => {
-                    if (err) {
-                        return callback(err);
-                    }
-                    console.log(`${'ok'.green} -- Theme task Finished`);
-                    return callback();
-                });
+                buildConfigManager.initConfig()
+                    .then(() => {
+                        buildConfigManager.initWorker().production((err) => {
+                            if (err) {
+                                return callback(err);
+                            }
+                            console.log(`${'ok'.green} -- Theme task Finished`);
+                            callback();
+                        });
+                    })
+                    .catch(callback);
             };
         }
         this.tasks = tasks;

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -233,8 +233,13 @@ class StencilStart {
             }
         });
         if (this._buildConfigManager.development) {
-            await this._buildConfigManager.initConfig();
-            this._buildConfigManager.initWorker().development(this._browserSync);
+            try {
+                await this._buildConfigManager.initConfig();
+                this._buildConfigManager.initWorker().development(this._browserSync);
+            } catch (error) {
+                this._logger.error('Failed to initialize development worker:', error);
+                throw error; // Re-throw to be caught by the calling function
+            }
         }
         await this.checkLangFiles(langsPath, this._storeSettingsLocale.default_shopper_language);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       },
       "bin": {
         "stencil": "bin/stencil.js",
+        "stencil-attributes-analyzer": "bin/stencil-attributes-analyzer.js",
         "stencil-bundle": "bin/stencil-bundle.js",
         "stencil-debug": "bin/stencil-debug.js",
         "stencil-download": "bin/stencil-download.js",
@@ -66,7 +67,6 @@
         "stencil-push": "bin/stencil-push.js",
         "stencil-release": "bin/stencil-release.js",
         "stencil-scss-autofix": "bin/stencil-scss-autofix.js",
-        "stencil-attributes-analyzer": "bin/stencil-attributes-analyzer.js",
         "stencil-start": "bin/stencil-start.js"
       },
       "devDependencies": {


### PR DESCRIPTION
#### What?

Fixed async/await handling in theme bundling to ensure proper configuration loading.

#### Tickets / Documentation

This PR addresses issue #1276 where JavaScript files weren't being bundled and the `assets/dist` directory wasn't being created in stencil-cli v8.8.0. The root cause was improper async/await handling in the theme bundling process.

#### Screenshots (if appropriate)

N/A

cc @bigcommerce/storefront-team
