### PR TITLE
fix: Use channel ID to get correct locale

### DIFF
--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -81,6 +81,7 @@ class StencilStart {
         const apiHost = cliOptions.apiHost || stencilConfig.apiHost;
         return this._storeSettingsApiClient.getStoreSettingsLocale({
             storeHash: this.storeHash,
+            channelId: this.channelId,
             accessToken,
             apiHost,
         });
@@ -103,9 +104,8 @@ class StencilStart {
         const channelId = cliOptions.channelId
             ? cliOptions.channelId
             : await this._stencilPushUtils.promptUserToSelectChannel(channels);
-        const foundChannel = channels.find(
-            (channel) => channel.channel_id === parseInt(channelId, 10),
-        );
+        this.channelId = parseInt(channelId, 10);
+        const foundChannel = channels.find((channel) => channel.channel_id === this.channelId);
         return foundChannel ? foundChannel.url : null;
     }
 

--- a/lib/stencil-start.spec.js
+++ b/lib/stencil-start.spec.js
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { describe, expect, jest } from '@jest/globals';
 import path from 'path';
 import StencilStart from './stencil-start.js';
 import stencilPushUtilsModule from './stencil-push.utils.js';
@@ -168,7 +168,36 @@ describe('StencilStart unit tests', () => {
             expect(result).toEqual(channelUrl);
         });
     });
-
+    describe('getStoreSettingsLocale method', () => {
+        const accessToken = 'accessToken_value';
+        const apiHost = 'apiHost_value';
+        const storeHash = 'storeHash_value';
+        const channelId = 5;
+        it('should pass the channel id when getting store settings locale', async () => {
+            const channels = [{ channel_id: channelId }];
+            const themeApiClientStub = {
+                getStoreHash: jest.fn().mockResolvedValue(storeHash),
+                getStoreChannels: jest.fn().mockResolvedValue(channels),
+            };
+            const storeSettingsApiClientStub = getStoreSettingsApiClientStub();
+            const { instance } = createStencilStartInstance({
+                themeApiClient: themeApiClientStub,
+                storeSettingsApiClient: storeSettingsApiClientStub,
+            });
+            // getChannelUrl is what actually gets/loads the channel ID.
+            await instance.getChannelUrl({ accessToken }, { apiHost, channelId });
+            const result = await instance.getStoreSettingsLocale({ apiHost }, { accessToken });
+            expect(result).toEqual({
+                default_shopper_language: 'en_US',
+            });
+            expect(storeSettingsApiClientStub.getStoreSettingsLocale).toHaveBeenCalledWith({
+                accessToken,
+                apiHost,
+                channelId,
+                storeHash,
+            });
+        });
+    });
     describe('port option', () => {
         it('should read port from the config file', async () => {
             const port = 1234;

--- a/lib/store-settings-api-client.js
+++ b/lib/store-settings-api-client.js
@@ -2,10 +2,12 @@ import 'colors';
 import NetworkUtils from './utils/NetworkUtils.js';
 
 const networkUtils = new NetworkUtils();
-async function getStoreSettingsLocale({ apiHost, storeHash, accessToken }) {
+async function getStoreSettingsLocale({ apiHost, storeHash, channelId, accessToken }) {
     try {
         const response = await networkUtils.sendApiRequest({
-            url: `${apiHost}/stores/${storeHash}/v3/settings/store/locale`,
+            url: `${apiHost}/stores/${storeHash}/v3/settings/store/locale?channel_id=${
+                channelId || 1
+            }`,
             accessToken,
         });
         if (!response.data.data) {

--- a/server/plugins/renderer/responses/pencil-response.js
+++ b/server/plugins/renderer/responses/pencil-response.js
@@ -128,7 +128,7 @@ class PencilResponse {
             return this.data.context;
         }
         try {
-            await paper.loadTheme(templatePath, this.data.acceptLanguage);
+            await paper.loadTheme(templatePath, this.data.acceptLanguage?.toLowerCase());
             const output = await paper.renderTheme(templatePath, this.data);
             const response = h.response(output).code(this.data.statusCode);
             if (this.data.headers['set-cookie']) {


### PR DESCRIPTION
#### What?

Passes the channel ID to the call to /v3/settings/store/locale. Also fixes a problem where the locale (e.g. fr-CA) can't be found in the map of translations due to all of the map's keys having been converted to lower-case earlier in execution.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

-   Relates to issue #1142.

#### Screenshots (if appropriate)

Not applicable.

cc @bigcommerce/storefront-team
