### PR TITLE
fix: STRF-12935 Fix docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
                   GA_USERNAME: ${{ secrets.PAT_USERNAME }}
                   GA_TOKEN: ${{ secrets.PAT_TOKEN }}
 
+            - name: Get latest Git tag
+              id: tag
+              run: |
+                  git fetch --tags
+                  TAG=$(git describe --tags --abbrev=0)
+                  echo "tag=$TAG" >> $GITHUB_OUTPUT
             - name: Log in to the Github Container registry
               uses: docker/login-action@v3
               with:
@@ -33,14 +39,13 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
-              uses: docker/metadata-action@v4
+              uses: docker/metadata-action@v5
               with:
                   images: ghcr.io/${{ github.repository_owner }}/stencil-cli
                   tags: |
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                      type=semver,pattern={{major}}
-                      type=raw,pattern=latest
+                      type=semver,pattern={{version}},prefix=,value=${{ steps.tag.outputs.tag }}
+                      type=semver,pattern={{major}},prefix=,value=${{ steps.tag.outputs.tag }}
+                      type=semver,pattern={{major}}.{{minor}},prefix=,value=${{ steps.tag.outputs.tag }}
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
#### What?

Manually prepare git tags for docker metadata action

#### Tickets / Documentation

-   [STRF-12935](https://bigcommercecloud.atlassian.net/browse/STRF-12935)

#### Screenshots (if appropriate)

<img width="285" alt="Screenshot 2025-07-03 at 13 24 02" src="https://github.com/user-attachments/assets/2ad32aea-51a3-47d1-8d8f-39bc45297b6f" />

cc @bigcommerce/storefront-team


[STRF-12935]: https://bigcommercecloud.atlassian.net/browse/STRF-12935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ