### PR TITLE
fix(deps): TRAC-308: bump @bigcommerce/stencil-paper to 5.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bigcommerce/stencil-cli",
-  "version": "8.10.5",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/stencil-cli",
-      "version": "8.10.5",
+      "version": "9.0.0",
       "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper": "5.3.0",
+        "@bigcommerce/stencil-paper": "5.4.1",
         "@bigcommerce/stencil-styles": "6.2.6",
         "@hapi/boom": "^10.0.1",
         "@hapi/glue": "^9.0.1",
@@ -791,17 +791,19 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/handlebars-v4": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.7.8.tgz",
-      "integrity": "sha512-1gu8AtGfryFCnmbhoPmCqQh4FLEWMwgwJ/RMn71NpppLBJlrTYVfpnt3kqUUfpE8inqU/pnkCCIqQfCaBcz/KA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/handlebars-v4/-/handlebars-v4-4.8.1.tgz",
+      "integrity": "sha512-5BMmg/oq+CZ1DHDZiYhjusMbzIRSj5uyZ42XDakbHf3k3ZlmXlAO3ivnBP5wtpwWT5IQ3KLwRQn3NVdi4ZaZAg==",
+      "license": "BSD-4-Clause",
       "dependencies": {
-        "handlebars": "4.7.8"
+        "handlebars": "4.7.9"
       }
     },
     "node_modules/@bigcommerce/handlebars-v4/node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -822,6 +824,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -830,6 +833,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -841,7 +845,8 @@
     "node_modules/@bigcommerce/handlebars-v4/node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     },
     "node_modules/@bigcommerce/node-sass": {
       "version": "10.0.2",
@@ -911,21 +916,23 @@
       }
     },
     "node_modules/@bigcommerce/stencil-paper": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.3.0.tgz",
-      "integrity": "sha512-C0sh3K5oncwGcrwzzOvSoQzgARp6MwJbrDv5r+nlgM0yUG373xaQytEAdzMvzk13FnBNGlAgD6FA9gzsTSQl0w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-5.4.1.tgz",
+      "integrity": "sha512-vx6QBpGwvbR5j3hR+EmKPkWQhD7YGUsO4ysef22nm+FB+g3jfw5boeJe5Zk4Xahy8Is4BwtYaRj+iLdigRXqOQ==",
+      "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/stencil-paper-handlebars": "6.4.1",
+        "@bigcommerce/stencil-paper-handlebars": "6.5.1",
         "accept-language-parser": "~1.4.1",
         "messageformat": "~0.3.1"
       }
     },
     "node_modules/@bigcommerce/stencil-paper-handlebars": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.4.1.tgz",
-      "integrity": "sha512-w/g9clzMPHAY+KUCAeubqmc8dAPtawXwA57os2f3N6tU06F1FjsOPqi5Y2yzQqKTlOxznYNvZ4vyb8H+bpngeA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-6.5.1.tgz",
+      "integrity": "sha512-d2wAhPxRmwZtBJRNdkyZ38M1E6yni4TYYGfrMqAyncwdQyF4guBBiBNR4PV5XguIBfH/Kh+dr/OyRWHOmtQ1wA==",
+      "license": "BSD-4-Clause",
       "dependencies": {
-        "@bigcommerce/handlebars-v4": "4.7.8",
+        "@bigcommerce/handlebars-v4": "4.8.1",
         "chrono-node": "2.8.0",
         "handlebars": "3.0.8",
         "he": "^1.2.0",
@@ -2158,12 +2165,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -4341,6 +4342,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "kind-of": "^3.0.2",
@@ -4355,12 +4357,14 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/align-text/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -4435,6 +4439,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "license": "BSD-3-Clause OR MIT",
       "engines": {
         "node": ">=0.4.2"
       }
@@ -4777,6 +4782,7 @@
       "version": "3.16.2",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
       "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -5453,6 +5459,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "align-text": "^0.1.3",
@@ -5572,6 +5579,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.0.tgz",
       "integrity": "sha512-//a/HhnCQ4zFHxRfi1m+jQwr8o0Gxsg0GUjZ39O6ud9lkhrnuLGX1oOKjGsivm9AVMS79cn0PmTa6JCRlzgfWA==",
+      "license": "MIT",
       "dependencies": {
         "dayjs": "^1.10.0"
       },
@@ -6956,9 +6964,10 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA=="
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -8987,12 +8996,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/front-matter/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -9680,6 +9683,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.8.tgz",
       "integrity": "sha512-frzSzoxbJZSB719r+lM3UFKrnHIY6VPY/j47+GNOHVnBHxO+r+Y/iDjozAbj1SztmmMpr2CcZY6rLeN5mqX8zA==",
+      "license": "MIT",
       "dependencies": {
         "optimist": "^0.6.1",
         "source-map": "^0.1.40"
@@ -9791,6 +9795,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
@@ -11691,6 +11696,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12028,6 +12034,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12601,6 +12608,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -13304,6 +13312,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13312,6 +13321,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/brace-expansion": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13323,6 +13333,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13334,11 +13345,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13354,6 +13367,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "9.1.9",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13400,6 +13414,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "10.4.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13418,6 +13433,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13429,6 +13445,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "7.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13447,6 +13464,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13462,6 +13480,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "5.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13476,6 +13495,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "9.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13491,6 +13511,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13499,6 +13520,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13507,6 +13529,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "7.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13524,6 +13547,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13535,6 +13559,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13546,6 +13571,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13554,6 +13580,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "10.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13570,6 +13597,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13581,6 +13609,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -13589,6 +13618,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -13597,6 +13627,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13613,6 +13644,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13621,6 +13653,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13633,6 +13666,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13646,6 +13680,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13654,6 +13689,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13666,6 +13702,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13680,6 +13717,7 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13688,6 +13726,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13696,6 +13735,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13704,21 +13744,25 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13734,6 +13778,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13745,6 +13790,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13753,6 +13799,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "20.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13774,6 +13821,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13785,6 +13833,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -13793,6 +13842,7 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.3.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13807,6 +13857,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -13818,6 +13869,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13830,6 +13882,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13838,11 +13891,13 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -13854,6 +13909,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13870,6 +13926,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -13878,19 +13935,23 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13899,16 +13960,19 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13917,6 +13981,7 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13928,6 +13993,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "13.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -13944,11 +14010,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "9.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13960,11 +14028,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13977,6 +14047,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13989,8 +14060,10 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -14000,6 +14073,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14011,6 +14085,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14019,6 +14094,7 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14027,6 +14103,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "8.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14044,6 +14121,7 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "10.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14052,6 +14130,7 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14063,6 +14142,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -14074,6 +14154,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14082,6 +14163,7 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14090,6 +14172,7 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14098,6 +14181,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -14106,6 +14190,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -14114,16 +14199,19 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14136,6 +14224,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "8.0.12",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14154,6 +14243,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "10.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14176,6 +14266,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "7.0.12",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14187,6 +14278,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14199,6 +14291,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "9.0.12",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14213,6 +14306,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "11.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14231,6 +14325,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14242,6 +14337,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14254,6 +14350,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14269,6 +14366,7 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "11.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14277,6 +14375,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "15.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14298,6 +14397,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "10.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14312,6 +14412,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14320,6 +14421,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14331,6 +14433,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14347,6 +14450,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14358,6 +14462,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14369,6 +14474,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14380,6 +14486,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14391,6 +14498,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14402,6 +14510,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14413,6 +14522,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14424,11 +14534,13 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14437,6 +14549,7 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14445,6 +14558,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "12.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14468,6 +14582,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14482,6 +14597,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14490,6 +14606,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14501,6 +14618,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -14512,6 +14630,7 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14520,6 +14639,7 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "13.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14534,6 +14654,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "10.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14546,6 +14667,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "11.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14560,6 +14682,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "12.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14572,6 +14695,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "19.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14590,6 +14714,7 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -14598,6 +14723,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14609,6 +14735,7 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "21.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14639,6 +14766,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14652,6 +14780,7 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14667,6 +14796,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14679,6 +14809,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14687,6 +14818,7 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14695,6 +14827,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -14703,6 +14836,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -14711,6 +14845,7 @@
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14723,6 +14858,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14734,6 +14870,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -14741,6 +14878,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14752,6 +14890,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14760,6 +14899,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14768,11 +14908,14 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -14784,6 +14927,7 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14795,6 +14939,7 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14811,6 +14956,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14820,6 +14966,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14833,6 +14980,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14846,6 +14994,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14855,6 +15004,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14864,11 +15014,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14878,11 +15030,13 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.22",
+      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "13.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14894,6 +15048,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14907,6 +15062,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14918,6 +15074,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "10.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14929,6 +15086,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "7.5.2",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14944,6 +15102,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -14952,16 +15111,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.15",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14977,6 +15139,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14993,6 +15156,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15004,6 +15168,7 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15012,6 +15177,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15025,6 +15191,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15036,6 +15203,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15047,11 +15215,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15061,6 +15231,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15070,6 +15241,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15078,6 +15250,7 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15086,6 +15259,7 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15100,6 +15274,7 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15112,6 +15287,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -15487,6 +15663,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "license": "MIT/X11",
       "dependencies": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -15495,7 +15672,8 @@
     "node_modules/optimist/node_modules/minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -17016,6 +17194,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
       "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.10",
         "autolinker": "^3.11.0"
@@ -17031,19 +17210,16 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "node_modules/remarkable/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10"
@@ -17187,6 +17363,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "align-text": "^0.1.1"
@@ -19155,6 +19332,12 @@
         "readable-stream": "^3.0.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ssri": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.0.tgz",
@@ -19435,6 +19618,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
       "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
+      "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2"
       }
@@ -20181,6 +20365,7 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+      "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
         "source-map": "~0.5.1",
@@ -20200,6 +20385,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20209,6 +20395,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "center-align": "^0.1.1",
@@ -20220,6 +20407,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20229,6 +20417,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "license": "MIT/X11",
       "optional": true,
       "engines": {
         "node": ">=0.4.0"
@@ -20238,6 +20427,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "camelcase": "^1.0.2",
@@ -20250,6 +20440,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/unbox-primitive": {
@@ -20658,6 +20849,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "package-lock.json"
   ],
   "dependencies": {
-    "@bigcommerce/stencil-paper": "5.3.0",
+    "@bigcommerce/stencil-paper": "5.4.1",
     "@bigcommerce/stencil-styles": "6.2.6",
     "@hapi/boom": "^10.0.1",
     "@hapi/glue": "^9.0.1",


### PR DESCRIPTION
Jira: [TRAC-308](https://bigcommercecloud.atlassian.net/browse/TRAC-308)

## What/Why?
Bump `@bigcommerce/stencil-paper` to `5.4.1` to pick up `@bigcommerce/handlebars-v4` `4.8.1`.

Depends on: bigcommerce/paper#427

## Rollout/Rollback
Standard npm package bump. Rollback by reverting this PR.

## Testing
Existing test suite covers rendering behavior.

[TRAC-308]: https://bigcommercecloud.atlassian.net/browse/TRAC-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ