### PR TITLE
fix: TRAC-513 - clear stale variation override on stencil pull

### DIFF
--- a/lib/stencil-pull.utils.js
+++ b/lib/stencil-pull.utils.js
@@ -74,15 +74,19 @@ utils.mergeThemeConfiguration = async (options) => {
             continue;
         }
         const defaultVal = localConfig.settings[key];
+        // Compare against the variation override (when present) so stale ones get cleared.
+        const effectiveLocalVal = _.has(variation.settings, key)
+            ? variation.settings[key]
+            : defaultVal;
         // Check for different types, and throw an error if they are found
-        if (typeof defaultVal !== typeof remoteVal) {
+        if (typeof effectiveLocalVal !== typeof remoteVal) {
             throw new Error(
                 `Theme configuration key "${key}" cannot be merged because it is not of the same type. ` +
-                    `Remote configuration is of type ${typeof remoteVal} while local configuration is of type ${typeof defaultVal}.`,
+                    `Remote configuration is of type ${typeof remoteVal} while local configuration is of type ${typeof effectiveLocalVal}.`,
             );
         }
         // If a different value is found, overwrite the local config
-        if (!_.isEqual(defaultVal, remoteVal)) {
+        if (!_.isEqual(effectiveLocalVal, remoteVal)) {
             if (!variation.settings) {
                 variation.settings = {};
             }


### PR DESCRIPTION
## Summary

- `stencil pull` was failing to clear a previously-stored variation value when the corresponding Page Builder field was emptied — the stale value persisted locally even after re-pulling.
- Root cause: `mergeThemeConfiguration` compared each remote setting only against the top-level default in `config.json`. When a Page Builder field was cleared, the remote variation value matched the default, so the loop thought "in sync" and never overwrote the stale `variation.settings[key]`.
- Fix: compare the remote value against the *effective* local value — the variation override if one exists, otherwise the default — so stale overrides get cleared back to the default.

Linear: [LTRAC-528](https://linear.app/commerce/issue/LTRAC-528/stencil-pull-does-not-clear-variation-values-when-page-builder-field) · Jira: [TRAC-513](https://bigcommercecloud.atlassian.net/browse/TRAC-513)

## Testing

https://github.com/user-attachments/assets/2c1cc74e-e2df-4cc9-9823-e11cbb740eea

[TRAC-513]: https://bigcommercecloud.atlassian.net/browse/TRAC-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ