### PR TITLE
feat: add --serverHost CLI option for configurable dev server hostname

### DIFF
--- a/bin/stencil-start.js
+++ b/bin/stencil-start.js
@@ -24,7 +24,12 @@ program
         '-cu, --channelUrl [channelUrl]',
         'Set a custom domain url to bypass dns/proxy protection',
     )
-    .option('-p --port [portnumber]', 'Set port number to listen dev server');
+    .option('-p --port [portnumber]', 'Set port number to listen dev server')
+    .option(
+        '--serverHost [serverHost]',
+        'Set the hostname for the dev server (default: localhost)',
+        'localhost',
+    );
 const cliOptions = prepareCommand(program);
 const options = {
     open: cliOptions.open,
@@ -35,6 +40,7 @@ const options = {
     cache: cliOptions.cache,
     channelUrl: cliOptions.channelUrl,
     port: cliOptions.port,
+    host: cliOptions.serverHost,
 };
 
 async function run() {

--- a/lib/stencil-start.js
+++ b/lib/stencil-start.js
@@ -149,6 +149,7 @@ class StencilStart {
             themePath: this._themeConfigManager.themePath,
             stencilCliVersion: PACKAGE_INFO.version,
             storeSettingsLocale: this._storeSettingsLocale,
+            host: cliOptions.serverHost,
         });
     }
 
@@ -213,13 +214,14 @@ class StencilStart {
         const watchIgnored = (watchOptions && watchOptions.ignored) || DEFAULT_WATCH_IGNORED;
         this._browserSync.init({
             open: !!cliOptions.open,
+            host: cliOptions.serverHost || 'localhost',
             port: browserSyncPort,
             files: watchFiles.map((val) => path.join(themePath, val)),
             watchOptions: {
                 ignoreInitial: true,
                 ignored: watchIgnored.map((val) => path.join(themePath, val)),
             },
-            proxy: `localhost:${Number(browserSyncPort) + 1}`,
+            proxy: `${cliOptions.host || 'localhost'}:${Number(browserSyncPort) + 1}`,
             tunnel,
         });
         // Handle manual reloading of browsers by typing 'rs';

--- a/server/config.js
+++ b/server/config.js
@@ -3,7 +3,7 @@ import Confidence from 'confidence';
 const config = {
     $meta: 'Config file',
     server: {
-        host: 'localhost',
+        host: process.env.STENCIL_SERVER_HOST || 'localhost',
         port: 3000,
     },
 };

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,7 @@ function buildManifest(srcManifest, options) {
     pluginsByName['./plugins/renderer/renderer.module.js'].storeUrl = storeUrl;
     pluginsByName['./plugins/renderer/renderer.module.js'].storeSettingsLocale =
         options.storeSettingsLocale;
+    pluginsByName['./plugins/renderer/renderer.module.js'].serverHost = options.serverHost;
     pluginsByName['./plugins/theme-assets/theme-assets.module.js'].themePath = options.themePath;
     resManifest.register.plugins = _.reduce(
         pluginsByName,

--- a/server/plugins/renderer/renderer.module.js
+++ b/server/plugins/renderer/renderer.module.js
@@ -357,6 +357,7 @@ function getAcceptLanguageHeader(request) {
  * @returns {*}
  */
 internals.getPencilResponse = (data, request, response, configuration, renderedRegions = {}) => {
+    const serverHost = internals.options.serverHost || 'localhost';
     const context = {
         ...data.context,
         theme_settings: configuration.settings,
@@ -368,7 +369,7 @@ internals.getPencilResponse = (data, request, response, configuration, renderedR
             theme_version_id: int2uuid(1),
             theme_config_id: int2uuid(request.app.themeConfig.variationIndex + 1),
             theme_session_id: null,
-            maintenance: { secure_path: `http://localhost:${internals.options.port}` },
+            maintenance: { secure_path: `http://${serverHost}:${internals.options.port}` },
         },
     };
     return new PencilResponse(

--- a/server/plugins/renderer/responses/pencil-response.spec.js
+++ b/server/plugins/renderer/responses/pencil-response.spec.js
@@ -23,8 +23,8 @@ describe('PencilResponse', () => {
         data = {
             context: {
                 settings: {
-                    base_url: 'http://localhost:3000',
-                    secure_base_url: 'https://localhost:3000',
+                    base_url: 'http://0.0.0.0:3000',
+                    secure_base_url: 'https://0.0.0.0:3000',
                 },
                 theme_settings: {},
                 template_engine: 'handlebars-v3',


### PR DESCRIPTION
- Add --serverHost option to stencil start command with localhost default
- Support STENCIL_SERVER_HOST environment variable in server config
- Pass serverHost through BrowserSync and renderer plugin configuration
- Maintains backward compatibility with existing localhost behavior
- Enables easier Docker configuration without disrupting defaults

#### What?

This pull request adds a new `--serverHost` CLI option to the `stencil start` command that allows developers to specify a custom hostname for the development server. The feature also supports configuration via the `STENCIL_SERVER_HOST` environment variable. This enhancement maintains full backward compatibility by defaulting to `localhost` when no custom host is specified.

The implementation propagates the serverHost configuration through the entire application stack:
- CLI argument parsing and validation
- BrowserSync proxy and host configuration
- Server configuration via environment variable
- Renderer plugin options for proper URL generation

This change is particularly valuable for Docker-based development environments where binding to `0.0.0.0` or a specific hostname is required for proper container networking, while preserving the existing localhost behavior for traditional development setups.

#### Tickets / Documentation

- [issue regarding the addition of this feature](https://github.com/bigcommerce/stencil-cli/issues/1242)
- `README.md#running-in-docker` provides some steps on how to run stencil in docker, I've tried following those on both WSL and Linux with no success because of the lack of this feature, after patching it with this feature it worked(perhaps I was missing something and if that is the case I would really like to know)

#### Screenshots (if appropriate)

N/A - This is a CLI configuration enhancement without visual changes.

cc @bigcommerce/storefront-team
