### PR TITLE
fix: fix stencil push command from skipping theme task

### DIFF
--- a/lib/stencil-push.utils.js
+++ b/lib/stencil-push.utils.js
@@ -9,6 +9,7 @@ import Bundle from './stencil-bundle.js';
 import themeApiClient from './theme-api-client.js';
 import ThemeConfig from './theme-config.js';
 import StencilConfigManager from './StencilConfigManager.js';
+import BuildConfigManager from './BuildConfigManager.js';
 
 const themeConfigManager = ThemeConfig.getInstance(THEME_PATH);
 const stencilConfigManager = new StencilConfigManager();
@@ -58,8 +59,16 @@ utils.generateBundle = async (options) => {
         ? { dest: THEME_PATH, name: options.saveBundleName }
         : { dest: os.tmpdir(), name: uuid() };
     const rawConfig = await themeConfigManager.getRawConfig();
-    const bundle = new Bundle(THEME_PATH, themeConfigManager, rawConfig, output);
+    const buildConfigManager = new BuildConfigManager();
     try {
+        await buildConfigManager.initConfig();
+        const bundle = new Bundle(
+            THEME_PATH,
+            themeConfigManager,
+            rawConfig,
+            output,
+            buildConfigManager,
+        );
         const bundleZipPath = await bundle.initBundle();
         return { ...options, bundleZipPath };
     } catch (err) {


### PR DESCRIPTION
#### What?
This fix ensures that the `stencil push` command properly triggers the theme task to build JavaScript assets before uploading the theme bundle.

Currently, `stencil push` skips the webpack build process, which causes missing or outdated JavaScript assets in the uploaded theme. This update aligns the behavior with `stencil start` and `stencil bundle`.

#### Screenshots (if appropriate)

Before the fix:
![Screenshot 2025-07-08 at 8 45 02 PM](https://github.com/user-attachments/assets/5b699b60-ac5f-458d-b3a7-38f932ede3e0)

With the fix:
![Screenshot 2025-07-08 at 8 45 55 PM](https://github.com/user-attachments/assets/1fed9504-f06d-4362-a538-87defe06a8d2)


cc @bigcommerce/storefront-team
