### PR TITLE
fix: use absolute path for build tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
               uses: docker/build-push-action@v6
               with:
                   push: true
-                  tags: bigcommerce/stencil-cli:latest
+                  tags: ghcr.io/${{ github.repository_owner }}/stencil-cli:latest


### PR DESCRIPTION
#### What?

use absolute path for docker build and push tag

#### Tickets / Documentation


-   [STRF-12935](https://bigcommercecloud.atlassian.net/browse/STRF-12935)

#### Screenshots (if appropriate)

<img width="761" alt="Screenshot 2025-07-01 at 18 16 39" src="https://github.com/user-attachments/assets/c16068c8-6189-494d-ade8-487e4f691309" />


cc @bigcommerce/storefront-team


[STRF-12935]: https://bigcommercecloud.atlassian.net/browse/STRF-12935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ