### PR TITLE
chore: add team-trac to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@bigcommerce/storefront-team
+@bigcommerce/storefront-team @bigcommerce/team-trac


### PR DESCRIPTION
Add `@bigcommerce/team-trac` as codeowner for all files in the repository.

## Changes

- Updated `.github/CODEOWNERS` to append `@bigcommerce/team-trac` alongside `@bigcommerce/storefront-team` on the catch-all line
