### PR TITLE
fix: explicitly set port for hapi server

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -65,6 +65,7 @@ class StencilStart {
         const updatedStencilConfig = this.updateStencilConfig(
             initialStencilConfig,
             storeInfoFromAPI,
+            browserSyncPort,
         );
         this._storeSettingsLocale = await this.getStoreSettingsLocale(
             cliOptions,
@@ -126,11 +127,12 @@ class StencilStart {
         }
     }
 
-    updateStencilConfig(stencilConfig, storeInfoFromAPI) {
+    updateStencilConfig(stencilConfig, storeInfoFromAPI, browserSyncPort) {
         return {
             ...stencilConfig,
             storeUrl: storeInfoFromAPI.sslUrl,
             normalStoreUrl: storeInfoFromAPI.baseUrl,
+            port: browserSyncPort,
         };
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "8.8.0",
+  "version": "8.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "8.8.0",
+      "version": "8.8.6",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/stencil-paper": "5.1.6",

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ function buildManifest(srcManifest, options) {
     const parsedSecureUrl = new URL(options.dotStencilFile.storeUrl); // The url to a secure page (prompted as login page)
     const parsedNormalUrl = new URL(options.dotStencilFile.normalStoreUrl); // The host url of the homepage;
     const storeUrl = parsedSecureUrl.protocol + '//' + parsedSecureUrl.host;
-    resManifest.server.port = options.dotStencilFile.port;
+    resManifest.server.port = parseInt(options.dotStencilFile.port, 10) + 1;
     pluginsByName['./plugins/router/router.module.js'].storeUrl = storeUrl;
     pluginsByName['./plugins/router/router.module.js'].normalStoreUrl =
         parsedNormalUrl.protocol + '//' + parsedNormalUrl.host;


### PR DESCRIPTION
#### What?

Resolve explicitly port of hapi proxy server, otherwise it would set same as browsersync and cause issues running stencil start. 
Fixes https://github.com/bigcommerce/stencil-cli/issues/1290


#### Screenshots (if appropriate)
<img width="697" height="149" alt="Screenshot 2025-07-24 at 15 03 28" src="https://github.com/user-attachments/assets/1114d1d9-fafd-4510-974b-b779a1d0c465" />



cc @bigcommerce/storefront-team
