### PR TITLE
fix: bump changes to docker ghcr login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ jobs:
               uses: docker/login-action@v3
               with:
                   registry: ghcr.io
-                  username: ${{ secrets.PAT_USERNAME }}
-                  password: ${{ secrets.PAT_TOKEN }}
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ env.IMAGE_NAME }}
+                  images: ghcr.io/bigcommerce/stencil-cli
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
@@ -43,7 +43,4 @@ jobs:
               uses: docker/build-push-action@v6
               with:
                   push: true
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
                   tags: bigcommerce/stencil-cli:latest


### PR DESCRIPTION
#### What?

Hard code registry image name, revert PAT token to github token for login

#### Tickets / Documentation

-   [STRF-12935](https://bigcommercecloud.atlassian.net/browse/STRF-12935)

cc @bigcommerce/storefront-team


[STRF-12935]: https://bigcommercecloud.atlassian.net/browse/STRF-12935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ