### PR TITLE
chore: bump @bigcommerce/stencil-paper from 5.1.6 to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "8.9.4",
+  "version": "8.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "8.9.4",
+      "version": "8.10.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "5.1.6",
+        "@bigcommerce/stencil-paper": "5.2.0",
         "@bigcommerce/stencil-styles": "^6.1.1",
         "@hapi/boom": "^10.0.1",
         "@hapi/glue": "^9.0.1",
@@ -797,21 +797,21 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.1.6.tgz",
-      "integrity": "sha512-AMHu+ZArrBPBa1/38alQnXfZ1iwLEUu2Yan/Q1xMA6zxNmt+YkSggMhDeIE758fRBE0OtyIUKJhuS5rP7Wry3Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.2.0.tgz",
+      "integrity": "sha512-W2p2XBo5z62A7Z0y9FSW8wb6u0dPj0bmHdGQI382mmpRiy9QoKrSAR3U/8g58XvJYw0yyys+QSkja2jffJjT7A==",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "6.3.2",
+        "@bigcommerce/stencil-paper-handlebars": "6.4.0",
         "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.3.1"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.3.2.tgz",
-      "integrity": "sha512-NWX0nFRPdJIqcwFl84WIqh2F4ldU41FiWX5tw9lHic4CUrROgSuYBe1aZ7vOr7xJQeef1gUAriVeMqVmZcjMpA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.4.0.tgz",
+      "integrity": "sha512-IIBbfjWle+9XPafz1+84+m1gzLUxKZCeEVLYzSegMtyDZrq7RFa/F8Rx8VH7bq8bwnsmUT6QTkiLjeOv7so5ZA==",
       "license": "BSD-4-Clause",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "5.1.6",
+    "@bigcommerce/stencil-paper": "5.2.0",
     "@bigcommerce/stencil-styles": "^6.1.1",
     "@hapi/boom": "^10.0.1",
     "@hapi/glue": "^9.0.1",


### PR DESCRIPTION
## Summary

This PR bumps the @bigcommerce/stencil-paper dependency from version 5.1.6 to 5.2.0.

## Changes

- Updated @bigcommerce/stencil-paper from 5.1.6 to 5.2.0 in package.json
- Updated package-lock.json with the new dependency version

## Testing

- All existing tests pass with the updated dependency
- No breaking changes detected

## Related

- Stencil Paper 5.2.0 was published 17 hours ago
- This is a minor version bump (5.1.6 → 5.2.0)