### PR TITLE
fix: STRF-13605 Fix case-sensitive lang store setting

### DIFF
--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -315,14 +315,19 @@ internals.getTemplatePath = (requestPath, data) => {
     }
     return templatePath || data.template_file;
 };
-function getAcceptLanguageHeader(request) {
+function getRawAcceptLanguageHeader(request) {
     if (
         internals.options.storeSettingsLocale.shopper_language_selection_method ===
         'default_shopper_language'
     ) {
         return internals.options.storeSettingsLocale.default_shopper_language;
     }
-    return request.headers['accept-language'].toLowerCase();
+    return request.headers['accept-language'];
+}
+
+function getAcceptLanguageHeader(request) {
+    const rawHeader = getRawAcceptLanguageHeader(request);
+    return rawHeader.toLowerCase();
 }
 /**
  * Creates a new Pencil Response object and returns it.


### PR DESCRIPTION
#### What?

When "Enable automatic translation based on shopper’s browser language" is not set, language should be lower cased as translations are stored lowercased.

#### Tickets / Documentation

-   [STRF-13605](https://bigcommercecloud.atlassian.net/browse/STRF-13605)

#### Screenshots (if appropriate)
Init: 
<img width="751" height="250" alt="Screenshot 2025-09-23 at 13 37 47" src="https://github.com/user-attachments/assets/03a6fd71-9873-4a1e-8af3-4a5480683963" />

Before:
<img width="942" height="282" alt="Screenshot 2025-09-23 at 13 35 00" src="https://github.com/user-attachments/assets/5e5ac85a-6382-47bb-a0dd-0b8ac0524be8" />


After:
<img width="684" height="155" alt="Screenshot 2025-09-23 at 13 37 28" src="https://github.com/user-attachments/assets/9589ef6d-26e7-433c-9d68-826baffb7d91" />


cc @bigcommerce/storefront-team


[STRF-13605]: https://bigcommercecloud.atlassian.net/browse/STRF-13605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ