### PR TITLE
fix: TRAC-896 - avoid archiveManager readEntry stall on Windows/Node 24 CI

### DIFF
--- a/lib/archiveManager.js
+++ b/lib/archiveManager.js
@@ -44,6 +44,10 @@ async function extractZipFiles({ zipPath, fileToExtract, exclude = [], outputNam
                     resolve();
                     return;
                 }
+                // Windows: yield a tick so the previous entry's read stream (zlib
+                // inflate + fd) fully tears down before requesting the next one,
+                // otherwise readEntry() can stall (observed on windows-latest/Node 24 CI).
+                await new Promise(setImmediate);
                 zipFile.readEntry();
             } catch (err) {
                 reject(err);


### PR DESCRIPTION
#### What?

- `extractZipFiles()` called `readEntry()` right after `pipeline()` resolved
- Stalls on `windows-latest` + Node 24.x once a 2nd real read+inflate cycle is requested (exceeds Jest's 5000ms timeout)
- Matches exact CI split: failing tests process ≥2 real zip entries; passing tests resolve/reject on the first entry only
- Fix: yield a tick (`setImmediate`) before `readEntry()` so previous entry's zlib/fd fully tear down
- Can't repro on macOS/Linux — validated against real CI: `build (24.x, windows-latest)` passed twice after this fix

#### Tickets / Documentation

-   [TRAC-896](https://bigcommercecloud.atlassian.net/browse/TRAC-896)
-   Fix windows tests [Failing run (PR #1383)](https://github.com/bigcommerce/stencil-cli/actions/runs/27714622538/job/82003137092)


cc @bigcommerce/storefront-team

[TRAC-896]: https://bigcommercecloud.atlassian.net/browse/TRAC-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ