### PR TITLE
chore: bump @bigcommerce/stencil-paper from 5.2.0 to 5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.10.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "5.2.0",
+        "@bigcommerce/stencil-paper": "5.3.0",
         "@bigcommerce/stencil-styles": "^6.1.1",
         "@hapi/boom": "^10.0.1",
         "@hapi/glue": "^9.0.1",
@@ -742,7 +742,6 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.8.tgz",
       "integrity": "sha512-1gu8AtGfryFCnmbhoPmCqQh4FLEWMwgwJ/RMn71NpppLBJlrTYVfpnt3kqUUfpE8inqU/pnkCCIqQfCaBcz/KA==",
-      "license": "BSD-4-Clause",
       "dependencies": {
         "handlebars": "4.7.8"
       }
@@ -751,7 +750,6 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -772,7 +770,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -781,7 +778,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -793,44 +789,22 @@
     "node_modules/@bigcommerce/handlebars-v4/node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "license": "MIT"
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.2.0.tgz",
-      "integrity": "sha512-W2p2XBo5z62A7Z0y9FSW8wb6u0dPj0bmHdGQI382mmpRiy9QoKrSAR3U/8g58XvJYw0yyys+QSkja2jffJjT7A==",
-      "license": "BSD-4-Clause",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.3.0.tgz",
+      "integrity": "sha512-C0sh3K5oncwGcrwzzOvSoQzgARp6MwJbrDv5r+nlgM0yUG373xaQytEAdzMvzk13FnBNGlAgD6FA9gzsTSQl0w==",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "6.4.0",
-        "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
+        "@bigcommerce/stencil-paper-handlebars": "6.4.1",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.3.1"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.4.0.tgz",
-      "integrity": "sha512-IIBbfjWle+9XPafz1+84+m1gzLUxKZCeEVLYzSegMtyDZrq7RFa/F8Rx8VH7bq8bwnsmUT6QTkiLjeOv7so5ZA==",
-      "license": "BSD-4-Clause",
-      "dependencies": {
-        "@bigcommerce/handlebars-v4": "4.7.8",
-        "chrono-node": "2.8.0",
-        "handlebars": "3.0.8",
-        "he": "^1.2.0",
-        "moment": "^2.29.4",
-        "remarkable": "^2.0.1",
-        "stringz": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@bigcommerce/stencil-paper-handlebars-v2": {
-      "name": "@bigcommerce/stencil-paper-handlebars",
-      "version": "6.3.2",
-      "resolved": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#0dd26e244b4f8d9318cb3c14a1ab7dd87a591ba4",
-      "license": "BSD-4-Clause",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.4.1.tgz",
+      "integrity": "sha512-w/g9clzMPHAY+KUCAeubqmc8dAPtawXwA57os2f3N6tU06F1FjsOPqi5Y2yzQqKTlOxznYNvZ4vyb8H+bpngeA==",
       "dependencies": {
         "@bigcommerce/handlebars-v4": "4.7.8",
         "chrono-node": "2.8.0",
@@ -4259,7 +4233,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "kind-of": "^3.0.2",
@@ -4274,14 +4247,12 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT",
       "optional": true
     },
     "node_modules/align-text/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -4356,7 +4327,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "license": "BSD-3-Clause OR MIT",
       "engines": {
         "node": ">=0.4.2"
       }
@@ -4728,7 +4698,6 @@
       "version": "3.16.2",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
       "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -5433,7 +5402,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "align-text": "^0.1.3",
@@ -5553,7 +5521,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.0.tgz",
       "integrity": "sha512-//a/HhnCQ4zFHxRfi1m+jQwr8o0Gxsg0GUjZ39O6ud9lkhrnuLGX1oOKjGsivm9AVMS79cn0PmTa6JCRlzgfWA==",
-      "license": "MIT",
       "dependencies": {
         "dayjs": "^1.10.0"
       },
@@ -6961,10 +6928,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA=="
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -9701,7 +9667,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.8.tgz",
       "integrity": "sha512-frzSzoxbJZSB719r+lM3UFKrnHIY6VPY/j47+GNOHVnBHxO+r+Y/iDjozAbj1SztmmMpr2CcZY6rLeN5mqX8zA==",
-      "license": "MIT",
       "dependencies": {
         "optimist": "^0.6.1",
         "source-map": "^0.1.40"
@@ -9819,7 +9784,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
@@ -11738,7 +11702,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12076,7 +12039,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12657,7 +12619,6 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -16308,7 +16269,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "license": "MIT/X11",
       "dependencies": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -16317,8 +16277,7 @@
     "node_modules/optimist/node_modules/minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "license": "MIT"
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -17830,7 +17789,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
       "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
-      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.10",
         "autolinker": "^3.11.0"
@@ -17846,7 +17804,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -17854,14 +17811,12 @@
     "node_modules/remarkable/node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10"
@@ -18005,7 +17960,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "align-text": "^0.1.1"
@@ -20152,7 +20106,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
       "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
-      "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2"
       }
@@ -20889,7 +20842,6 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
-      "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
         "source-map": "~0.5.1",
@@ -20909,7 +20861,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20919,7 +20870,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
-      "license": "ISC",
       "optional": true,
       "dependencies": {
         "center-align": "^0.1.1",
@@ -20931,7 +20881,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20941,7 +20890,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
-      "license": "MIT/X11",
       "optional": true,
       "engines": {
         "node": ">=0.4.0"
@@ -20951,7 +20899,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "camelcase": "^1.0.2",
@@ -20964,7 +20911,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
-      "license": "MIT",
       "optional": true
     },
     "node_modules/unbox-primitive": {
@@ -21391,7 +21337,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "5.2.0",
+    "@bigcommerce/stencil-paper": "5.3.0",
     "@bigcommerce/stencil-styles": "^6.1.1",
     "@hapi/boom": "^10.0.1",
     "@hapi/glue": "^9.0.1",


### PR DESCRIPTION
#### What?

This PR bumps the `@bigcommerce/stencil-paper dependency` from version 5.2.0 to 5.3.0.

#### Tickets / Documentation

-   [SD-11304](https://bigcommercecloud.atlassian.net/browse/SD-11304)


#### Changes 
- Updated `@bigcommerce/stencil-paper` to 5.3.0 in package.json
- Updated `package-lock.json` with the new dependency version

#### Related

- Stencil Paper 5.3.0 was published on Sept 5 2025  as an experiment cleanup
- This is a minor version bump (5.2.0 → 5.3.0)

cc @bigcommerce/storefront-team


[SD-11304]: https://bigcommercecloud.atlassian.net/browse/SD-11304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ